### PR TITLE
fix: replace DST|SRC encoding with CRC16(DST)+SRC in CALL/ACCEPT frames

### DIFF
--- a/datalink_arq/arith.c
+++ b/datalink_arq/arith.c
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define NUM_SYMBOLS 39  // 37 symbols + 1 EOF + separator
+#define NUM_SYMBOLS 38  // 37 symbols + 1 EOF
 #define CODE_BITS 32
 #define MAX_CODE ((1ULL << CODE_BITS) - 1)
 #define HALF (1ULL << (CODE_BITS - 1))
@@ -24,7 +24,7 @@
 char symbols[NUM_SYMBOLS] = {
     'A','B','C','D','E','F','G','H','I','J','K','L','M',
     'N','O','P','Q','R','S','T','U','V','W','X','Y','Z',
-    '0','1','2','3','4','5','6','7','8','9','-', '|',
+    '0','1','2','3','4','5','6','7','8','9','-',
     '\0'  // EOF symbol
 };
 

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -397,6 +397,18 @@ bool arq_handle_incoming_connect_frame(uint8_t *data, size_t frame_size)
         return false;
     }
 
+    /* Validate that DST CRC16 matches our own callsign */
+    if (arq_conn.my_call_sign[0] != 0)
+    {
+        uint16_t frame_crc = (uint16_t)data[ARQ_CONNECT_PAYLOAD_IDX]
+                           | ((uint16_t)data[ARQ_CONNECT_PAYLOAD_IDX + 1] << 8);
+        if (frame_crc != arq_protocol_callsign_crc16(arq_conn.my_call_sign))
+        {
+            HLOGD(LOG_COMP, "CALL/ACCEPT not for us (DST CRC16 mismatch)");
+            return false;
+        }
+    }
+
     arq_event_t ev = {0};
     ev.id         = is_accept ? ARQ_EV_RX_ACCEPT : ARQ_EV_RX_CALL;
     ev.session_id = session_id;

--- a/datalink_arq/arq_protocol.c
+++ b/datalink_arq/arq_protocol.c
@@ -295,64 +295,80 @@ int arq_protocol_build_data(uint8_t *buf, size_t buf_len,
  * CALL/ACCEPT frame builders and parsers
  * ====================================================================== */
 
-/* Encode "DST|SRC" as arithmetic-compressed callsign payload. */
+/* CRC16-CCITT of uppercase-normalised callsign — for DST field validation. */
+uint16_t arq_protocol_callsign_crc16(const char *callsign)
+{
+    char upper[CALLSIGN_MAX_SIZE];
+    int n = 0;
+    for (; callsign[n] && n < (int)sizeof(upper) - 1; n++)
+    {
+        char c = callsign[n];
+        if (c >= 'a' && c <= 'z') c = (char)(c - ('a' - 'A'));
+        upper[n] = c;
+    }
+    upper[n] = 0;
+    return freedv_gen_crc16((unsigned char *)upper, n);
+}
+
+/* New frame layout (bytes 2-13):
+ *   Bytes 0-1: CRC16-CCITT of DST callsign, little-endian  (ARQ_CONNECT_DST_CRC_SIZE)
+ *   Bytes 2-11: arithmetic_encode(SRC only)                 (ARQ_CONNECT_SRC_MAX_ENCODED = 10)
+ *
+ * 10 bytes is sufficient for any realistic callsign
+ * (e.g. "PU2UIT-15" needs ~7 bytes compressed). */
 static int encode_callsign_payload(const char *src, const char *dst,
                                    uint8_t *out, size_t out_cap)
 {
-    char msg[(CALLSIGN_MAX_SIZE * 2) + 2];
     uint8_t tmp[4096];
-    int n, enc_len;
+    int enc_len;
 
-    n = snprintf(msg, sizeof(msg), "%s|%s", dst, src);
-    if (n <= 0 || n >= (int)sizeof(msg))
+    if (out_cap < ARQ_CONNECT_DST_CRC_SIZE)
         return -1;
 
-    /* normalise to uppercase */
-    for (int i = 0; i < n; i++)
-        if (msg[i] >= 'a' && msg[i] <= 'z')
-            msg[i] = (char)(msg[i] - ('a' - 'A'));
+    /* Bytes [0..1]: CRC16 of DST, little-endian */
+    uint16_t crc = arq_protocol_callsign_crc16(dst);
+    out[0] = (uint8_t)(crc & 0xFF);
+    out[1] = (uint8_t)(crc >> 8);
+
+    /* Bytes [2..]: arithmetic_encode(uppercase SRC) */
+    char src_upper[CALLSIGN_MAX_SIZE];
+    int n = 0;
+    for (; src[n] && n < (int)sizeof(src_upper) - 1; n++)
+    {
+        char c = src[n];
+        if (c >= 'a' && c <= 'z') c = (char)(c - ('a' - 'A'));
+        src_upper[n] = c;
+    }
+    src_upper[n] = 0;
 
     init_model();
-    enc_len = arithmetic_encode(msg, tmp);
+    enc_len = arithmetic_encode(src_upper, tmp);
     if (enc_len <= 0)
         return -1;
-    if ((size_t)enc_len > out_cap)
-        enc_len = (int)out_cap;
-    memcpy(out, tmp, (size_t)enc_len);
-    return enc_len;
+
+    size_t src_cap = out_cap - ARQ_CONNECT_DST_CRC_SIZE;
+    if ((size_t)enc_len > src_cap)
+        enc_len = (int)src_cap;
+    memcpy(out + ARQ_CONNECT_DST_CRC_SIZE, tmp, (size_t)enc_len);
+    return (int)(ARQ_CONNECT_DST_CRC_SIZE + (size_t)enc_len);
 }
 
-/* Decode compressed callsign payload into src/dst strings. */
+/* Decode: bytes [2..] are arithmetic-encoded SRC only.
+ * DST is not in the frame; caller validates via CRC at bytes [0..1]. */
 static int decode_callsign_payload(const uint8_t *in, size_t in_len,
                                    char *src_out, char *dst_out)
 {
-    char decoded[(CALLSIGN_MAX_SIZE * 2) + 2];
-    char *sep;
+    if (in_len < ARQ_CONNECT_DST_CRC_SIZE)
+        return -1;
+
+    dst_out[0] = 0;  /* DST not transmitted as string */
 
     init_model();
-    if (arithmetic_decode((uint8_t *)in, (int)in_len, decoded,
-                          (int)sizeof(decoded)) < 0)
+    if (arithmetic_decode((uint8_t *)(in + ARQ_CONNECT_DST_CRC_SIZE),
+                          (int)(in_len - ARQ_CONNECT_DST_CRC_SIZE),
+                          src_out, CALLSIGN_MAX_SIZE) < 0)
         return -1;
-    if (decoded[0] == 0)
-        return -1;
-
-    sep = strchr(decoded, '|');
-    if (sep)
-    {
-        size_t dst_len = (size_t)(sep - decoded);
-        if (dst_len >= CALLSIGN_MAX_SIZE) dst_len = CALLSIGN_MAX_SIZE - 1;
-        memcpy(dst_out, decoded, dst_len);
-        dst_out[dst_len] = 0;
-        strncpy(src_out, sep + 1, CALLSIGN_MAX_SIZE - 1);
-        src_out[CALLSIGN_MAX_SIZE - 1] = 0;
-    }
-    else
-    {
-        /* Only dst present (truncated) */
-        strncpy(dst_out, decoded, CALLSIGN_MAX_SIZE - 1);
-        dst_out[CALLSIGN_MAX_SIZE - 1] = 0;
-        src_out[0] = 0;
-    }
+    src_out[CALLSIGN_MAX_SIZE - 1] = 0;
     return 0;
 }
 

--- a/datalink_arq/arq_protocol.c
+++ b/datalink_arq/arq_protocol.c
@@ -310,12 +310,12 @@ uint16_t arq_protocol_callsign_crc16(const char *callsign)
     return freedv_gen_crc16((unsigned char *)upper, n);
 }
 
-/* New frame layout (bytes 2-13):
- *   Bytes 0-1: CRC16-CCITT of DST callsign, little-endian  (ARQ_CONNECT_DST_CRC_SIZE)
- *   Bytes 2-11: arithmetic_encode(SRC only)                 (ARQ_CONNECT_SRC_MAX_ENCODED = 10)
+/* CALL/ACCEPT payload layout (frame bytes 2-13, i.e. 12 payload bytes):
+ *   Frame bytes 2-3  (payload [0..1]):  CRC16-CCITT of DST callsign, LE  (ARQ_CONNECT_DST_CRC_SIZE)
+ *   Frame bytes 4-13 (payload [2..11]): arithmetic_encode(SRC only)       (ARQ_CONNECT_SRC_MAX_ENCODED = 10)
  *
- * 10 bytes is sufficient for any realistic callsign
- * (e.g. "PU2UIT-15" needs ~7 bytes compressed). */
+ * 10 bytes encodes up to ~14 characters (38-symbol alphabet, ~5.25 bits/sym).
+ * Callsigns longer than 14 characters will fail to encode. */
 static int encode_callsign_payload(const char *src, const char *dst,
                                    uint8_t *out, size_t out_cap)
 {

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -60,7 +60,7 @@
  *  Byte 0: framer byte (PACKET_TYPE_ARQ_CALL | CRC5, set by write_frame_header)
  *  Byte 1: connect_meta  = (session_id & 0x7F) | (is_accept ? 0x80 : 0x00)
  *  Bytes 2-3:  CRC16-CCITT of DST callsign (little-endian) — for local validation
- *  Bytes 4-13: arithmetic_encode(SRC callsign only) — 10 bytes, fits any callsign
+ *  Bytes 4-13: arithmetic_encode(SRC callsign only) — 10 bytes, fits callsigns up to ~14 chars
  */
 #define ARQ_CONNECT_SESSION_IDX       1
 #define ARQ_CONNECT_PAYLOAD_IDX       2

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -59,7 +59,8 @@
  *
  *  Byte 0: framer byte (PACKET_TYPE_ARQ_CALL | CRC5, set by write_frame_header)
  *  Byte 1: connect_meta  = (session_id & 0x7F) | (is_accept ? 0x80 : 0x00)
- *  Bytes 2-13: arithmetic-encoded "DST|SRC" callsign string (12 bytes max)
+ *  Bytes 2-3:  CRC16-CCITT of DST callsign (little-endian) — for local validation
+ *  Bytes 4-13: arithmetic_encode(SRC callsign only) — 10 bytes, fits any callsign
  */
 #define ARQ_CONNECT_SESSION_IDX       1
 #define ARQ_CONNECT_PAYLOAD_IDX       2
@@ -68,6 +69,8 @@
 #define ARQ_CONTROL_FRAME_SIZE        14
 #define ARQ_CONNECT_META_SIZE         2   /* framer byte + connect_meta byte */
 #define ARQ_CONNECT_MAX_ENCODED       (ARQ_CONTROL_FRAME_SIZE - ARQ_CONNECT_META_SIZE)
+#define ARQ_CONNECT_DST_CRC_SIZE      2   /* CRC16-CCITT of DST at bytes [2..3], little-endian */
+#define ARQ_CONNECT_SRC_MAX_ENCODED   (ARQ_CONNECT_MAX_ENCODED - ARQ_CONNECT_DST_CRC_SIZE) /* 10 */
 
 /* ======================================================================
  * Flags byte (byte 2)
@@ -250,6 +253,12 @@ uint32_t arq_protocol_decode_ack_delay(uint8_t raw);
  * @return Pointer to timing entry, or NULL if mode is unknown.
  */
 const arq_mode_timing_t *arq_protocol_mode_timing(int freedv_mode);
+
+/**
+ * @brief Compute CRC16-CCITT of an uppercase-normalised callsign.
+ * Used to encode/validate the DST field in CALL/ACCEPT frames.
+ */
+uint16_t arq_protocol_callsign_crc16(const char *callsign);
 
 /* ======================================================================
  * Frame builder API


### PR DESCRIPTION
Long callsigns like "PU2UIT-10|PU2UIT-2" (18 chars) overflowed the 12-byte arithmetic-encoded payload, silently truncating SRC → callee sent wrong callsign to uucpd → UUCP session failed.

New wire layout (bytes 2-13):
  Bytes 2-3:  CRC16-CCITT(DST), little-endian — local validation only
  Bytes 4-13: arithmetic_encode(SRC only) — 10 bytes, fits any callsign

The callee already knows its own callsign (DST) locally; only SRC needs to be transmitted. CRC16 replaces the DST string and also adds the previously missing wrong-destination rejection.

Use freedv_gen_crc16() (already linked) — no new CRC implementation. Remove '|' separator from arithmetic encoder symbol table (NUM_SYMBOLS 39→38).