### PR TITLE
Add MinGW cross-compilation support for Windows (make windows)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,10 @@ endif
 
 include config.mk
 
-.PHONY: all install internal_deps utils clean doxygen doxygen-clean FORCE
+MINGW_CC  = x86_64-w64-mingw32-gcc
+MINGW_AR  = x86_64-w64-mingw32-ar
+
+.PHONY: all install internal_deps utils clean doxygen doxygen-clean windows FORCE
 
 prefix ?= /usr
 bindir ?= $(prefix)/bin
@@ -50,6 +53,12 @@ DOXYGEN ?= doxygen
 DOXYFILE ?= Doxyfile
 
 CFLAGS = $(COMMON_CFLAGS) -Imodem/freedv -Imodem -Idatalink_broadcast -Idata_interfaces -Idatalink_arq -Iaudioio/ffaudio -Icommon
+
+ifeq ($(OS),Windows_NT)
+BINARY = mercury.exe
+else
+BINARY = mercury
+endif
 
 LDFLAGS=$(FFAUDIO_LINKFLAGS) -lm
 
@@ -61,14 +70,14 @@ MERCURY_LINK_INPUTS = \
 	common/chan.o common/queue.o data_interfaces/tcp_interfaces.o data_interfaces/net.o
 
 all: internal_deps utils
-	$(MAKE) mercury
+	$(MAKE) $(BINARY)
 	$(MAKE) -C utils
 
 install: all
-	install -D -m 755 mercury $(DESTDIR)$(bindir)/mercury
+	install -D -m 755 $(BINARY) $(DESTDIR)$(bindir)/mercury
 
-mercury: $(MERCURY_LINK_INPUTS)
-	$(CC) -o mercury  \
+$(BINARY): $(MERCURY_LINK_INPUTS)
+	$(CC) -o $(BINARY)  \
 		$(MERCURY_LINK_INPUTS) $(LDFLAGS)
 
 # Stamp file: written only when GIT_HASH changes so main.o is rebuilt
@@ -93,8 +102,12 @@ internal_deps:
 	$(MAKE) -C common
 
 
+windows:
+	$(MAKE) clean OS=Windows_NT CC=$(MINGW_CC) AR=$(MINGW_AR)
+	$(MAKE) -j$$(nproc) OS=Windows_NT CC=$(MINGW_CC) AR=$(MINGW_AR)
+
 clean:
-	rm -f mercury *.o .git_hash_stamp
+	rm -f mercury mercury.exe *.o .git_hash_stamp
 	$(MAKE) -C modem clean
 	$(MAKE) -C datalink_arq clean
 	$(MAKE) -C datalink_broadcast clean

--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <limits.h>
+#include "os_interop.h"
 #include <ffaudio/audio.h>
 #include "std.h"
 #ifdef FF_LINUX
@@ -20,7 +21,6 @@
 #include "ring_buffer_posix.h"
 #include "shm_posix.h"
 #include "../common/defines_modem.h"
-#include "os_interop.h"
 
 #include "audioio.h"
 

--- a/common/chan.c
+++ b/common/chan.c
@@ -36,17 +36,6 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#define CLOCK_REALTIME 0
-static int clock_gettime (int __attribute__((__unused__)) clockid, struct timespec *tp) {
-    FILETIME ft;
-    ULARGE_INTEGER t64;
-    GetSystemTimeAsFileTime (&ft);
-    t64.LowPart = ft.dwLowDateTime;
-    t64.HighPart = ft.dwHighDateTime;
-    tp->tv_sec = t64.QuadPart / 10000000 - 11644473600;
-    tp->tv_nsec = t64.QuadPart % 10000000 * 100;
-    return 0;
-}
 #endif
 
 static int buffered_chan_init(chan_t* chan, size_t capacity);
@@ -477,7 +466,12 @@ int chan_select(chan_t* recv_chans[], int recv_count, void** recv_out,
     seed = (unsigned int)(ts.tv_nsec ^ (unsigned long)pthread_self());
 
     // Select candidate and perform operation.
+#ifdef _WIN32
+    srand(seed);
+    select_op_t select = candidates[rand() % count];
+#else
     select_op_t select = candidates[rand_r(&seed) % count];
+#endif
     if (select.recv && chan_recv(select.chan, recv_out) != 0)
     {
         return -1;

--- a/common/chan.c
+++ b/common/chan.c
@@ -466,12 +466,7 @@ int chan_select(chan_t* recv_chans[], int recv_count, void** recv_out,
     seed = (unsigned int)(ts.tv_nsec ^ (unsigned long)pthread_self());
 
     // Select candidate and perform operation.
-#ifdef _WIN32
-    srand(seed);
-    select_op_t select = candidates[rand() % count];
-#else
-    select_op_t select = candidates[rand_r(&seed) % count];
-#endif
+    select_op_t select = candidates[seed % count];
     if (select.recv && chan_recv(select.chan, recv_out) != 0)
     {
         return -1;

--- a/common/defines_modem.h
+++ b/common/defines_modem.h
@@ -21,7 +21,9 @@
 #ifndef HAVE_DEFINES_MODEM_H
 #define HAVE_DEFINES_MODEM_H
 
+#ifndef MAX_PATH
 #define MAX_PATH 255
+#endif
 
 // {TX,RX}_SHM broadcast memory interface
 #define SHM_PAYLOAD_BUFFER_SIZE 131072

--- a/common/hermes_log.c
+++ b/common/hermes_log.c
@@ -8,6 +8,11 @@
 
 #include "hermes_log.h"
 
+#ifdef _WIN32
+/* Windows localtime_s has reversed argument order from POSIX localtime_r */
+#define localtime_r(timep, result) localtime_s((result), (timep))
+#endif
+
 #include <pthread.h>
 #include <stdarg.h>
 #include <stdbool.h>

--- a/common/os_interop.h
+++ b/common/os_interop.h
@@ -14,9 +14,31 @@
 #if defined(_WIN32)
 
 #include <winsock2.h>
+#include <ws2tcpip.h>
 #include <windows.h>
+#include <pthread.h>
 #include <io.h>
 #include <time.h>
+
+/* Socket compatibility */
+#define SOCK_CLOSE(fd) closesocket(fd)
+#define SOCK_IOCTL(fd, cmd, argp) ioctlsocket((SOCKET)(fd), (long)(cmd), (u_long*)(argp))
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif
+#define poll(fds, nfds, timeout) WSAPoll((fds), (ULONG)(nfds), (timeout))
+typedef ULONG nfds_t;
+
+static inline int sock_set_nonblocking(int fd)
+{
+    u_long one = 1;
+    return ioctlsocket((SOCKET)fd, FIONBIO, &one) == 0 ? 0 : -1;
+}
+
+static inline int sock_errno(void) { return WSAGetLastError(); }
+#define SOCK_EAGAIN      WSAEWOULDBLOCK
+#define SOCK_EWOULDBLOCK WSAEWOULDBLOCK
+#define SOCK_EINTR       WSAEINTR
 
 #ifdef __cplusplus
 extern "C" {
@@ -73,6 +95,25 @@ int COND_SIGNAL(HANDLE *mqh_wait);
 #include <sys/mman.h>
 #include <sys/stat.h>        /* For mode constants */
 #include <unistd.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <errno.h>
+
+/* Socket compatibility */
+#define SOCK_CLOSE(fd) close(fd)
+#define SOCK_IOCTL(fd, cmd, argp) ioctl((fd), (unsigned long)(cmd), (argp))
+
+static inline int sock_set_nonblocking(int fd)
+{
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags < 0) return -1;
+    return fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+}
+
+static inline int sock_errno(void) { return errno; }
+#define SOCK_EAGAIN      EAGAIN
+#define SOCK_EWOULDBLOCK EWOULDBLOCK
+#define SOCK_EINTR       EINTR
 
 #define MUTEX_LOCK(x)   pthread_mutex_lock(x)
 #define MUTEX_UNLOCK(x) pthread_mutex_unlock(x)

--- a/data_interfaces/net.c
+++ b/data_interfaces/net.c
@@ -21,20 +21,19 @@
  */
 
 #include "net.h"
+#include "os_interop.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
-#include <sys/types.h> 
+#include <sys/types.h>
+#if !defined(_WIN32)
 #include <sys/socket.h>
 #include <netinet/in.h>
-#include <errno.h>
+#endif
 #include <time.h>
 
 #include <pthread.h>
-
-#include <sys/ioctl.h>
 
 static int ctl_sockfd, data_sockfd;
 
@@ -206,10 +205,10 @@ int tcp_open(int portno, int port_type)
     }
 
     int opt = 1;  
-    if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0)
+    if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, (const char *)&opt, sizeof(opt)) < 0)
     {
         fprintf(stderr, "setsockopt(SO_REUSEADDR) failed\n");
-        close(sockfd);
+        SOCK_CLOSE(sockfd);
         return -1;
     }
       
@@ -248,20 +247,20 @@ ssize_t tcp_read(int port_type, uint8_t *buffer, size_t rx_size)
 
     if (port_type == CTL_TCP_PORT && net_get_status(CTL_TCP_PORT) == NET_CONNECTED)
     {
-        ioctl(cli_ctl_sockfd, FIONREAD, &count);
+        SOCK_IOCTL(cli_ctl_sockfd, FIONREAD, &count);
         if (count < rx_size)
             rx_size = count ? count : rx_size;
-        n = recv(cli_ctl_sockfd, buffer, rx_size, MSG_NOSIGNAL);
+        n = recv(cli_ctl_sockfd, (char *)buffer, rx_size, MSG_NOSIGNAL);
 
         if (n < 0)
             net_set_status(CTL_TCP_PORT, NET_RESTART);
     }
     if (port_type == DATA_TCP_PORT && net_get_status(DATA_TCP_PORT) == NET_CONNECTED)
     {
-        ioctl(cli_data_sockfd, FIONREAD, &count);
+        SOCK_IOCTL(cli_data_sockfd, FIONREAD, &count);
         if (count < rx_size)
             rx_size = count ? count : rx_size;
-        n = recv(cli_data_sockfd, buffer, rx_size, MSG_NOSIGNAL);
+        n = recv(cli_data_sockfd, (char *)buffer, rx_size, MSG_NOSIGNAL);
 
         if (n < 0)
             net_set_status(DATA_TCP_PORT, NET_RESTART);
@@ -285,14 +284,14 @@ ssize_t tcp_write(int port_type, uint8_t *buffer, size_t tx_size)
     if (port_type == CTL_TCP_PORT && net_get_status(CTL_TCP_PORT) == NET_CONNECTED)
     {
         attempted_send = 1;
-        n = send(cli_ctl_sockfd, buffer, tx_size, MSG_NOSIGNAL);
+        n = send(cli_ctl_sockfd, (const char *)buffer, tx_size, MSG_NOSIGNAL);
 
         if (n < 0)
         {
             /* EAGAIN/EWOULDBLOCK: non-blocking socket whose send buffer is
              * momentarily full.  This is a transient condition; drop the
              * message but do NOT tear down the connection. */
-            if (errno != EAGAIN && errno != EWOULDBLOCK)
+            if (sock_errno() != SOCK_EAGAIN && sock_errno() != SOCK_EWOULDBLOCK)
                 net_set_status(CTL_TCP_PORT, NET_RESTART);
         }
         else if (n != (ssize_t) tx_size)
@@ -305,11 +304,11 @@ ssize_t tcp_write(int port_type, uint8_t *buffer, size_t tx_size)
     if (port_type == DATA_TCP_PORT && net_get_status(DATA_TCP_PORT) == NET_CONNECTED)
     {
         attempted_send = 1;
-        n = send(cli_data_sockfd, buffer, tx_size, MSG_NOSIGNAL);
+        n = send(cli_data_sockfd, (const char *)buffer, tx_size, MSG_NOSIGNAL);
 
         if (n < 0)
         {
-            if (errno != EAGAIN && errno != EWOULDBLOCK)
+            if (sock_errno() != SOCK_EAGAIN && sock_errno() != SOCK_EWOULDBLOCK)
                 net_set_status(DATA_TCP_PORT, NET_RESTART);
         }
         else if (n != (ssize_t) tx_size)
@@ -331,14 +330,14 @@ int tcp_close(int port_type)
 
     if(port_type == CTL_TCP_PORT)
     {
-        close(cli_ctl_sockfd);
-        close(ctl_sockfd);
+        SOCK_CLOSE(cli_ctl_sockfd);
+        SOCK_CLOSE(ctl_sockfd);
         net_set_status(CTL_TCP_PORT, NET_NONE);
     }
     if(port_type == DATA_TCP_PORT)
     {
-        close(cli_data_sockfd);
-        close(data_sockfd);
+        SOCK_CLOSE(cli_data_sockfd);
+        SOCK_CLOSE(data_sockfd);
         net_set_status(DATA_TCP_PORT, NET_NONE);
     }
     

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -20,20 +20,22 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <pthread.h>
 #include <stdbool.h>
 #include <string.h>
 #include <stdint.h>
 #include <stdatomic.h>
-#include <fcntl.h>
+#include <sys/types.h>
+#if !defined(_WIN32)
+#include <unistd.h>
 #include <poll.h>
 #include <sys/time.h>
-#include <sys/types.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
-#include <errno.h>
+#endif
+
+#include "os_interop.h"
 
 #include "tcp_interfaces.h"
 #include "ring_buffer_posix.h"
@@ -79,7 +81,7 @@ static ssize_t send_all(int socket_fd, const uint8_t *buffer, size_t len)
 
     while (total_sent < len)
     {
-        ssize_t sent = send(socket_fd, buffer + total_sent, len - total_sent, HERMES_SEND_FLAGS);
+        ssize_t sent = send(socket_fd, (const char *)buffer + total_sent, len - total_sent, HERMES_SEND_FLAGS);
         if (sent <= 0)
         {
             return -1;
@@ -139,15 +141,9 @@ static uint64_t monotonic_ms(void)
 
 static int set_nonblocking(int fd)
 {
-    int flags;
     if (fd < 0)
         return -1;
-    flags = fcntl(fd, F_GETFL, 0);
-    if (flags < 0)
-        return -1;
-    if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0)
-        return -1;
-    return 0;
+    return sock_set_nonblocking(fd);
 }
 
 static int open_listener_socket(int port, int port_type, const char *tag)
@@ -160,9 +156,9 @@ static int open_listener_socket(int port, int port_type, const char *tag)
     if (fd < 0)
         return -1;
 
-    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0)
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (const char *)&opt, sizeof(opt)) < 0)
     {
-        close(fd);
+        SOCK_CLOSE(fd);
         return -1;
     }
 
@@ -173,17 +169,17 @@ static int open_listener_socket(int port, int port_type, const char *tag)
 
     if (bind(fd, (struct sockaddr *)&local_addr, sizeof(local_addr)) < 0)
     {
-        close(fd);
+        SOCK_CLOSE(fd);
         return -1;
     }
     if (listen(fd, 1) < 0)
     {
-        close(fd);
+        SOCK_CLOSE(fd);
         return -1;
     }
     if (set_nonblocking(fd) < 0)
     {
-        close(fd);
+        SOCK_CLOSE(fd);
         return -1;
     }
 
@@ -384,7 +380,7 @@ static void close_data_client(int *data_client_fd)
     if (!data_client_fd || *data_client_fd < 0)
         return;
 
-    close(*data_client_fd);
+    SOCK_CLOSE(*data_client_fd);
     *data_client_fd = -1;
     cli_data_sockfd = -1;
     net_set_status(DATA_TCP_PORT, NET_LISTENING);
@@ -396,7 +392,7 @@ static void close_ctl_client(int *ctl_client_fd, int *data_client_fd, bool notif
     if (!ctl_client_fd || *ctl_client_fd < 0)
         return;
 
-    close(*ctl_client_fd);
+    SOCK_CLOSE(*ctl_client_fd);
     *ctl_client_fd = -1;
     cli_ctl_sockfd = -1;
     net_set_status(CTL_TCP_PORT, NET_LISTENING);
@@ -485,7 +481,7 @@ static void *arq_reactor_thread(void *port)
     if (data_listener < 0)
     {
         HLOGE("tcp-data", "Could not open TCP port %d", tcp_base_port + 1);
-        close(ctl_listener);
+        SOCK_CLOSE(ctl_listener);
         net_set_status(CTL_TCP_PORT, NET_NONE);
         shutdown_ = true;
         return NULL;
@@ -531,7 +527,7 @@ static void *arq_reactor_thread(void *port)
             {
                 if (set_nonblocking(fd) < 0)
                 {
-                    close(fd);
+                    SOCK_CLOSE(fd);
                 }
                 else
                 {
@@ -561,7 +557,7 @@ static void *arq_reactor_thread(void *port)
             {
                 if (set_nonblocking(fd) < 0)
                 {
-                    close(fd);
+                    SOCK_CLOSE(fd);
                 }
                 else
                 {
@@ -584,12 +580,12 @@ static void *arq_reactor_thread(void *port)
             }
             else if (events & POLLIN)
             {
-                ssize_t n = recv(ctl_client, rx_buf, sizeof(rx_buf), 0);
+                ssize_t n = recv(ctl_client, (char *)rx_buf, sizeof(rx_buf), 0);
                 if (n > 0)
                 {
                     process_control_bytes(ctl_line, &ctl_len, rx_buf, n);
                 }
-                else if (n == 0 || (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR))
+                else if (n == 0 || (n < 0 && sock_errno() != SOCK_EAGAIN && sock_errno() != SOCK_EWOULDBLOCK && sock_errno() != SOCK_EINTR))
                 {
                     close_ctl_client(&ctl_client, &data_client, true);
                 }
@@ -605,7 +601,7 @@ static void *arq_reactor_thread(void *port)
             }
             else if (events & POLLIN)
             {
-                ssize_t n = recv(data_client, rx_buf, sizeof(rx_buf), 0);
+                ssize_t n = recv(data_client, (char *)rx_buf, sizeof(rx_buf), 0);
                 if (n > 0)
                 {
                     int queued = arq_submit_tcp_payload(rx_buf, (size_t)n);
@@ -614,7 +610,7 @@ static void *arq_reactor_thread(void *port)
                     else
                         tnc_send_buffer((uint32_t)arq_buffered_bytes_snapshot());
                 }
-                else if (n == 0 || (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR))
+                else if (n == 0 || (n < 0 && sock_errno() != SOCK_EAGAIN && sock_errno() != SOCK_EWOULDBLOCK && sock_errno() != SOCK_EINTR))
                 {
                     close_data_client(&data_client);
                 }
@@ -676,9 +672,9 @@ static void *arq_reactor_thread(void *port)
     close_data_client(&data_client);
     drain_tnc_queue_to_ctl();
     if (ctl_listener >= 0)
-        close(ctl_listener);
+        SOCK_CLOSE(ctl_listener);
     if (data_listener >= 0)
-        close(data_listener);
+        SOCK_CLOSE(data_listener);
     net_set_status(CTL_TCP_PORT, NET_NONE);
     net_set_status(DATA_TCP_PORT, NET_NONE);
     return NULL;
@@ -796,7 +792,7 @@ void *recv_thread(void *client_socket_ptr)
 
     while (!shutdown_)
     {
-        ssize_t received = recv(client_socket, buffer, DATA_TX_BUFFER_SIZE, 0);
+        ssize_t received = recv(client_socket, (char *)buffer, DATA_TX_BUFFER_SIZE, 0);
         if (received > 0)
         {
             for (ssize_t i = 0; i < received; i++)
@@ -850,10 +846,10 @@ void *tcp_server_thread(void *port_ptr)
         return NULL;
     }
 
-    if (setsockopt(tcp_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0)
+    if (setsockopt(tcp_socket, SOL_SOCKET, SO_REUSEADDR, (const char *)&opt, sizeof(opt)) < 0)
     {
         perror("Failed to set SO_REUSEADDR on broadcast TCP socket");
-        close(tcp_socket);
+        SOCK_CLOSE(tcp_socket);
         return NULL;
     }
 
@@ -865,14 +861,14 @@ void *tcp_server_thread(void *port_ptr)
     if (bind(tcp_socket, (struct sockaddr *)&local_addr, sizeof(local_addr)) < 0)
     {
         perror("Failed to bind TCP socket");
-        close(tcp_socket);
+        SOCK_CLOSE(tcp_socket);
         return NULL;
     }
 
     if (listen(tcp_socket, 1) < 0)
     {
         perror("Failed to listen on TCP socket");
-        close(tcp_socket);
+        SOCK_CLOSE(tcp_socket);
         return NULL;
     }
 
@@ -902,11 +898,11 @@ void *tcp_server_thread(void *port_ptr)
         pthread_cancel(send_tid);
         pthread_join(send_tid, NULL);
 
-        close(client_socket);
+        SOCK_CLOSE(client_socket);
         printf("Waiting for a new client to connect...\n");
     }
 
-    close(tcp_socket);
+    SOCK_CLOSE(tcp_socket);
     return NULL;
 }
 

--- a/datalink_broadcast/broadcast.c
+++ b/datalink_broadcast/broadcast.c
@@ -25,7 +25,9 @@
 #include <unistd.h>
 #include <string.h>
 #include <pthread.h>
+#if !defined(_WIN32)
 #include <arpa/inet.h>
+#endif
 
 #include "modem.h"
 #include "arq.h"

--- a/main.c
+++ b/main.c
@@ -33,6 +33,10 @@
 #include <sched.h>
 #endif
 
+#ifdef _WIN32
+#include <winsock2.h>
+#endif
+
 
 #include "freedv_api.h"
 #include "ldpc_codes.h"
@@ -110,6 +114,15 @@ int main(int argc, char *argv[])
     printf("\e[0;31mRhizomatica Mercury Version %s (git %.8s)\e[0m\n", VERSION__, GIT_HASH); // we go red
 #elif defined(_WIN32)
     printf("Rhizomatica Mercury Version %s (git %.8s)\n", VERSION__, GIT_HASH);
+#endif
+
+#ifdef _WIN32
+    WSADATA wsa_data;
+    if (WSAStartup(MAKEWORD(2, 2), &wsa_data) != 0)
+    {
+        fprintf(stderr, "WSAStartup failed\n");
+        return EXIT_FAILURE;
+    }
 #endif
     int verbose = 0;
     const int mode_count = (int)(sizeof(freedv_modes) / sizeof(freedv_modes[0]));
@@ -462,6 +475,10 @@ int main(int argc, char *argv[])
     shutdown_modem(&g_modem);
     HLOGI("main", "Shutting down");
     hermes_log_shutdown();
+
+#ifdef _WIN32
+    WSACleanup();
+#endif
 
     return 0;
 

--- a/modem/freedv/defines.h
+++ b/modem/freedv/defines.h
@@ -113,7 +113,7 @@ extern const struct lsp_codebook newamp1_energy_cb[];
 extern const struct lsp_codebook newamp2vq_cb[];
 extern const struct lsp_codebook newamp2_energy_cb[];
 
-#ifdef _GNU_SOURCE
+#if defined(_GNU_SOURCE) && !defined(_WIN32)
 #define POW10F(x) exp10f((x))
 #else
 #define POW10F(x) expf(2.302585092994046f * (x))

--- a/modem/modem.c
+++ b/modem/modem.c
@@ -296,25 +296,31 @@ static int maybe_switch_modem_mode(generic_modem_t *g_modem,
 
 int init_modem(generic_modem_t *g_modem, int mode, int frames_per_burst, int test_mode, int freedv_verbosity)
 {
-// connect to shared memory buffers
-try_shm_connect1:
-    capture_buffer = circular_buf_connect_shm(SIGNAL_BUFFER_SIZE, SIGNAL_INPUT);
+// connect to shared memory buffers (skip if audioio already set them up)
     if (capture_buffer == NULL)
     {
-        printf("Shared memory not created. Waiting for the radio daemon\n");
-        sleep(1);
-        goto try_shm_connect1;
+try_shm_connect1:
+        capture_buffer = circular_buf_connect_shm(SIGNAL_BUFFER_SIZE, SIGNAL_INPUT);
+        if (capture_buffer == NULL)
+        {
+            printf("Shared memory not created. Waiting for the radio daemon\n");
+            sleep(1);
+            goto try_shm_connect1;
+        }
     }
 
-try_shm_connect2:
-    playback_buffer = circular_buf_connect_shm(SIGNAL_BUFFER_SIZE, SIGNAL_OUTPUT);
     if (playback_buffer == NULL)
     {
-        printf("Shared memory not created. Waiting for the radio daemon...\n");
-        sleep(1);
-        goto try_shm_connect2;
+try_shm_connect2:
+        playback_buffer = circular_buf_connect_shm(SIGNAL_BUFFER_SIZE, SIGNAL_OUTPUT);
+        if (playback_buffer == NULL)
+        {
+            printf("Shared memory not created. Waiting for the radio daemon...\n");
+            sleep(1);
+            goto try_shm_connect2;
+        }
+        printf("Connected to Shared Memory Radio I/O tx/rx buffers.\n");
     }
-    printf("Connected to Shared Memory Radio I/O tx/rx buffers.\n");
 
     // buffers for the ARQ datalink
     uint8_t *buffer_tx = (uint8_t *) malloc(DATA_TX_BUFFER_SIZE);

--- a/modem/modem.c
+++ b/modem/modem.c
@@ -297,6 +297,7 @@ static int maybe_switch_modem_mode(generic_modem_t *g_modem,
 int init_modem(generic_modem_t *g_modem, int mode, int frames_per_burst, int test_mode, int freedv_verbosity)
 {
 // connect to shared memory buffers (skip if audioio already set them up)
+    bool shm_connected = false;
     if (capture_buffer == NULL)
     {
 try_shm_connect1:
@@ -307,6 +308,7 @@ try_shm_connect1:
             sleep(1);
             goto try_shm_connect1;
         }
+        shm_connected = true;
     }
 
     if (playback_buffer == NULL)
@@ -319,8 +321,10 @@ try_shm_connect2:
             sleep(1);
             goto try_shm_connect2;
         }
-        printf("Connected to Shared Memory Radio I/O tx/rx buffers.\n");
     }
+
+    if (shm_connected)
+        printf("Connected to Shared Memory Radio I/O tx/rx buffers.\n");
 
     // buffers for the ARQ datalink
     uint8_t *buffer_tx = (uint8_t *) malloc(DATA_TX_BUFFER_SIZE);


### PR DESCRIPTION
Port mercuryv2 to build as a Windows executable using MinGW-w64 cross-compiler. Adds socket compatibility layer in os_interop.h (SOCK_CLOSE, SOCK_IOCTL, sock_set_nonblocking, sock_errno, WSAPoll mapping), WSAStartup/WSACleanup lifecycle in main.c, and fixes for localtime_r, clock_gettime, rand_r, exp10f, and include ordering on Windows. Both Linux and Windows builds are clean.

modem: skip SHM connect when audio buffers already initialized

When using sound card audio (ALSA, PulseAudio, DirectSound, etc.), audioio_init_internal() sets up capture/playback buffers via circular_buf_init() before init_modem() runs. Skip the SHM connect if buffers are already set - matches the mercuryv1 pattern where the modem just uses the globals that audioio already initialized.