### PR TITLE
Fix headless build: decouple coarse_freq_sync from GUI state

### DIFF
--- a/include/physical_layer/telecom_system.h
+++ b/include/physical_layer/telecom_system.h
@@ -193,6 +193,8 @@ public:
 
 	int bit_energy_dispersal_seed;
 
+	bool coarse_freq_sync_enabled;  // Coarse freq search (±30 Hz) for HF radio drift
+
 	st_reinit_subsystems reinit_subsystems;
 
 };

--- a/source/main.cc
+++ b/source/main.cc
@@ -551,6 +551,7 @@ start_modem:
         else if (g_settings.ldpc_iterations_max != 50)
             telecom_system.default_configurations_telecom_system.ldpc_nIteration_max = g_settings.ldpc_iterations_max;
         g_gui_state.ldpc_iterations_max.store(telecom_system.default_configurations_telecom_system.ldpc_nIteration_max);
+        telecom_system.coarse_freq_sync_enabled = g_settings.coarse_freq_sync_enabled;
         g_gui_state.coarse_freq_sync_enabled.store(g_settings.coarse_freq_sync_enabled);
         // Robust mode: CLI -R overrides INI setting
         if (robust_mode)
@@ -668,6 +669,8 @@ start_modem:
                 // Update SNR measurements (uplink = what we receive, downlink = what remote receives from us)
                 gui_update_arq_measurements(ARQ.get_snr_uplink(), ARQ.get_snr_downlink());
 
+                // Sync coarse freq sync from GUI to telecom_system
+                telecom_system.coarse_freq_sync_enabled = g_gui_state.coarse_freq_sync_enabled.load();
                 // Sync robust mode from GUI to ARQ (takes effect on next connection)
                 ARQ.robust_enabled = g_gui_state.robust_mode_enabled.load() ? YES : NO;
 

--- a/source/physical_layer/telecom_system.cc
+++ b/source/physical_layer/telecom_system.cc
@@ -60,6 +60,7 @@ cl_telecom_system::cl_telecom_system()
 	ctrl_nBits=0;
 	ctrl_nsymb=0;
 	mfsk_ctrl_mode=false;
+	coarse_freq_sync_enabled=false;
 	ack_pattern_passband_samples=0;
 	ack_pattern_detection_threshold=0.8;
 	operation_mode=BER_PLOT_baseband;
@@ -946,7 +947,7 @@ skip_h_retry_point:
 			{
 				receive_stats.delay=receive_stats.delay_of_last_decoded_message;
 			}
-			else if (receive_stats.sync_trials == 1 && g_gui_state.coarse_freq_sync_enabled.load())
+			else if (receive_stats.sync_trials == 1 && coarse_freq_sync_enabled)
 			{
 				// Trial 0 failed - try coarse frequency search before trial 1
 				// Search ±30 Hz; Moose handles ±22 Hz residual at each,


### PR DESCRIPTION
## Summary

- `telecom_system.cc` references `g_gui_state.coarse_freq_sync_enabled` outside of any `#ifdef MERCURY_GUI_ENABLED` guard, which breaks compilation without GLFW (as in PR #21's MinGW cross-build Makefile)
- Moves the flag to `cl_telecom_system` as a plain `bool` member so the physical layer has no dependency on GUI state
- Defaults to `false` (same as current behavior), set from INI at startup, bridged from GUI checkbox at runtime

## Changes

- **telecom_system.h**: Add `bool coarse_freq_sync_enabled` member
- **telecom_system.cc**: Initialize in constructor, use member instead of `g_gui_state`
- **main.cc**: Set from INI settings at startup, bridge from `g_gui_state` in GUI update loop

Related: #21