### PR TITLE
Fix idle ARQ connect confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Options:
 Mode behavior notes:
 - `-m` / `-s` affects **broadcast** and **test** modes only.
 - During an active ARQ link, control frames use DATAC13 and ARQ payload starts in DATAC4 (then may adapt to DATAC3/DATAC1).
+- VARA `BW500` blocks DATAC1; `BW2300` and `BW2750` both allow the full Mercury
+  payload-mode ladder, with `BW2750` preserved as a compatibility/reporting token.
 - `FSK_LDPC` is currently **experimental** (mainly for lab/test usage), may have longer decode/sync latency depending on setup, and is not recommended for production links yet.
 
 Radio control notes:

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -292,6 +292,9 @@ static void execute_control_command(char *buffer)
         memset(&cmd, 0, sizeof(cmd));
         cmd.type = ARQ_CMD_SET_BANDWIDTH;
         if (sscanf(buffer, "BW%d", &cmd.value) == 1 &&
+            (cmd.value == ARQ_BANDWIDTH_NARROW_HZ ||
+             cmd.value == ARQ_BANDWIDTH_FULL_HZ ||
+             cmd.value == ARQ_BANDWIDTH_TACTICAL_HZ) &&
             arq_submit_tcp_cmd(&cmd) == 0)
             tcp_write(CTL_TCP_PORT, (uint8_t *)"OK\r", 3);
         else
@@ -965,7 +968,7 @@ void tnc_send_connected()
                             ? arq_conn.dst_addr
                             : arq_conn.my_call_sign;
     sprintf(buffer, "CONNECTED %s %s %d\r",
-            source_call, dest_call, arq_effective_bandwidth_hz());
+            source_call, dest_call, arq_reported_bandwidth_hz());
     if (tnc_queue_line(buffer) < 0)
         HLOGW("tcp-ctl", "Error queuing connected message");
 }

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -964,7 +964,7 @@ void tnc_send_connected()
     const char *source_call = arq_conn.src_addr[0]
                               ? arq_conn.src_addr
                               : arq_conn.my_call_sign;
-    const char *dest_call = strcmp(source_call, arq_conn.my_call_sign) == 0
+    const char *dest_call = arq_conn.dst_addr[0]
                             ? arq_conn.dst_addr
                             : arq_conn.my_call_sign;
     sprintf(buffer, "CONNECTED %s %s %d\r",

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -958,8 +958,14 @@ void ptt_off()
 void tnc_send_connected()
 {
     char buffer[128];
+    const char *source_call = arq_conn.src_addr[0]
+                              ? arq_conn.src_addr
+                              : arq_conn.my_call_sign;
+    const char *dest_call = strcmp(source_call, arq_conn.my_call_sign) == 0
+                            ? arq_conn.dst_addr
+                            : arq_conn.my_call_sign;
     sprintf(buffer, "CONNECTED %s %s %d\r",
-            arq_conn.my_call_sign, arq_conn.dst_addr, arq_effective_bandwidth_hz());
+            source_call, dest_call, arq_effective_bandwidth_hz());
     if (tnc_queue_line(buffer) < 0)
         HLOGW("tcp-ctl", "Error queuing connected message");
 }

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -970,6 +970,18 @@ void tnc_send_connected()
         HLOGW("tcp-ctl", "Error queuing connected message");
 }
 
+void tnc_send_pending()
+{
+    if (tnc_queue_line("PENDING\r") < 0)
+        HLOGW("tcp-ctl", "Error queuing pending message");
+}
+
+void tnc_send_cancelpending()
+{
+    if (tnc_queue_line("CANCELPENDING\r") < 0)
+        HLOGW("tcp-ctl", "Error queuing cancelpending message");
+}
+
 void tnc_send_disconnected()
 {
     char buffer[128];

--- a/data_interfaces/tcp_interfaces.h
+++ b/data_interfaces/tcp_interfaces.h
@@ -48,6 +48,8 @@ void *tcp_server_thread(void *port_ptr);
 // TNC / radio functions
 void ptt_on();
 void ptt_off();
+void tnc_send_pending();
+void tnc_send_cancelpending();
 void tnc_send_connected();
 void tnc_send_disconnected();
 void tnc_send_buffer(uint32_t bytes);

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -159,6 +159,8 @@ static void cb_send_tx_frame(int packet_type, int mode,
 
 static void cb_notify_connected(const char *remote_call)
 {
+    if (arq_conn.src_addr[0] == '\0')
+        snprintf(arq_conn.src_addr, CALLSIGN_MAX_SIZE, "%s", remote_call);
     snprintf(arq_conn.dst_addr, CALLSIGN_MAX_SIZE, "%s", remote_call);
     arq_conn.TRX = RX;
     /* Flush any stale RX bytes from the previous session before notifying
@@ -174,6 +176,7 @@ static void cb_notify_disconnected(bool to_no_client)
 {
     (void)to_no_client;
     bool was_connected = arq_conn.dst_addr[0] != '\0';
+    memset(arq_conn.src_addr, 0, sizeof(arq_conn.src_addr));
     memset(arq_conn.dst_addr, 0, sizeof(arq_conn.dst_addr));
     arq_conn.TRX = RX;
     /* Flush stale TX bytes from the previous session.  RX bytes are flushed
@@ -282,6 +285,8 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
         break;
 
     case ARQ_CMD_CONNECT:
+        snprintf(arq_conn.src_addr, CALLSIGN_MAX_SIZE, "%s", msg->arg0);
+        snprintf(arq_conn.dst_addr, CALLSIGN_MAX_SIZE, "%s", msg->arg1);
         snprintf(ev.remote_call, CALLSIGN_MAX_SIZE, "%s", msg->arg1);
         ev.id = ARQ_EV_APP_CONNECT;
         break;

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -162,8 +162,10 @@ static void cb_send_tx_frame(int packet_type, int mode,
 static void cb_notify_connected(const char *remote_call)
 {
     if (arq_conn.src_addr[0] == '\0')
+    {
         snprintf(arq_conn.src_addr, CALLSIGN_MAX_SIZE, "%s", remote_call);
-    snprintf(arq_conn.dst_addr, CALLSIGN_MAX_SIZE, "%s", remote_call);
+        snprintf(arq_conn.dst_addr, CALLSIGN_MAX_SIZE, "%s", arq_conn.my_call_sign);
+    }
     arq_conn.TRX = RX;
     /* Flush any stale RX bytes from the previous session before notifying
      * UUCP.  Moved here from cb_notify_disconnected so that the last bytes

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -256,6 +256,16 @@ int arq_effective_bandwidth_hz(void)
     return ARQ_BANDWIDTH_FULL_HZ;
 }
 
+int arq_reported_bandwidth_hz(void)
+{
+    if (arq_conn.bw == ARQ_BANDWIDTH_NARROW_HZ ||
+        arq_conn.bw == ARQ_BANDWIDTH_FULL_HZ ||
+        arq_conn.bw == ARQ_BANDWIDTH_TACTICAL_HZ)
+        return arq_conn.bw;
+
+    return ARQ_BANDWIDTH_FULL_HZ;
+}
+
 bool arq_bandwidth_allows_mode(int mode)
 {
     if (mode == FREEDV_MODE_DATAC1)

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -50,6 +50,8 @@ extern cbuf_handle_t data_tx_buffer_arq;
 extern cbuf_handle_t data_tx_buffer_arq_control;
 extern cbuf_handle_t data_rx_buffer_arq;
 
+extern void tnc_send_pending(void);
+extern void tnc_send_cancelpending(void);
 extern void tnc_send_connected(void);
 extern void tnc_send_disconnected(void);
 extern void tnc_send_buffer(uint32_t bytes);
@@ -170,6 +172,18 @@ static void cb_notify_connected(const char *remote_call)
     clear_buffer(data_rx_buffer_arq);
     tnc_send_connected();
     HLOGI(LOG_COMP, "Connected to %s", remote_call);
+}
+
+static void cb_notify_pending(const char *remote_call)
+{
+    tnc_send_pending();
+    HLOGI(LOG_COMP, "Incoming connection from %s (pending)", remote_call);
+}
+
+static void cb_notify_cancelpending(void)
+{
+    tnc_send_cancelpending();
+    HLOGI(LOG_COMP, "Incoming connection cancelled");
 }
 
 static void cb_notify_disconnected(bool to_no_client)
@@ -578,6 +592,8 @@ int arq_init(size_t frame_size, int mode)
     static const arq_fsm_callbacks_t cbs = {
         .send_tx_frame       = cb_send_tx_frame,
         .notify_connected    = cb_notify_connected,
+        .notify_pending      = cb_notify_pending,
+        .notify_cancelpending = cb_notify_cancelpending,
         .notify_disconnected = cb_notify_disconnected,
         .deliver_rx_data     = cb_deliver_rx_data,
         .tx_backlog          = cb_tx_backlog,

--- a/datalink_arq/arq.h
+++ b/datalink_arq/arq.h
@@ -25,6 +25,7 @@
 
 #define ARQ_BANDWIDTH_NARROW_HZ 500
 #define ARQ_BANDWIDTH_FULL_HZ   2300
+#define ARQ_BANDWIDTH_TACTICAL_HZ 2750
 
 #define RX 0
 #define TX 1
@@ -127,10 +128,16 @@ void arq_post_event(int event);
 bool arq_is_link_connected(void);
 
 /**
- * @brief Get the effective ARQ bandwidth cap in Hz.
+ * @brief Get the effective ARQ bandwidth cap in Hz used for mode gating.
  * @return 500 for narrow-band mode, otherwise 2300.
  */
 int arq_effective_bandwidth_hz(void);
+
+/**
+ * @brief Get the configured ARQ bandwidth token to report to VARA clients.
+ * @return 500, 2300, or 2750 when configured; otherwise 2300.
+ */
+int arq_reported_bandwidth_hz(void);
 
 /**
  * @brief Check whether the current ARQ bandwidth cap allows a modem mode.

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -153,6 +153,11 @@ static void sess_enter(arq_session_t *sess, arq_conn_state_t new_state,
     sess->state_enter_ms = hermes_uptime_ms();
     sess->deadline_ms    = deadline_ms;
     sess->deadline_event = deadline_event;
+    if (new_state != ARQ_CONN_CONNECTED)
+    {
+        sess->pending_connect_confirm = false;
+        sess->need_initial_guard = false;
+    }
     /* Reset data-flow and mode state when returning to idle connection states.
      * Restore peer_tx_mode to initial_payload_mode (= broadcast mode) so the
      * payload decoder can receive broadcast frames while LISTENING.  The
@@ -798,6 +803,7 @@ static void fsm_calling(arq_session_t *sess, const arq_event_t *ev)
     case ARQ_EV_RX_ACCEPT:
         if (ev->session_id == sess->session_id)
         {
+            bool has_tx_backlog = g_cbs.tx_backlog && g_cbs.tx_backlog() > 0;
             sess->role        = ARQ_ROLE_CALLER;
             sess->tx_seq      = 0;
             sess->rx_expected = 0;
@@ -816,9 +822,23 @@ static void fsm_calling(arq_session_t *sess, const arq_event_t *ev)
                 g_cbs.notify_connected(sess->remote_call);
             if (g_timing)
                 arq_timing_record_connect(g_timing, sess->control_mode);
-            sess->need_initial_guard = true;  /* guard first DATA so IRS can reset decoders */
+            /* The callee does not enter CONNECTED until it sees the caller's
+             * first DATA or ACK.  If the app has no payload queued yet, send
+             * an initial ACK after the post-ACCEPT guard so the peer does not
+             * sit in ACCEPTING retrying ACCEPT forever. */
+            sess->pending_connect_confirm = !has_tx_backlog;
+            sess->need_initial_guard = has_tx_backlog;
             sess_enter(sess, ARQ_CONN_CONNECTED, UINT64_MAX, ARQ_EV_TIMER_RETRY);
-            enter_idle_iss_guarded(sess, false);   /* caller sends data first */
+            if (sess->pending_connect_confirm)
+            {
+                dflow_enter(sess, ARQ_DFLOW_ACK_TX,
+                            hermes_uptime_ms() + ARQ_ISS_POST_ACK_GUARD_MS,
+                            ARQ_EV_TIMER_ACK);
+            }
+            else
+            {
+                enter_idle_iss_guarded(sess, false);   /* caller sends data first */
+            }
         }
         break;
 
@@ -1409,9 +1429,22 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
         break;
 
     case ARQ_DFLOW_ACK_TX:
-        if (ev->id == ARQ_EV_TX_COMPLETE)
+        if (ev->id == ARQ_EV_TIMER_ACK && sess->pending_connect_confirm)
         {
-            if (sess->peer_has_data)
+            send_ack(sess, 0);
+            dflow_enter(sess, ARQ_DFLOW_ACK_TX, UINT64_MAX, ARQ_EV_TIMER_RETRY);
+        }
+        else if (ev->id == ARQ_EV_TX_COMPLETE)
+        {
+            if (sess->pending_connect_confirm)
+            {
+                sess->pending_connect_confirm = false;
+                if (g_cbs.tx_backlog && g_cbs.tx_backlog() > 0)
+                    enter_idle_iss_guarded(sess, false);
+                else
+                    enter_idle_iss(sess, false);
+            }
+            else if (sess->peer_has_data)
                 enter_idle_irs(sess);
             else if (sess->acktx_had_has_data)
             {

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -743,6 +743,8 @@ static void fsm_listening(arq_session_t *sess, const arq_event_t *ev)
         sess_enter(sess, ARQ_CONN_ACCEPTING,
                    hermes_uptime_ms() + ARQ_CHANNEL_GUARD_MS,
                    ARQ_EV_TIMER_RETRY);
+        if (g_cbs.notify_pending)
+            g_cbs.notify_pending(ev->remote_call);
         break;
 
     case ARQ_EV_RX_ACCEPT:
@@ -935,6 +937,8 @@ static void fsm_accepting(arq_session_t *sess, const arq_event_t *ev)
         }
         else
         {
+            if (g_cbs.notify_cancelpending)
+                g_cbs.notify_cancelpending();
             sess_enter(sess, ARQ_CONN_LISTENING, UINT64_MAX, ARQ_EV_TIMER_RETRY);
         }
         break;
@@ -945,11 +949,15 @@ static void fsm_accepting(arq_session_t *sess, const arq_event_t *ev)
          * given up its CALLING attempt already (its retries exhausted), so
          * continuing to send ACCEPTs is pointless.  Transition through
          * DISCONNECTED → CALLING so the new session gets a fresh ID. */
+        if (g_cbs.notify_cancelpending)
+            g_cbs.notify_cancelpending();
         sess_enter(sess, ARQ_CONN_DISCONNECTED, UINT64_MAX, ARQ_EV_TIMER_RETRY);
         fsm_disconnected(sess, ev);
         break;
 
     case ARQ_EV_APP_DISCONNECT:
+        if (g_cbs.notify_cancelpending)
+            g_cbs.notify_cancelpending();
         if (g_cbs.notify_disconnected) g_cbs.notify_disconnected(false);
         sess_enter(sess, ARQ_CONN_DISCONNECTED, UINT64_MAX, ARQ_EV_TIMER_RETRY);
         break;

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -711,6 +711,14 @@ static void fsm_disconnected(arq_session_t *sess, const arq_event_t *ev)
     }
 }
 
+static void arm_connect_confirm(arq_session_t *sess)
+{
+    sess->pending_connect_confirm = true;
+    dflow_enter(sess, ARQ_DFLOW_ACK_TX,
+                hermes_uptime_ms() + ARQ_ISS_POST_ACK_GUARD_MS,
+                ARQ_EV_TIMER_ACK);
+}
+
 static void fsm_listening(arq_session_t *sess, const arq_event_t *ev)
 {
     switch (ev->id)
@@ -826,14 +834,12 @@ static void fsm_calling(arq_session_t *sess, const arq_event_t *ev)
              * first DATA or ACK.  If the app has no payload queued yet, send
              * an initial ACK after the post-ACCEPT guard so the peer does not
              * sit in ACCEPTING retrying ACCEPT forever. */
-            sess->pending_connect_confirm = !has_tx_backlog;
+            sess->pending_connect_confirm = false;
             sess->need_initial_guard = has_tx_backlog;
             sess_enter(sess, ARQ_CONN_CONNECTED, UINT64_MAX, ARQ_EV_TIMER_RETRY);
-            if (sess->pending_connect_confirm)
+            if (!has_tx_backlog)
             {
-                dflow_enter(sess, ARQ_DFLOW_ACK_TX,
-                            hermes_uptime_ms() + ARQ_ISS_POST_ACK_GUARD_MS,
-                            ARQ_EV_TIMER_ACK);
+                arm_connect_confirm(sess);
             }
             else
             {
@@ -1039,6 +1045,20 @@ static void fsm_connected(arq_session_t *sess, const arq_event_t *ev)
         if (g_timing) arq_timing_record_disconnect(g_timing, "rx_disconnect");
         sess_enter(sess, ARQ_CONN_DISCONNECTED, UINT64_MAX, ARQ_EV_TIMER_RETRY);
         return;
+
+    case ARQ_EV_RX_ACCEPT:
+        if (sess->role == ARQ_ROLE_CALLER &&
+            ev->session_id == sess->session_id &&
+            sess->dflow_state == ARQ_DFLOW_IDLE_ISS &&
+            !sess->pending_connect_confirm)
+        {
+            /* The callee is retrying ACCEPT because it did not decode our
+             * earlier post-ACCEPT confirmation. Re-send the confirmation ACK
+             * so the peer can leave ACCEPTING without restarting the session. */
+            arm_connect_confirm(sess);
+            return;
+        }
+        break;
 
     case ARQ_EV_TIMER_KEEPALIVE:
         send_ctrl_frame(sess, ARQ_SUBTYPE_KEEPALIVE);

--- a/datalink_arq/arq_fsm.h
+++ b/datalink_arq/arq_fsm.h
@@ -202,6 +202,9 @@ typedef struct
     bool     pending_disconnect;       /* APP_DISCONNECT deferred until TX buf empty */
 
     /* --- Initial connect guard --- */
+    bool     pending_connect_confirm;  /* caller must ACK ACCEPT when no initial
+                                        * DATA is queued, otherwise callee stays
+                                        * in ACCEPTING waiting for first traffic */
     bool     need_initial_guard;       /* ISS must apply channel guard before
                                         * first DATA after connect (prevents
                                         * transmitting before IRS resets its

--- a/datalink_arq/arq_fsm.h
+++ b/datalink_arq/arq_fsm.h
@@ -251,6 +251,12 @@ typedef struct
     /** Notify TCP interface that a connection is established. */
     void (*notify_connected)(const char *remote_call);
 
+    /** Notify TCP interface of an incoming call that is pending acceptance. */
+    void (*notify_pending)(const char *remote_call);
+
+    /** Notify TCP interface that a pending incoming call did not complete. */
+    void (*notify_cancelpending)(void);
+
     /** Notify TCP interface of disconnection.
      *  @param to_no_client  true = client disconnected too; clear arq_conn. */
     void (*notify_disconnected)(bool to_no_client);

--- a/docs/ARQ.md
+++ b/docs/ARQ.md
@@ -210,6 +210,8 @@ If the caller receives `ACCEPT` before any application payload is queued, it
 sends an empty `ACK` after the post-`ACCEPT` guard to complete the handshake.
 Without that confirmation, the callee remains in `ACCEPTING` and keeps retrying
 `ACCEPT` until its window expires.
+If a duplicate `ACCEPT` arrives for the active session while the caller is
+already connected and idle, the caller re-sends that confirmation `ACK`.
 
 ### Level 2 — Data-Flow Sub-FSM
 

--- a/docs/ARQ.md
+++ b/docs/ARQ.md
@@ -206,6 +206,11 @@ States:
 | CONNECTED      | Data-flow sub-FSM is active                        |
 | DISCONNECTING  | DISCONNECT frame exchange in progress              |
 
+If the caller receives `ACCEPT` before any application payload is queued, it
+sends an empty `ACK` after the post-`ACCEPT` guard to complete the handshake.
+Without that confirmation, the callee remains in `ACCEPTING` and keeps retrying
+`ACCEPT` until its window expires.
+
 ### Level 2 — Data-Flow Sub-FSM
 
 Active only when L1 is in `CONNECTED`.  Manages the half-duplex turn-taking and

--- a/docs/TNC.md
+++ b/docs/TNC.md
@@ -81,7 +81,9 @@ BW2750\r
 
 - **BW2300** — Full bandwidth.  Allows gear-shifting up to DATAC1 (510 bytes/frame).
 - **BW500** — Narrow bandwidth.  Restricts the maximum payload mode to DATAC3/DATAC4.
-- **BW2750** — Accepted for compatibility, but currently behaves like **BW2300**.
+- **BW2750** — Tactical mode token accepted for VARA compatibility. Mercury
+  currently uses the same payload-mode ceiling as **BW2300**, but preserves
+  `2750` in `CONNECTED ... BW` reports.
 
 ---
 
@@ -250,9 +252,9 @@ Mercury returns to the idle/listening state.
 
 Sent when a session is successfully established (either outgoing CONNECT
 or incoming CALL accepted).  The `<bandwidth>` value is the effective
-negotiated bandwidth, currently `500` or `2300`.  `<sourcecall>` is always the
-station that initiated the session, and `<destcall>` is always the station that
-was called.
+configured VARA bandwidth token for this side (`500`, `2300`, or `2750`).
+`<sourcecall>` is always the station that initiated the session, and
+`<destcall>` is always the station that was called.
 
 ### DISCONNECTED
 

--- a/docs/TNC.md
+++ b/docs/TNC.md
@@ -224,6 +224,8 @@ These are sent on the **control port** without a preceding command.
 
 | Response                                    | Meaning                                      |
 |---------------------------------------------|----------------------------------------------|
+| `PENDING\r`                                 | Incoming connect request detected            |
+| `CANCELPENDING\r`                           | Pending incoming connect did not complete    |
 | `CONNECTED <sourcecall> <destcall> <bandwidth>\r` | ARQ session established                |
 | `DISCONNECTED\r`                            | ARQ session ended                            |
 | `PTT ON\r`                                  | Radio transmitter keyed                      |
@@ -232,6 +234,17 @@ These are sent on the **control port** without a preceding command.
 | `SN <value>\r`                              | SNR update                                   |
 | `BITRATE (<level>) <bps> BPS\r`            | Throughput update                            |
 | `IAMALIVE\r`                                | Heartbeat (sent periodically while idle)     |
+
+### PENDING
+
+Sent when Mercury detects an incoming ARQ connect request addressed to the
+local station. This is an early warning so VARA-compatible host applications
+can suspend scanning or other idle activity while the link setup is in progress.
+
+### CANCELPENDING
+
+Sent when a previously pending incoming connect request does not complete and
+Mercury returns to the idle/listening state.
 
 ### CONNECTED
 

--- a/docs/TNC.md
+++ b/docs/TNC.md
@@ -144,8 +144,9 @@ CONNECT <mycall> <theircall>\r
 **Response:** `OK\r` if the command was accepted, `WRONG\r` on error.
 
 Mercury will transmit CALL frames on DATAC13 and wait for an ACCEPT.
-On success, the asynchronous response `CONNECTED <mycall> <theircall> <bandwidth>\r`
-is sent on the control port.
+On success, the asynchronous response
+`CONNECTED <sourcecall> <destcall> <bandwidth>\r` is sent on the control port,
+preserving the same call order as the original `CONNECT` command on both peers.
 
 Example:
 ```
@@ -223,7 +224,7 @@ These are sent on the **control port** without a preceding command.
 
 | Response                                    | Meaning                                      |
 |---------------------------------------------|----------------------------------------------|
-| `CONNECTED <mycall> <theircall> <bandwidth>\r` | ARQ session established                   |
+| `CONNECTED <sourcecall> <destcall> <bandwidth>\r` | ARQ session established                |
 | `DISCONNECTED\r`                            | ARQ session ended                            |
 | `PTT ON\r`                                  | Radio transmitter keyed                      |
 | `PTT OFF\r`                                 | Radio transmitter unkeyed                    |
@@ -236,7 +237,9 @@ These are sent on the **control port** without a preceding command.
 
 Sent when a session is successfully established (either outgoing CONNECT
 or incoming CALL accepted).  The `<bandwidth>` value is the effective
-negotiated bandwidth, currently `500` or `2300`.
+negotiated bandwidth, currently `500` or `2300`.  `<sourcecall>` is always the
+station that initiated the session, and `<destcall>` is always the station that
+was called.
 
 ### DISCONNECTED
 


### PR DESCRIPTION
Send an empty ACK after ACCEPT when the caller has no payload queued yet, so the callee can leave ACCEPTING and enter CONNECTED instead of retrying ACCEPT until timeout.

This was discovered during varim tests.