### PR TITLE
arq: fix WAIT_ACK pending-disconnect dropping last frame (Fix-14 regr…

### DIFF
--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -1158,6 +1158,11 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
         {
             if (sess->tx_retries_left > 0)
             {
+                /* Save the pre-cap value so the attempt number reported to
+                 * timing instrumentation reflects the true retry count rather
+                 * than the artificially capped one. */
+                int retries_before_cap = (int)sess->tx_retries_left;
+
                 /* When a disconnect is pending (deferred from DATA_TX), cap
                  * remaining retries to 1 so the peer gets one more chance to
                  * ACK our last frame before we give up.  Aborting with zero
@@ -1177,7 +1182,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                  * when the ACK handler also calls it. */
                 if (g_timing)
                     arq_timing_record_retry(g_timing, (int)sess->tx_seq,
-                                            ARQ_DATA_RETRY_SLOTS - sess->tx_retries_left,
+                                            ARQ_DATA_RETRY_SLOTS - retries_before_cap + 1,
                                             "ack_timeout");
                 dflow_enter(sess, ARQ_DFLOW_DATA_TX, UINT64_MAX, ARQ_EV_TIMER_RETRY);
                 send_data_frame(sess);

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -1285,23 +1285,20 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
         }
         else if (ev->id == ARQ_EV_TIMER_ACK)
         {
-            /* Honour a disconnect that was deferred while a frame was in
-             * flight (DATA_TX).  The PTT is now off; stop retrying. */
-            if (sess->pending_disconnect)
-            {
-                HLOGI(LOG_COMP,
-                      "Pending DISCONNECT: aborting retry seq=%d",
-                      (int)sess->tx_seq);
-                sess->pending_disconnect      = false;
-                sess->tx_retries_left         = ARQ_DISCONNECT_RETRY_SLOTS;
-                sess->disconnect_to_no_client = false;
-                sess_enter(sess, ARQ_CONN_DISCONNECTING,
-                           hermes_uptime_ms() + ARQ_CHANNEL_GUARD_MS,
-                           ARQ_EV_TIMER_ACK);
-                return;
-            }
             if (sess->tx_retries_left > 0)
             {
+                /* When a disconnect is pending (deferred from DATA_TX), cap
+                 * remaining retries to 1 so the peer gets one more chance to
+                 * ACK our last frame before we give up.  Aborting with zero
+                 * retries (old Fix-14 behaviour) drops the final UUCP hangup
+                 * frame, causing "Got termination signal" on the remote side. */
+                if (sess->pending_disconnect && sess->tx_retries_left > 1)
+                {
+                    HLOGD(LOG_COMP,
+                          "Pending DISCONNECT: capping retries to 1 for seq=%d",
+                          (int)sess->tx_seq);
+                    sess->tx_retries_left = 1;
+                }
                 sess->tx_retries_left--;
                 /* Ladder step-down happens once per frame in the RX_ACK /
                  * implicit-ACK handler via record_tx_outcome(), NOT here.

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -1287,6 +1287,11 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
         {
             if (sess->tx_retries_left > 0)
             {
+                /* Save the pre-cap value so the attempt number reported to
+                 * timing instrumentation reflects the true retry count rather
+                 * than the artificially capped one. */
+                int retries_before_cap = (int)sess->tx_retries_left;
+
                 /* When a disconnect is pending (deferred from DATA_TX), cap
                  * remaining retries to 1 so the peer gets one more chance to
                  * ACK our last frame before we give up.  Aborting with zero
@@ -1306,7 +1311,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                  * when the ACK handler also calls it. */
                 if (g_timing)
                     arq_timing_record_retry(g_timing, (int)sess->tx_seq,
-                                            ARQ_DATA_RETRY_SLOTS - sess->tx_retries_left,
+                                            ARQ_DATA_RETRY_SLOTS - retries_before_cap + 1,
                                             "ack_timeout");
                 dflow_enter(sess, ARQ_DFLOW_DATA_TX, UINT64_MAX, ARQ_EV_TIMER_RETRY);
                 send_data_frame(sess);

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -1059,16 +1059,22 @@ static void fsm_connected(arq_session_t *sess, const arq_event_t *ev)
     {
     case ARQ_EV_APP_DISCONNECT:
         /* Defer DISCONNECT while a frame is physically being transmitted
-         * (PTT on, DATA_TX) or the TX buffer still has unsent bytes, so the
-         * last application bytes get delivered before teardown.  The deferral
-         * is bounded three ways and can never hang: (1) retry exhaustion with
-         * a pending disconnect tears down immediately, (2) the absolute
-         * disconnect_drain_timeout_s deadline armed below forces teardown
-         * regardless of FSM state, and (3) a drained buffer fires the
-         * deferred disconnect at the next idle-ISS entry.  An idle WAIT_ACK
-         * with no backlog falls through to immediate teardown below. */
+         * (PTT on, DATA_TX), still awaiting its ACK (WAIT_ACK), or the TX
+         * buffer has unsent bytes, so the last application bytes get
+         * delivered before teardown.  Without the WAIT_ACK case the final
+         * frame loses its retry protection whenever the app's disconnect
+         * lands after PTT-OFF but before the ACK — the same last-frame loss
+         * the WAIT_ACK capped-retry fix addresses, just in a different
+         * timing window.  The deferral is bounded three ways and can never
+         * hang: (1) retry exhaustion with a pending disconnect tears down
+         * immediately, (2) the absolute disconnect_drain_timeout_s deadline
+         * armed below forces teardown regardless of FSM state, and (3) a
+         * drained buffer fires the deferred disconnect at the next idle-ISS
+         * entry (an ACKed last frame with empty backlog disconnects there
+         * without extra delay). */
         if ((g_cbs.tx_backlog && g_cbs.tx_backlog() > 0) ||
-            sess->dflow_state == ARQ_DFLOW_DATA_TX)
+            sess->dflow_state == ARQ_DFLOW_DATA_TX ||
+            sess->dflow_state == ARQ_DFLOW_WAIT_ACK)
         {
             HLOGD(LOG_COMP,
                   "APP_DISCONNECT deferred — backlog=%d dflow=%s",

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -1156,23 +1156,20 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
         }
         else if (ev->id == ARQ_EV_TIMER_ACK)
         {
-            /* Honour a disconnect that was deferred while a frame was in
-             * flight (DATA_TX).  The PTT is now off; stop retrying. */
-            if (sess->pending_disconnect)
-            {
-                HLOGI(LOG_COMP,
-                      "Pending DISCONNECT: aborting retry seq=%d",
-                      (int)sess->tx_seq);
-                sess->pending_disconnect      = false;
-                sess->tx_retries_left         = ARQ_DISCONNECT_RETRY_SLOTS;
-                sess->disconnect_to_no_client = false;
-                sess_enter(sess, ARQ_CONN_DISCONNECTING,
-                           hermes_uptime_ms() + ARQ_CHANNEL_GUARD_MS,
-                           ARQ_EV_TIMER_ACK);
-                return;
-            }
             if (sess->tx_retries_left > 0)
             {
+                /* When a disconnect is pending (deferred from DATA_TX), cap
+                 * remaining retries to 1 so the peer gets one more chance to
+                 * ACK our last frame before we give up.  Aborting with zero
+                 * retries (old Fix-14 behaviour) drops the final UUCP hangup
+                 * frame, causing "Got termination signal" on the remote side. */
+                if (sess->pending_disconnect && sess->tx_retries_left > 1)
+                {
+                    HLOGD(LOG_COMP,
+                          "Pending DISCONNECT: capping retries to 1 for seq=%d",
+                          (int)sess->tx_seq);
+                    sess->tx_retries_left = 1;
+                }
                 sess->tx_retries_left--;
                 /* Ladder step-down happens once per frame in the RX_ACK /
                  * implicit-ACK handler via record_tx_outcome(), NOT here.

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -258,8 +258,13 @@ extern _Atomic int arq_no_progress_timeout_s;
  * DISCONNECT handshake within this window — otherwise a stuck/ping-ponging
  * session keeps keying the rig forever (the K7EK "Mercury kept hanging on"
  * report).  On a healthy link the drain completes in seconds via idle-ISS, so
- * this only bites when the FSM would otherwise be starved. */
-#define ARQ_DISCONNECT_DRAIN_TIMEOUT_S_DEFAULT 30
+ * this only bites when the FSM would otherwise be starved.
+ *
+ * Must outlast one full capped-retry cycle for the last unACKed frame on the
+ * slowest mode (frame + ack_timeout, twice: ~36-39 s for DATAC4), so the
+ * deadline does not cut short the single retry the WAIT_ACK
+ * pending-disconnect path grants before teardown. */
+#define ARQ_DISCONNECT_DRAIN_TIMEOUT_S_DEFAULT 45
 extern _Atomic int arq_disconnect_drain_timeout_s;
 #define ARQ_DISCONNECT_DRAIN_TIMEOUT_S atomic_load(&arq_disconnect_drain_timeout_s)
 

--- a/tests/datalink_arq/test_arq_fsm.c
+++ b/tests/datalink_arq/test_arq_fsm.c
@@ -324,6 +324,61 @@ static void goto_wait_ack(void)
     TEST_ASSERT_EQUAL_INT(ARQ_DFLOW_WAIT_ACK, sess.dflow_state);
 }
 
+/* A pending (deferred) disconnect must not drop the unACKed last frame: the
+ * first ACK timeout retries it once (capped), and only the second timeout
+ * completes the teardown.  Regression test for the Fix-14 zero-retry abort
+ * that dropped the peer's final UUCP hangup packet. */
+void test_pending_disconnect_retries_last_frame_before_teardown(void)
+{
+    goto_connected();
+    goto_wait_ack();   /* one frame in flight, backlog still > 0 */
+
+    arq_event_t ev = make_event(ARQ_EV_APP_DISCONNECT);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
+    TEST_ASSERT_TRUE(sess.pending_disconnect);
+
+    /* First ACK timeout: must retransmit the unACKed frame, not abort. */
+    unsigned sends_before = fake_send_tx_frame_fake.call_count;
+    ev = make_event(ARQ_EV_TIMER_ACK);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
+    TEST_ASSERT_EQUAL_INT(ARQ_DFLOW_DATA_TX, sess.dflow_state);
+    TEST_ASSERT_GREATER_THAN(sends_before, fake_send_tx_frame_fake.call_count);
+    TEST_ASSERT_TRUE(sess.pending_disconnect);
+
+    /* Retry exhausted (capped to 1): the next timeout completes the
+     * deferred disconnect cleanly. */
+    ev = make_event(ARQ_EV_TX_COMPLETE);
+    arq_fsm_dispatch(&sess, &ev);
+    ev = make_event(ARQ_EV_TIMER_ACK);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_DISCONNECTING, sess.conn_state);
+    TEST_ASSERT_FALSE(sess.pending_disconnect);
+}
+
+/* APP_DISCONNECT landing in WAIT_ACK with an empty backlog (last frame sent,
+ * awaiting its ACK) must defer, not tear down immediately — otherwise the
+ * unACKed final frame loses its retry protection whenever the disconnect
+ * arrives after PTT-OFF instead of during DATA_TX. */
+void test_app_disconnect_defers_in_wait_ack(void)
+{
+    goto_connected();
+    goto_wait_ack();
+    fake_tx_backlog_fake.return_val = 0;  /* everything sent, ACK outstanding */
+
+    arq_event_t ev = make_event(ARQ_EV_APP_DISCONNECT);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
+    TEST_ASSERT_TRUE(sess.pending_disconnect);
+
+    /* The capped retry still protects the in-flight frame. */
+    ev = make_event(ARQ_EV_TIMER_ACK);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
+    TEST_ASSERT_EQUAL_INT(ARQ_DFLOW_DATA_TX, sess.dflow_state);
+}
+
 /* Retry exhaustion within the no-progress budget persists (stays CONNECTED);
  * once the budget elapses, the next exhaustion tears the link down. */
 void test_retry_exhaustion_persists_then_disconnects(void)
@@ -429,6 +484,8 @@ int main(void)
     RUN_TEST(test_rx_disconnect_from_connected);
     RUN_TEST(test_connected_seeds_no_progress_clock);
     RUN_TEST(test_app_disconnect_defers_with_backlog);
+    RUN_TEST(test_pending_disconnect_retries_last_frame_before_teardown);
+    RUN_TEST(test_app_disconnect_defers_in_wait_ack);
     RUN_TEST(test_disconnect_drain_timeout_forces_teardown);
     RUN_TEST(test_retry_exhaustion_persists_then_disconnects);
     RUN_TEST(test_retry_exhaustion_disconnects_from_zero_uptime_baseline);


### PR DESCRIPTION
…ession)

Fix-14 added an early-abort path in WAIT_ACK TIMER_ACK: when pending_disconnect was set (APP_DISCONNECT deferred during DATA_TX), the first retry timeout immediately entered DISCONNECTING with zero retries.  This dropped the peer's unACKed last frame — typically the UUCP protocol-'y' hangup packet — leaving the remote uucico without a clean session end and causing "Got termination signal".

Root cause confirmed in log3-14.log: station 3 sent seq=2 (25 bytes = UUCP hangup), station 2 missed it (channel fade).  Station 3 had pending_disconnect=true from an earlier APP_DISCONNECT deferral.  At TIMER_ACK, instead of retrying seq=2, it aborted directly into DISCONNECTING.  Station 2 never received the hangup; the remote side was killed mid-session.

Fix: remove the zero-retry abort.  Instead, cap tx_retries_left to 1 when pending_disconnect is set, giving the peer exactly one more attempt to ACK the last frame.  If the ACK arrives, pending_disconnect fires cleanly in enter_idle_iss().  If the peer is gone, the existing retry-exhausted path handles DISCONNECTING after one retry (~12 s).