### PR TITLE
fixing pulseaudio on Debian11

### DIFF
--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -128,10 +128,25 @@ void *radio_playback_thread(void *device_ptr)
     // Resampling ratio: 8kHz -> 48kHz = 1:6
     const int resample_ratio = 6;
 
-    if ( audio->init(&aconf) != 0)
+    /* PulseAudio uses a single global context (gconn in pulse.c).
+     * If init() returns "already initialized" it means the capture thread
+     * already called init() successfully and we can proceed normally.
+     * Track whether we initialized so we only uninit once.
+     */
+    bool did_init_play = false;
+    r = audio->init(&aconf);
+    if (r != 0)
     {
-        printf("Error in audio->init()\n");
-        goto finish_play;
+        if (aconf.error == NULL || strcmp(aconf.error, "already initialized") != 0)
+        {
+            printf("Error in audio->init(): %s\n", aconf.error ? aconf.error : "unknown");
+            goto finish_play;
+        }
+        // "already initialized" is fine - another thread owns the context
+    }
+    else
+    {
+        did_init_play = true;
     }
 
     // playback code...
@@ -275,7 +290,9 @@ cleanup_play:
 
     audio->free(b);
 
-    audio->uninit();
+    // Only uninit if this thread was the one that initialized the PA context
+    if (did_init_play)
+        audio->uninit();
 
 finish_play:
 
@@ -344,10 +361,25 @@ void *radio_capture_thread(void *device_ptr)
     // Resampling ratio: 48kHz -> 8kHz = 6:1
     const int resample_ratio = 6;
 
-    if ( audio->init(&aconf) != 0)
+    /* PulseAudio uses a single global context (gconn in pulse.c).
+     * If init() returns "already initialized" it means the playback thread
+     * already called init() successfully and we can proceed normally.
+     * Track whether we initialized so we only uninit once.
+     */
+    bool did_init_cap = false;
+    r = audio->init(&aconf);
+    if (r != 0)
     {
-        printf("Error in audio->init()\n");
-        goto finish_cap;
+        if (aconf.error == NULL || strcmp(aconf.error, "already initialized") != 0)
+        {
+            printf("Error in audio->init(): %s\n", aconf.error ? aconf.error : "unknown");
+            goto finish_cap;
+        }
+        // "already initialized" is fine - another thread owns the context
+    }
+    else
+    {
+        did_init_cap = true;
     }
 
     // capture code
@@ -425,7 +457,8 @@ void *radio_capture_thread(void *device_ptr)
             }
 
             // Take every 6th sample (when remainder == 0)
-            if (resample_remainder == 0)
+            // Bounds check: ensure we don't overflow buffer_downsampled
+            if (resample_remainder == 0 && downsampled_frames < (int)SIGNAL_BUFFER_SIZE)
             {
                 buffer_downsampled[downsampled_frames++] = sample;
             }
@@ -433,10 +466,13 @@ void *radio_capture_thread(void *device_ptr)
             resample_remainder = (resample_remainder + 1) % resample_ratio;
         }
 
-        if (circular_buf_free_size(capture_buffer) >= (size_t)(downsampled_frames * sizeof(int32_t)))
-            write_buffer(capture_buffer, (uint8_t *)buffer_downsampled, downsampled_frames * sizeof(int32_t));
-        else
-            printf("Buffer full in capture buffer!\n");
+        if (downsampled_frames > 0)
+        {
+            if (circular_buf_free_size(capture_buffer) >= (size_t)(downsampled_frames * sizeof(int32_t)))
+                write_buffer(capture_buffer, (uint8_t *)buffer_downsampled, downsampled_frames * sizeof(int32_t));
+            else
+                printf("Buffer full in capture buffer!\n");
+        }
     }
 
     r = audio->stop(b);
@@ -454,7 +490,9 @@ cleanup_cap:
 
     audio->free(b);
 
-    audio->uninit();
+    // Only uninit if this thread was the one that initialized the PA context
+    if (did_init_cap)
+        audio->uninit();
 
 finish_cap:
     printf("radio_capture_thread exit\n");
@@ -594,6 +632,25 @@ int audioio_init_internal(char *capture_dev, char *playback_dev, int audio_subsy
 
     clear_buffer(capture_buffer);
     clear_buffer(playback_buffer);
+
+    /* Pre-initialize PulseAudio once here in the main thread before spawning
+     * capture/playback threads. ffpulse_init() uses a single global context
+     * (gconn) and returns an error if called more than once. By initializing
+     * here, both threads will see "already initialized" and proceed normally
+     * rather than one of them failing and exiting early.
+     */
+#if defined(__linux__)
+    if (audio_subsystem == AUDIO_SUBSYSTEM_PULSE)
+    {
+        ffaudio_interface *audio = (ffaudio_interface *) &ffpulse;
+        ffaudio_init_conf aconf = {};
+        aconf.app_name = "mercury";
+        if (audio->init(&aconf) != 0)
+        {
+            printf("Error pre-initializing PulseAudio: %s\n", aconf.error ? aconf.error : "unknown");
+        }
+    }
+#endif
 
     pthread_create(radio_capture, NULL, radio_capture_thread, (void *) capture_dev);
     pthread_create(radio_playback, NULL, radio_playback_thread, (void *) playback_dev);

--- a/modem/modem.c
+++ b/modem/modem.c
@@ -512,8 +512,14 @@ int shutdown_modem(generic_modem_t *g_modem)
     pthread_join(tx_thread_tid, NULL);
     pthread_join(rx_thread_tid, NULL);
     
-    circular_buf_disconnect_shm(capture_buffer, SIGNAL_BUFFER_SIZE);
-    circular_buf_disconnect_shm(playback_buffer, SIGNAL_BUFFER_SIZE);
+    if (capture_buffer) {
+	    circular_buf_disconnect_shm(capture_buffer, SIGNAL_BUFFER_SIZE);
+	    circular_buf_free_shm(capture_buffer);
+    }
+    if (playback_buffer) {
+	    circular_buf_disconnect_shm(playback_buffer, SIGNAL_BUFFER_SIZE);
+	    circular_buf_free_shm(playback_buffer);
+    }
     circular_buf_free_shm(capture_buffer);
     circular_buf_free_shm(playback_buffer);
 


### PR DESCRIPTION
A few things I fixed for my system on debian 11 to make it work with pulseaudio.

# Fix PulseAudio crashes on Linux

This PR fixes several bugs that cause mercury to crash when using PulseAudio (`-x pulse`) on Linux.

## Bugs Fixed

### 1. PulseAudio double-init crash (`audioio.c`)

`ffpulse_init()` uses a single global PA context (`gconn`). When the capture and playback threads each call `audio->init()` independently, the second call fails with `"already initialized"` and the thread exits early, leaving its shared memory buffer uninitialized and causing a downstream crash.

**Fix:** Pre-initialize PulseAudio once in `audioio_init_internal()` before spawning threads. Both threads now treat `"already initialized"` as a non-fatal condition and proceed normally.

---

### 2. PulseAudio double-uninit segfault (`audioio.c`)

Both threads called `audio->uninit()` on cleanup, causing the second call to destroy an already-freed PA context. This resulted in a NULL function pointer dereference inside the PA mainloop thread (`threaded-ml`).

**Fix:** Track which thread actually initialized the PA context (`did_init_play` / `did_init_cap`). Only the initializing thread calls `uninit()` on exit.

---

### 3. `write_buffer()` called with `len=0` causing corrupt `memcpy` (`audioio.c`)

When a capture read returns fewer frames than the decimation ratio (e.g. 3 frames when ratio is 6:1) and `resample_remainder` is positioned such that no frames are selected, `downsampled_frames` stays at 0. `write_buffer()` was called with `len=0`, which caused a corrupt `memcpy` length argument and segfault.

**Fix:** Skip the `write_buffer()` call entirely when `downsampled_frames == 0`.

---

### 4. Buffer overflow in `buffer_downsampled` (`audioio.c`)

No upper bounds check existed on `downsampled_frames` before writing into `buffer_downsampled`, which is allocated as `SIGNAL_BUFFER_SIZE * sizeof(int32_t)` bytes but indexed by frame count. Under high input frame counts this could overflow the buffer.

**Fix:** Added `downsampled_frames < (int)SIGNAL_BUFFER_SIZE` guard to the decimation condition.

---

### 5. NULL pointer crash in `shutdown_modem()` on stale/failed shared memory (`modem.c`)

If `circular_buf_connect_shm()` fails — for example due to stale shared memory segments left in `/dev/shm/` by a previous crash — it returns `NULL`. `shutdown_modem()` then calls `circular_buf_disconnect_shm()` on the NULL pointer, triggering an assertion failure.

**Fix:** Added NULL checks before calling `circular_buf_disconnect_shm()` and `circular_buf_free_shm()` in `shutdown_modem()`.

---

## Notes

Stale shared memory segments (`/dev/shm/signal-modem2radio-*`, `/dev/shm/signal-radio2modem-*`) left over from a previous crash will cause issues on the next run. It is recommended to clean these up before starting mercury:

```bash
rm -f /dev/shm/signal-*
```

This could be added to a wrapper script or systemd service `ExecStartPre` directive.
