### PR TITLE
Redesign framer byte extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ Mode behavior notes:
 - `-m` / `-s` affects **broadcast** and **test** modes only.
 - During an active ARQ link, control frames use DATAC13 and ARQ payload starts in DATAC4 (then may adapt to DATAC3/DATAC1).
 - VARA `BW500` blocks DATAC1; `BW2300` and `BW2750` both allow the full Mercury
-  payload-mode ladder, with `BW2750` preserved as a compatibility/reporting token.
+  payload-mode ladder.
+- `CALL` advertises the local BW token and `ACCEPT` returns the negotiated
+  session token. If either side uses `BW500`, the link stays narrow; `BW2750`
+  is preserved in `CONNECTED ... BW` only when both peers advertise it.
 - `FSK_LDPC` is currently **experimental** (mainly for lab/test usage), may have longer decode/sync latency depending on setup, and is not recommended for production links yet.
 
 Radio control notes:

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -973,6 +973,18 @@ void tnc_send_connected()
         HLOGW("tcp-ctl", "Error queuing connected message");
 }
 
+void tnc_send_cqframe(const char *source_call, int bw_hz)
+{
+    char buffer[128];
+
+    if (!source_call || source_call[0] == '\0')
+        return;
+
+    sprintf(buffer, "CQFRAME %s %d\r", source_call, bw_hz);
+    if (tnc_queue_line(buffer) < 0)
+        HLOGW("tcp-ctl", "Error queuing CQFRAME message");
+}
+
 void tnc_send_pending()
 {
     if (tnc_queue_line("PENDING\r") < 0)

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -357,6 +357,21 @@ static void execute_control_command(char *buffer)
         return;
     }
 
+    if (!memcmp(buffer, "CQFRAME", strlen("CQFRAME")))
+    {
+        memset(&cmd, 0, sizeof(cmd));
+        cmd.type = ARQ_CMD_SEND_CQ;
+        if (sscanf(buffer, "CQFRAME %15s %d", cmd.arg0, &cmd.value) == 2 &&
+            (cmd.value == ARQ_BANDWIDTH_NARROW_HZ ||
+             cmd.value == ARQ_BANDWIDTH_FULL_HZ ||
+             cmd.value == ARQ_BANDWIDTH_TACTICAL_HZ) &&
+            arq_submit_tcp_cmd(&cmd) == 0)
+            tcp_write(CTL_TCP_PORT, (uint8_t *)"OK\r", 3);
+        else
+            tcp_write(CTL_TCP_PORT, (uint8_t *)"WRONG\r", 6);
+        return;
+    }
+
     if (!memcmp(buffer, "DISCONNECT", strlen("DISCONNECT")))
     {
         memset(&cmd, 0, sizeof(cmd));

--- a/data_interfaces/tcp_interfaces.h
+++ b/data_interfaces/tcp_interfaces.h
@@ -51,6 +51,7 @@ void ptt_off();
 void tnc_send_pending();
 void tnc_send_cancelpending();
 void tnc_send_connected();
+void tnc_send_cqframe(const char *source_call, int bw_hz);
 void tnc_send_disconnected();
 void tnc_send_buffer(uint32_t bytes);
 void tnc_send_sn(float snr);

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -530,6 +530,18 @@ bool arq_handle_incoming_cq_frame(uint8_t *data, size_t frame_size)
     return true;
 }
 
+void arq_notify_cq_tx_started(void)
+{
+    tnc_send_pending();
+    HLOGI(LOG_COMP, "CQ transmission started");
+}
+
+void arq_notify_cq_tx_complete(void)
+{
+    tnc_send_cancelpending();
+    HLOGI(LOG_COMP, "CQ transmission completed");
+}
+
 void arq_handle_incoming_frame(uint8_t *data, size_t frame_size, float rx_snr)
 {
     if (!data || frame_size < ARQ_FRAME_HDR_SIZE) return;

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -53,6 +53,7 @@ extern cbuf_handle_t data_rx_buffer_arq;
 extern void tnc_send_pending(void);
 extern void tnc_send_cancelpending(void);
 extern void tnc_send_connected(void);
+extern void tnc_send_cqframe(const char *source_call, int bw_hz);
 extern void tnc_send_disconnected(void);
 extern void tnc_send_buffer(uint32_t bytes);
 
@@ -194,6 +195,7 @@ static void cb_notify_disconnected(bool to_no_client)
     bool was_connected = arq_conn.dst_addr[0] != '\0';
     memset(arq_conn.src_addr, 0, sizeof(arq_conn.src_addr));
     memset(arq_conn.dst_addr, 0, sizeof(arq_conn.dst_addr));
+    arq_conn.session_bw = 0;
     arq_conn.TRX = RX;
     /* Flush stale TX bytes from the previous session.  RX bytes are flushed
      * at connection start (cb_notify_connected) instead of here, so that the
@@ -250,9 +252,27 @@ static void cb_send_buffer_status(int backlog_bytes)
     tnc_send_buffer((uint32_t)(backlog_bytes < 0 ? 0 : backlog_bytes));
 }
 
+static int normalize_bandwidth_hz(int bw_hz)
+{
+    if (bw_hz == ARQ_BANDWIDTH_NARROW_HZ ||
+        bw_hz == ARQ_BANDWIDTH_FULL_HZ ||
+        bw_hz == ARQ_BANDWIDTH_TACTICAL_HZ)
+        return bw_hz;
+
+    return ARQ_BANDWIDTH_FULL_HZ;
+}
+
+static int active_session_bandwidth_hz(void)
+{
+    if (arq_conn.session_bw != 0)
+        return normalize_bandwidth_hz(arq_conn.session_bw);
+
+    return normalize_bandwidth_hz(arq_conn.bw);
+}
+
 int arq_effective_bandwidth_hz(void)
 {
-    if (arq_conn.bw == ARQ_BANDWIDTH_NARROW_HZ)
+    if (active_session_bandwidth_hz() == ARQ_BANDWIDTH_NARROW_HZ)
         return ARQ_BANDWIDTH_NARROW_HZ;
 
     return ARQ_BANDWIDTH_FULL_HZ;
@@ -260,12 +280,7 @@ int arq_effective_bandwidth_hz(void)
 
 int arq_reported_bandwidth_hz(void)
 {
-    if (arq_conn.bw == ARQ_BANDWIDTH_NARROW_HZ ||
-        arq_conn.bw == ARQ_BANDWIDTH_FULL_HZ ||
-        arq_conn.bw == ARQ_BANDWIDTH_TACTICAL_HZ)
-        return arq_conn.bw;
-
-    return ARQ_BANDWIDTH_FULL_HZ;
+    return active_session_bandwidth_hz();
 }
 
 bool arq_bandwidth_allows_mode(int mode)
@@ -292,7 +307,7 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
         return;
 
     case ARQ_CMD_SET_BANDWIDTH:
-        arq_conn.bw = msg->value;
+        arq_conn.bw = normalize_bandwidth_hz(msg->value);
         return;
 
     case ARQ_CMD_SET_RETRY:
@@ -313,6 +328,7 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
     case ARQ_CMD_CONNECT:
         snprintf(arq_conn.src_addr, CALLSIGN_MAX_SIZE, "%s", msg->arg0);
         snprintf(arq_conn.dst_addr, CALLSIGN_MAX_SIZE, "%s", msg->arg1);
+        arq_conn.session_bw = 0;
         snprintf(ev.remote_call, CALLSIGN_MAX_SIZE, "%s", msg->arg1);
         ev.id = ARQ_EV_APP_CONNECT;
         break;
@@ -439,10 +455,11 @@ bool arq_handle_incoming_connect_frame(uint8_t *data, size_t frame_size)
     uint8_t session_id;
     char src[CALLSIGN_MAX_SIZE] = {0};
     char dst[CALLSIGN_MAX_SIZE] = {0};
+    int bw_hz = 0;
 
     int rc = is_accept
-             ? arq_protocol_parse_accept(data, frame_size, &session_id, src, dst)
-             : arq_protocol_parse_call  (data, frame_size, &session_id, src, dst);
+             ? arq_protocol_parse_accept(data, frame_size, &session_id, src, dst, &bw_hz)
+             : arq_protocol_parse_call  (data, frame_size, &session_id, src, dst, &bw_hz);
 
     if (rc < 0)
     {
@@ -467,7 +484,31 @@ bool arq_handle_incoming_connect_frame(uint8_t *data, size_t frame_size)
     ev.session_id = session_id;
     /* src = transmitting side's callsign */
     snprintf(ev.remote_call, CALLSIGN_MAX_SIZE, "%s", src);
+    if (is_accept)
+        arq_conn.session_bw = normalize_bandwidth_hz(bw_hz);
+    else
+        arq_conn.session_bw = normalize_bandwidth_hz(
+            bw_hz < normalize_bandwidth_hz(arq_conn.bw) ? bw_hz : normalize_bandwidth_hz(arq_conn.bw));
     evq_push(&ev);
+    return true;
+}
+
+bool arq_handle_incoming_cq_frame(uint8_t *data, size_t frame_size)
+{
+    char source_call[CALLSIGN_MAX_SIZE] = {0};
+    int bw_hz = 0;
+
+    if (!data || frame_size < ARQ_CONTROL_FRAME_SIZE)
+        return false;
+
+    if (arq_protocol_parse_cq(data, frame_size, source_call, &bw_hz) < 0)
+    {
+        HLOGD(LOG_COMP, "CQ parse failed");
+        return false;
+    }
+
+    tnc_send_cqframe(source_call, normalize_bandwidth_hz(bw_hz));
+    HLOGI(LOG_COMP, "CQ frame decoded from %s (%d Hz)", source_call, bw_hz);
     return true;
 }
 
@@ -583,6 +624,7 @@ int arq_init(size_t frame_size, int mode)
     arq_conn.mode            = mode;
     arq_conn.call_burst_size = 1;
     arq_conn.bw              = ARQ_BANDWIDTH_FULL_HZ;
+    arq_conn.session_bw      = 0;
 
     init_model();
 

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -333,6 +333,24 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
         ev.id = ARQ_EV_APP_CONNECT;
         break;
 
+    case ARQ_CMD_SEND_CQ:
+    {
+        uint8_t frame[INT_BUFFER_SIZE];
+        const char *source_call = msg->arg0[0] ? msg->arg0 : arq_conn.my_call_sign;
+        int bw_hz = normalize_bandwidth_hz(msg->value);
+        int n = arq_protocol_build_cq(frame, sizeof(frame), source_call, bw_hz);
+        if (n <= 0)
+        {
+            HLOGW(LOG_COMP, "Failed to build CQ frame (source=%s bw=%d)",
+                  source_call, bw_hz);
+            return;
+        }
+
+        cb_send_tx_frame(PACKET_TYPE_ARQ_CQ, g_sess.control_mode, (size_t)n, frame);
+        HLOGI(LOG_COMP, "Queued CQ frame from %s (%d Hz)", source_call, bw_hz);
+        return;
+    }
+
     case ARQ_CMD_DISCONNECT:
         /* VARA TNC spec: send DISCONNECTED to host immediately on receiving
          * DISCONNECT command, before the over-the-air exchange completes.

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -185,6 +185,7 @@ static void cb_notify_pending(const char *remote_call)
 
 static void cb_notify_cancelpending(void)
 {
+    arq_conn.session_bw = 0;
     tnc_send_cancelpending();
     HLOGI(LOG_COMP, "Incoming connection cancelled");
 }

--- a/datalink_arq/arq.h
+++ b/datalink_arq/arq.h
@@ -215,6 +215,15 @@ bool arq_handle_incoming_connect_frame(uint8_t *data, size_t frame_size);
 bool arq_handle_incoming_cq_frame(uint8_t *data, size_t frame_size);
 
 /**
+ * @brief Emit VARA-style async status for an outgoing CQFRAME transmission.
+ *
+ * VARA clients such as varim treat CQFRAME as a pending operation and expect
+ * PENDING/CANCELPENDING around the actual send lifecycle.
+ */
+void arq_notify_cq_tx_started(void);
+void arq_notify_cq_tx_complete(void);
+
+/**
  * @brief Handle incoming regular ARQ control/data frame.
  * @param data Frame bytes.
  * @param frame_size Frame length in bytes.

--- a/datalink_arq/arq.h
+++ b/datalink_arq/arq.h
@@ -54,7 +54,8 @@ typedef struct
     bool encryption;
     int call_burst_size;
     bool listen;
-    int bw; // in Hz
+    int bw;         // configured local bandwidth in Hz
+    int session_bw; // negotiated session bandwidth in Hz (0 = not negotiated)
     int retry_slots; // 0 = use compiled default
     size_t frame_size;
     int mode;
@@ -204,6 +205,14 @@ void arq_set_active_modem_mode(int mode, size_t frame_size);
  * @return true if frame was handled by ARQ connect path.
  */
 bool arq_handle_incoming_connect_frame(uint8_t *data, size_t frame_size);
+
+/**
+ * @brief Handle incoming compact CQ frame and emit host-side CQFRAME notification.
+ * @param data Incoming frame bytes.
+ * @param frame_size Frame length in bytes.
+ * @return true if frame was handled by CQ path.
+ */
+bool arq_handle_incoming_cq_frame(uint8_t *data, size_t frame_size);
 
 /**
  * @brief Handle incoming regular ARQ control/data frame.

--- a/datalink_arq/arq_events.h
+++ b/datalink_arq/arq_events.h
@@ -29,7 +29,8 @@ typedef enum
     ARQ_CMD_SET_BANDWIDTH = 7,
     ARQ_CMD_CONNECT = 8,
     ARQ_CMD_DISCONNECT = 9,
-    ARQ_CMD_SET_RETRY = 10
+    ARQ_CMD_SET_RETRY = 10,
+    ARQ_CMD_SEND_CQ = 11
 } arq_cmd_type_t;
 
 typedef enum

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -195,7 +195,7 @@ static void send_frame(int ptype, int mode, size_t len, const uint8_t *frame)
         uint8_t padded[INT_BUFFER_SIZE];
         memcpy(padded, frame, len);
         memset(padded + len, 0, slot - len);
-        write_frame_header(padded, ptype, slot);
+        write_frame_header(padded, ptype, frame_header_extension(frame[0]));
         g_cbs.send_tx_frame(ptype, mode, slot, padded);
         return;
     }
@@ -436,12 +436,13 @@ static void send_call_accept(arq_session_t *sess, bool is_accept)
     uint8_t frame[INT_BUFFER_SIZE];
     int n;
     const char *my_call = arq_conn.my_call_sign;
+    int bw_hz = is_accept ? arq_reported_bandwidth_hz() : arq_conn.bw;
     if (is_accept)
         n = arq_protocol_build_accept(frame, sizeof(frame), sess->session_id,
-                                      my_call, sess->remote_call);
+                                      my_call, sess->remote_call, bw_hz);
     else
         n = arq_protocol_build_call(frame, sizeof(frame), sess->session_id,
-                                    my_call, sess->remote_call);
+                                    my_call, sess->remote_call, bw_hz);
     if (n > 0)
         send_frame(PACKET_TYPE_ARQ_CALL, sess->control_mode, (size_t)n, frame);
 }

--- a/datalink_arq/arq_protocol.c
+++ b/datalink_arq/arq_protocol.c
@@ -91,7 +91,7 @@ int arq_protocol_encode_hdr(uint8_t *buf, size_t buf_len, const arq_frame_hdr_t 
     if (!buf || !hdr || buf_len < ARQ_FRAME_HDR_SIZE)
         return -1;
 
-    /* byte 0 (framer: CRC6 + packet_type) is set by write_frame_header() */
+    /* byte 0 (framer: extension + packet_type) is set by write_frame_header() */
     buf[ARQ_HDR_SUBTYPE_IDX]  = hdr->subtype;
     buf[ARQ_HDR_FLAGS_IDX]    = hdr->flags;
     buf[ARQ_HDR_SESSION_IDX]  = hdr->session_id;
@@ -107,7 +107,8 @@ int arq_protocol_decode_hdr(const uint8_t *buf, size_t buf_len, arq_frame_hdr_t 
     if (!buf || !hdr || buf_len < ARQ_FRAME_HDR_SIZE)
         return -1;
 
-    hdr->packet_type   = (buf[0] >> PACKET_TYPE_SHIFT) & PACKET_TYPE_MASK;
+    hdr->packet_type   = frame_header_packet_type(buf[0]);
+    hdr->frame_ext     = frame_header_extension(buf[0]);
     hdr->subtype       = buf[ARQ_HDR_SUBTYPE_IDX];
     hdr->flags         = buf[ARQ_HDR_FLAGS_IDX];
     hdr->session_id    = buf[ARQ_HDR_SESSION_IDX];
@@ -116,6 +117,36 @@ int arq_protocol_decode_hdr(const uint8_t *buf, size_t buf_len, arq_frame_hdr_t 
     hdr->snr_raw       = buf[ARQ_HDR_SNR_IDX];
     hdr->ack_delay_raw = buf[ARQ_HDR_DELAY_IDX];
     return 0;
+}
+
+uint8_t arq_protocol_bw_token_from_hz(int bw_hz)
+{
+    switch (bw_hz)
+    {
+    case ARQ_BANDWIDTH_NARROW_HZ:
+        return ARQ_BW_TOKEN_500;
+    case ARQ_BANDWIDTH_FULL_HZ:
+        return ARQ_BW_TOKEN_2300;
+    case ARQ_BANDWIDTH_TACTICAL_HZ:
+        return ARQ_BW_TOKEN_2750;
+    default:
+        return ARQ_BW_TOKEN_NONE;
+    }
+}
+
+int arq_protocol_bw_hz_from_token(uint8_t bw_token)
+{
+    switch (bw_token)
+    {
+    case ARQ_BW_TOKEN_500:
+        return ARQ_BANDWIDTH_NARROW_HZ;
+    case ARQ_BW_TOKEN_2300:
+        return ARQ_BANDWIDTH_FULL_HZ;
+    case ARQ_BW_TOKEN_2750:
+        return ARQ_BANDWIDTH_TACTICAL_HZ;
+    default:
+        return 0;
+    }
 }
 
 /* ======================================================================
@@ -188,7 +219,7 @@ static int build_ctrl(uint8_t *buf, size_t buf_len,
     buf[ARQ_HDR_DELAY_IDX]    = ack_delay_raw;
     if (payload && payload_len > 0)
         memcpy(buf + ARQ_FRAME_HDR_SIZE, payload, payload_len);
-    write_frame_header(buf, PACKET_TYPE_ARQ_CONTROL, total);
+    write_frame_header(buf, PACKET_TYPE_ARQ_CONTROL, 0);
     return (int)total;
 }
 
@@ -294,7 +325,7 @@ int arq_protocol_build_data(uint8_t *buf, size_t buf_len,
     buf[ARQ_HDR_SNR_IDX]      = snr_raw;
     buf[ARQ_HDR_DELAY_IDX]    = payload_valid;   /* 0=full, else=valid bytes */
     memcpy(buf + ARQ_FRAME_HDR_SIZE, payload, payload_len);
-    write_frame_header(buf, PACKET_TYPE_ARQ_DATA, total);
+    write_frame_header(buf, PACKET_TYPE_ARQ_DATA, 0);
     return (int)total;
 }
 
@@ -379,14 +410,61 @@ static int decode_callsign_payload(const uint8_t *in, size_t in_len,
     return 0;
 }
 
+static int encode_callsign_only_payload(const char *src, uint8_t *out, size_t out_cap)
+{
+    uint8_t tmp[4096];
+    int enc_len;
+
+    if (!src || !out || out_cap == 0)
+        return -1;
+
+    char src_upper[CALLSIGN_MAX_SIZE];
+    int n = 0;
+    for (; src[n] && n < (int)sizeof(src_upper) - 1; n++)
+    {
+        char c = src[n];
+        if (c >= 'a' && c <= 'z') c = (char)(c - ('a' - 'A'));
+        src_upper[n] = c;
+    }
+    src_upper[n] = 0;
+
+    init_model();
+    enc_len = arithmetic_encode(src_upper, tmp);
+    if (enc_len <= 0)
+        return -1;
+
+    if ((size_t)enc_len > out_cap)
+        enc_len = (int)out_cap;
+    memcpy(out, tmp, (size_t)enc_len);
+    return enc_len;
+}
+
+static int decode_callsign_only_payload(const uint8_t *in, size_t in_len, char *src_out)
+{
+    if (!in || !src_out || in_len == 0)
+        return -1;
+
+    init_model();
+    if (arithmetic_decode((uint8_t *)in, (int)in_len, src_out, CALLSIGN_MAX_SIZE) < 0)
+        return -1;
+    src_out[CALLSIGN_MAX_SIZE - 1] = 0;
+    return 0;
+}
+
 static int build_call_accept(uint8_t *buf, size_t buf_len, bool is_accept,
                               uint8_t session_id,
-                              const char *src, const char *dst)
+                              const char *src, const char *dst,
+                              int bw_hz)
 {
     uint8_t encoded[ARQ_CONNECT_MAX_ENCODED];
     int enc_len;
+    uint8_t bw_token;
 
     if (!buf || !src || !dst || buf_len < ARQ_CONTROL_FRAME_SIZE)
+        return -1;
+
+    bw_token = arq_protocol_bw_token_from_hz(bw_hz);
+    if (bw_token == ARQ_BW_TOKEN_NONE)
         return -1;
 
     enc_len = encode_callsign_payload(src, dst, encoded, sizeof(encoded));
@@ -398,30 +476,37 @@ static int build_call_accept(uint8_t *buf, size_t buf_len, bool is_accept,
         (uint8_t)((session_id & ARQ_CONNECT_SESSION_MASK) |
                   (is_accept ? ARQ_CONNECT_ACCEPT_FLAG : 0));
     memcpy(buf + ARQ_CONNECT_PAYLOAD_IDX, encoded, (size_t)enc_len);
-    write_frame_header(buf, PACKET_TYPE_ARQ_CALL, ARQ_CONTROL_FRAME_SIZE);
+    write_frame_header(buf, PACKET_TYPE_ARQ_CALL, bw_token);
     return ARQ_CONTROL_FRAME_SIZE;
 }
 
 int arq_protocol_build_call(uint8_t *buf, size_t buf_len,
                              uint8_t session_id,
-                             const char *src, const char *dst)
+                             const char *src, const char *dst,
+                             int bw_hz)
 {
-    return build_call_accept(buf, buf_len, false, session_id, src, dst);
+    return build_call_accept(buf, buf_len, false, session_id, src, dst, bw_hz);
 }
 
 int arq_protocol_build_accept(uint8_t *buf, size_t buf_len,
                                uint8_t session_id,
-                               const char *src, const char *dst)
+                               const char *src, const char *dst,
+                               int bw_hz)
 {
-    return build_call_accept(buf, buf_len, true, session_id, src, dst);
+    return build_call_accept(buf, buf_len, true, session_id, src, dst, bw_hz);
 }
 
 static int parse_call_accept(const uint8_t *buf, size_t buf_len,
-                              uint8_t *session_id_out,
-                              char *src_out, char *dst_out)
+                               uint8_t *session_id_out,
+                               char *src_out, char *dst_out,
+                               int *bw_hz_out)
 {
     if (!buf || buf_len < ARQ_CONTROL_FRAME_SIZE ||
-        !session_id_out || !src_out || !dst_out)
+        !session_id_out || !src_out || !dst_out || !bw_hz_out)
+        return -1;
+
+    *bw_hz_out = arq_protocol_bw_hz_from_token(frame_header_extension(buf[0]));
+    if (*bw_hz_out == 0)
         return -1;
 
     *session_id_out = buf[ARQ_CONNECT_SESSION_IDX] & ARQ_CONNECT_SESSION_MASK;
@@ -431,15 +516,58 @@ static int parse_call_accept(const uint8_t *buf, size_t buf_len,
 }
 
 int arq_protocol_parse_call(const uint8_t *buf, size_t buf_len,
-                             uint8_t *session_id_out,
-                             char *src_out, char *dst_out)
+                              uint8_t *session_id_out,
+                              char *src_out, char *dst_out,
+                              int *bw_hz_out)
 {
-    return parse_call_accept(buf, buf_len, session_id_out, src_out, dst_out);
+    return parse_call_accept(buf, buf_len, session_id_out, src_out, dst_out,
+                             bw_hz_out);
 }
 
 int arq_protocol_parse_accept(const uint8_t *buf, size_t buf_len,
-                               uint8_t *session_id_out,
-                               char *src_out, char *dst_out)
+                                uint8_t *session_id_out,
+                                char *src_out, char *dst_out,
+                                int *bw_hz_out)
 {
-    return parse_call_accept(buf, buf_len, session_id_out, src_out, dst_out);
+    return parse_call_accept(buf, buf_len, session_id_out, src_out, dst_out,
+                             bw_hz_out);
+}
+
+int arq_protocol_build_cq(uint8_t *buf, size_t buf_len,
+                           const char *src, int bw_hz)
+{
+    int enc_len;
+    uint8_t bw_token;
+
+    if (!buf || !src || buf_len < ARQ_CONTROL_FRAME_SIZE)
+        return -1;
+
+    bw_token = arq_protocol_bw_token_from_hz(bw_hz);
+    if (bw_token == ARQ_BW_TOKEN_NONE)
+        return -1;
+
+    memset(buf, 0, ARQ_CONTROL_FRAME_SIZE);
+    enc_len = encode_callsign_only_payload(src,
+                                           buf + ARQ_CQ_PAYLOAD_IDX,
+                                           ARQ_CQ_SRC_MAX_ENCODED);
+    if (enc_len <= 0)
+        return -1;
+
+    write_frame_header(buf, PACKET_TYPE_ARQ_CQ, bw_token);
+    return ARQ_CONTROL_FRAME_SIZE;
+}
+
+int arq_protocol_parse_cq(const uint8_t *buf, size_t buf_len,
+                           char *src_out, int *bw_hz_out)
+{
+    if (!buf || !src_out || !bw_hz_out || buf_len < ARQ_CONTROL_FRAME_SIZE)
+        return -1;
+
+    *bw_hz_out = arq_protocol_bw_hz_from_token(frame_header_extension(buf[0]));
+    if (*bw_hz_out == 0)
+        return -1;
+
+    return decode_callsign_only_payload(buf + ARQ_CQ_PAYLOAD_IDX,
+                                        ARQ_CQ_SRC_MAX_ENCODED,
+                                        src_out);
 }

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -21,7 +21,7 @@
 #define ARQ_PROTO_VERSION  4   /* v4: framer extension field, no proto_ver field on wire */
 
 /* ======================================================================
- * Frame header layout (v3, 8 bytes total)
+ * Frame header layout (v4, 8 bytes total)
  *
  * Proto_ver field removed — both sides always run the same binary.
  * ack_delay reduced to 1 byte (10ms units, max 2.55s — covers all real delays).

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -18,7 +18,7 @@
  * Protocol version (informational — not carried in wire frames)
  * ====================================================================== */
 
-#define ARQ_PROTO_VERSION  3   /* v3: 8-byte header, no proto_ver field on wire */
+#define ARQ_PROTO_VERSION  4   /* v4: framer extension field, no proto_ver field on wire */
 
 /* ======================================================================
  * Frame header layout (v3, 8 bytes total)
@@ -27,9 +27,9 @@
  * ack_delay reduced to 1 byte (10ms units, max 2.55s — covers all real delays).
  * HAS_SNR bit removed — snr_raw==0 already signals "unknown".
  *
- *  Byte 0: framer byte — set/validated by write_frame_header()/parse_frame_header()
+ *  Byte 0: framer byte — set/read by write_frame_header()/parse_frame_header()
  *            bits [7:5] = packet_type (3 bits: PACKET_TYPE_ARQ_CONTROL=0, ARQ_DATA=1, ARQ_CALL=2)
- *            bits [4:0] = CRC5 of bytes [1..frame_size-1]
+ *            bits [4:0] = extension field (packet-type-specific)
  *  Byte 1: subtype      — arq_subtype_t
  *  Byte 2: flags        — bit7=TURN_REQ, bit6=HAS_DATA, bits[5:0]=spare
  *  Byte 3: session_id   — random byte chosen by caller at connect time
@@ -58,7 +58,7 @@
 /* CONNECT frames (CALL/ACCEPT) compact layout — 14 bytes, DATAC13 only.
  * Uses PACKET_TYPE_ARQ_CALL in the framer byte.
  *
- *  Byte 0: framer byte (PACKET_TYPE_ARQ_CALL | CRC5, set by write_frame_header)
+ *  Byte 0: framer byte (PACKET_TYPE_ARQ_CALL | BW token, set by write_frame_header)
  *  Byte 1: connect_meta  = (session_id & 0x7F) | (is_accept ? 0x80 : 0x00)
  *  Bytes 2-3:  CRC16-CCITT of DST callsign (little-endian) — for local validation
  *  Bytes 4-13: arithmetic_encode(SRC callsign only) — 10 bytes, fits callsigns up to ~14 chars
@@ -72,6 +72,21 @@
 #define ARQ_CONNECT_MAX_ENCODED       (ARQ_CONTROL_FRAME_SIZE - ARQ_CONNECT_META_SIZE)
 #define ARQ_CONNECT_DST_CRC_SIZE      2   /* CRC16-CCITT of DST at bytes [2..3], little-endian */
 #define ARQ_CONNECT_SRC_MAX_ENCODED   (ARQ_CONNECT_MAX_ENCODED - ARQ_CONNECT_DST_CRC_SIZE) /* 10 */
+
+/* Compact CQ frame layout — 14 bytes, DATAC13 only.
+ * Uses PACKET_TYPE_ARQ_CQ in the framer byte.
+ *
+ *  Byte 0: framer byte (PACKET_TYPE_ARQ_CQ | BW token)
+ *  Bytes 1-13: arithmetic_encode(SRC callsign only)
+ */
+#define ARQ_CQ_PAYLOAD_IDX            1
+#define ARQ_CQ_SRC_MAX_ENCODED        (ARQ_CONTROL_FRAME_SIZE - ARQ_CQ_PAYLOAD_IDX) /* 13 */
+
+/* BW token values carried in the framer byte extension field for ARQ_CALL/ARQ_CQ. */
+#define ARQ_BW_TOKEN_NONE             0
+#define ARQ_BW_TOKEN_500              1
+#define ARQ_BW_TOKEN_2300             2
+#define ARQ_BW_TOKEN_2750             3
 
 /* ======================================================================
  * Flags byte (byte 2)
@@ -112,6 +127,7 @@ typedef enum
 typedef struct
 {
     uint8_t  packet_type;   /* PACKET_TYPE_ARQ_CONTROL or _DATA   (from framer byte) */
+    uint8_t  frame_ext;     /* low 5 bits of framer byte                          */
     uint8_t  subtype;       /* arq_subtype_t                                         */
     uint8_t  flags;         /* ARQ_FLAG_* bitmask                                    */
     uint8_t  session_id;
@@ -215,8 +231,9 @@ extern _Atomic int arq_disconnect_retry_slots;
 /* In DATA frames the ack_delay byte is repurposed to carry payload_valid:
  *   0               = full frame (all user bytes are valid data)
  *   1 .. user_bytes = only this many leading bytes are valid; rest is padding
- * This lets partial last-frames be transmitted with correct CRC5 (the slot is
- * always filled to the full modem payload, CRC5 covers all bytes). */
+ * This lets partial last-frames be transmitted while still filling the full
+ * modem slot; the receiver uses `data_len` to distinguish valid payload bytes
+ * from trailing padding. */
 #define ARQ_DATA_LEN_FULL             0
 
 /* Mode table (defined in arq_protocol.c) */
@@ -238,6 +255,18 @@ int arq_protocol_encode_hdr(uint8_t *buf, size_t buf_len, const arq_frame_hdr_t 
  * @return 0 on success, -1 if buf too short.
  */
 int arq_protocol_decode_hdr(const uint8_t *buf, size_t buf_len, arq_frame_hdr_t *hdr);
+
+/**
+ * @brief Map a configured bandwidth in Hz to an on-air BW token.
+ * @return ARQ_BW_TOKEN_* value, or ARQ_BW_TOKEN_NONE if unsupported.
+ */
+uint8_t arq_protocol_bw_token_from_hz(int bw_hz);
+
+/**
+ * @brief Map an on-air BW token back to Hz.
+ * @return 500/2300/2750 on success, or 0 if the token is invalid.
+ */
+int arq_protocol_bw_hz_from_token(uint8_t bw_token);
 
 /**
  * @brief Encode a floating-point SNR (dB) into the snr_raw wire byte.
@@ -280,7 +309,7 @@ uint16_t arq_protocol_callsign_crc16(const char *callsign);
  * frame (framer byte + header/payload) and returns the total byte count,
  * or -1 if buf_len < required size or arguments are invalid.
  *
- * The framer byte (byte 0, CRC5 + packet_type) is written by
+ * The framer byte (byte 0, extension field + packet_type) is written by
  * write_frame_header() inside each builder.
  *
  * For control frames, frame_size = ARQ_CONTROL_FRAME_SIZE (14 bytes).
@@ -373,8 +402,9 @@ int arq_protocol_build_data(uint8_t *buf, size_t buf_len,
  * @return Total frame bytes (ARQ_CONTROL_FRAME_SIZE = 14) on success, -1 on error.
  */
 int arq_protocol_build_call(uint8_t *buf, size_t buf_len,
-                             uint8_t session_id,
-                             const char *src, const char *dst);
+                              uint8_t session_id,
+                              const char *src, const char *dst,
+                              int bw_hz);
 
 /**
  * Build an ACCEPT frame.
@@ -385,8 +415,9 @@ int arq_protocol_build_call(uint8_t *buf, size_t buf_len,
  * @param dst  Remote callsign.
  */
 int arq_protocol_build_accept(uint8_t *buf, size_t buf_len,
-                               uint8_t session_id,
-                               const char *src, const char *dst);
+                                uint8_t session_id,
+                                const char *src, const char *dst,
+                                int bw_hz);
 
 /**
  * Parse a CALL frame; extract callsigns.
@@ -398,14 +429,28 @@ int arq_protocol_build_accept(uint8_t *buf, size_t buf_len,
  * @return 0 on success, -1 on parse error.
  */
 int arq_protocol_parse_call(const uint8_t *buf, size_t buf_len,
-                             uint8_t *session_id_out,
-                             char *src_out, char *dst_out);
+                              uint8_t *session_id_out,
+                              char *src_out, char *dst_out,
+                              int *bw_hz_out);
 
 /**
  * Parse an ACCEPT frame; same layout as CALL.
  */
 int arq_protocol_parse_accept(const uint8_t *buf, size_t buf_len,
-                               uint8_t *session_id_out,
-                               char *src_out, char *dst_out);
+                                uint8_t *session_id_out,
+                                char *src_out, char *dst_out,
+                                int *bw_hz_out);
+
+/**
+ * Build a compact DATAC13 CQ frame carrying source callsign and BW token.
+ */
+int arq_protocol_build_cq(uint8_t *buf, size_t buf_len,
+                           const char *src, int bw_hz);
+
+/**
+ * Parse a compact DATAC13 CQ frame.
+ */
+int arq_protocol_parse_cq(const uint8_t *buf, size_t buf_len,
+                           char *src_out, int *bw_hz_out);
 
 #endif /* ARQ_PROTOCOL_H_ */

--- a/docs/ARQ.md
+++ b/docs/ARQ.md
@@ -10,7 +10,7 @@ a table-driven, two-level hierarchical FSM and a clean protocol codec.
 
 1. [Overview](#overview)
 2. [Module Map](#module-map)
-3. [Wire Protocol v3](#wire-protocol-v3)
+3. [Wire Protocol v4](#wire-protocol-v4)
 4. [Frame Types and Subtypes](#frame-types-and-subtypes)
 5. [Mode Timing Table](#mode-timing-table)
 6. [Two-Level FSM](#two-level-fsm)
@@ -65,14 +65,14 @@ datalink_arq/
 
 ---
 
-## Wire Protocol v3
+## Wire Protocol v4
 
 All ARQ frames begin with a **framer byte** managed by `modem/framer.c`:
 
 ```
-Byte 0: [packet_type(3)] | [CRC5(5)]
+Byte 0: [packet_type(3)] | [extension_field(5)]
          bits [7:5] = packet_type
-         bits [4:0] = CRC5 of bytes [1 .. frame_size-1]
+         bits [4:0] = packet-type-specific extension field
 ```
 
 Packet type values:
@@ -84,11 +84,12 @@ Packet type values:
 | 0x2   | `ARQ_CALL`            | CALL and ACCEPT compact frames      |
 | 0x3   | `BROADCAST_CONTROL`   | Broadcast subsystem (unrelated)     |
 | 0x4   | `BROADCAST_DATA`      | Broadcast subsystem (unrelated)     |
+| 0x5   | `ARQ_CQ`              | Compact DATAC13 CQ metadata frame   |
 
 ### Standard 8-byte header (ARQ_CONTROL and ARQ_DATA)
 
 ```
-Byte 0: framer byte  (packet_type | CRC5)
+Byte 0: framer byte  (packet_type | extension_field)
 Byte 1: subtype      (arq_subtype_t)
 Byte 2: flags        bit7=TURN_REQ  bit6=HAS_DATA
 Byte 3: session_id   random byte chosen by caller at connect time
@@ -100,13 +101,15 @@ Byte 7: ack_delay    IRS→ISS delay from data_rx to ack_tx, in 10ms units; 0=un
 
 For **DATA frames** (`ARQ_DATA`), payload bytes follow immediately after byte 7.
 The payload size is determined by the FreeDV mode in use.
+For current `ARQ_CONTROL` and `ARQ_DATA` frames, the extension field is transmitted
+as `0` and reserved for future use.
 
 ### CALL/ACCEPT compact frame (ARQ_CALL, 14 bytes)
 
 CALL and ACCEPT use a different layout to fit two callsigns in 14 bytes:
 
 ```
-Byte 0:      framer byte  (PACKET_TYPE_ARQ_CALL | CRC5)
+Byte 0:      framer byte  (PACKET_TYPE_ARQ_CALL | BW token)
 Byte 1:      connect_meta = (session_id & 0x7F) | (is_accept ? 0x80 : 0x00)
 Bytes 2-3:   CRC16-CCITT of DST callsign (little-endian) — for local validation
 Bytes 4-13:  arithmetic_encode(SRC callsign only) — 10 bytes, fits any realistic callsign
@@ -116,11 +119,40 @@ The transmitting side's callsign (SRC) is compressed with an arithmetic codec (`
 The receiving side's callsign (DST) is not transmitted in full; instead its CRC16 is sent
 so the receiver can silently discard frames not addressed to it.
 
-### CRC5
+BW token values in the framer-byte extension field:
 
-Polynomial `0x15` (x⁵ + x⁴ + x² + 1), non-reflected, init=1.
-Covers bytes `[1 .. frame_size-1]` of the *unframed* data.
-False-positive rate: 1/32 ≈ 3.1 %.
+| Token | Meaning   |
+|-------|-----------|
+| `0`   | Reserved  |
+| `1`   | `BW500`   |
+| `2`   | `BW2300`  |
+| `3`   | `BW2750`  |
+
+Handshake semantics:
+
+- `CALL` advertises the caller's configured BW token.
+- `ACCEPT` returns the negotiated session BW token, computed as `min(caller, callee)`.
+- Once `ACCEPT` is processed, both peers know the session bandwidth without adding a
+  separate negotiation round trip.
+
+### CQ compact frame (ARQ_CQ, 14 bytes)
+
+Mercury also defines a compact DATAC13 CQ metadata frame:
+
+```
+Byte 0:      framer byte  (PACKET_TYPE_ARQ_CQ | BW token)
+Bytes 1-13:  arithmetic_encode(SRC callsign only)
+```
+
+The BW token uses the same values as `ARQ_CALL`. When a CQ frame is decoded,
+Mercury emits `CQFRAME <source> <bw>` on the TNC control port.
+
+### Integrity note
+
+The framer byte no longer carries a CRC5. Mercury relies on the modem-layer
+FreeDV frame integrity checks for whole-frame validation, while `CALL` / `ACCEPT`
+still keep the destination callsign CRC16 so receivers can quickly reject connect
+attempts not addressed to them.
 
 ---
 
@@ -515,5 +547,5 @@ All in `arq_protocol.h`:
 | `datalink_arq/arq_channels.c`| Channel bus between TCP layer and event loop        |
 | `common/hermes_log.c`        | Async ring-buffer logger with TIMING level and JSONL|
 | `common/hermes_log.h`        | Logger API and `HLOGD/T/I/W/E` macros               |
-| `modem/framer.c`             | 3-bit packet_type + CRC5 framer byte encoding       |
-| `common/crc6.c`              | `crc5_0X15()` — CRC5 polynomial 0x15               |
+| `modem/framer.c`             | 3-bit packet_type + 5-bit extension-field encoding  |
+| `common/crc6.c`              | CRC helper implementations (legacy CRC5 still lives here) |

--- a/docs/TNC.md
+++ b/docs/TNC.md
@@ -163,6 +163,20 @@ CONNECT AAAA BBBB\r
 
 ---
 
+### CQFRAME
+
+Transmit a compact DATAC13 CQ frame.
+
+```
+CQFRAME <sourcecall> <bandwidth>\r
+```
+
+`<bandwidth>` must be one of `500`, `2300`, or `2750`.
+
+**Response:** `OK\r` if the command was accepted, `WRONG\r` on error.
+
+---
+
 ### DISCONNECT
 
 Terminate the current ARQ session.

--- a/docs/TNC.md
+++ b/docs/TNC.md
@@ -175,6 +175,9 @@ CQFRAME <sourcecall> <bandwidth>\r
 
 **Response:** `OK\r` if the command was accepted, `WRONG\r` on error.
 
+For VARA compatibility, Mercury also emits `PENDING\r` when the CQ frame
+starts transmitting and `CANCELPENDING\r` once that CQ transmission is done.
+
 ---
 
 ### DISCONNECT
@@ -246,8 +249,8 @@ These are sent on the **control port** without a preceding command.
 
 | Response                                    | Meaning                                      |
 |---------------------------------------------|----------------------------------------------|
-| `PENDING\r`                                 | Incoming connect request detected            |
-| `CANCELPENDING\r`                           | Pending incoming connect did not complete    |
+| `PENDING\r`                                 | Incoming connect request or outgoing CQ TX started |
+| `CANCELPENDING\r`                           | Pending incoming connect cancelled or outgoing CQ TX completed |
 | `CONNECTED <sourcecall> <destcall> <bandwidth>\r` | ARQ session established                |
 | `CQFRAME <sourcecall> <bandwidth>\r`        | Compact CQ frame decoded                     |
 | `DISCONNECTED\r`                            | ARQ session ended                            |
@@ -264,10 +267,16 @@ Sent when Mercury detects an incoming ARQ connect request addressed to the
 local station. This is an early warning so VARA-compatible host applications
 can suspend scanning or other idle activity while the link setup is in progress.
 
+Mercury also sends `PENDING\r` when an outgoing `CQFRAME` actually begins
+transmitting so VARA clients can treat CQ send as an in-progress operation.
+
 ### CANCELPENDING
 
 Sent when a previously pending incoming connect request does not complete and
 Mercury returns to the idle/listening state.
+
+Mercury also sends `CANCELPENDING\r` when an outgoing `CQFRAME` transmission
+finishes, which matches the lifecycle expected by VARA clients such as varim.
 
 ### CONNECTED
 

--- a/docs/TNC.md
+++ b/docs/TNC.md
@@ -83,7 +83,12 @@ BW2750\r
 - **BW500** — Narrow bandwidth.  Restricts the maximum payload mode to DATAC3/DATAC4.
 - **BW2750** — Tactical mode token accepted for VARA compatibility. Mercury
   currently uses the same payload-mode ceiling as **BW2300**, but preserves
-  `2750` in `CONNECTED ... BW` reports.
+  `2750` as a negotiated/reporting token.
+
+During connection setup, Mercury advertises the local BW token in `CALL` and
+returns the negotiated token in `ACCEPT`. If either side is `BW500`, the session
+stays at `500` on both ends. If both sides are wide, the session keeps the lower
+wide token (`2300` or `2750`) and `CONNECTED ... BW` reports that negotiated value.
 
 ---
 
@@ -145,7 +150,8 @@ CONNECT <mycall> <theircall>\r
 
 **Response:** `OK\r` if the command was accepted, `WRONG\r` on error.
 
-Mercury will transmit CALL frames on DATAC13 and wait for an ACCEPT.
+Mercury will transmit CALL frames on DATAC13, advertising the local BW token,
+and wait for an ACCEPT carrying the negotiated session BW.
 On success, the asynchronous response
 `CONNECTED <sourcecall> <destcall> <bandwidth>\r` is sent on the control port,
 preserving the same call order as the original `CONNECT` command on both peers.
@@ -229,6 +235,7 @@ These are sent on the **control port** without a preceding command.
 | `PENDING\r`                                 | Incoming connect request detected            |
 | `CANCELPENDING\r`                           | Pending incoming connect did not complete    |
 | `CONNECTED <sourcecall> <destcall> <bandwidth>\r` | ARQ session established                |
+| `CQFRAME <sourcecall> <bandwidth>\r`        | Compact CQ frame decoded                     |
 | `DISCONNECTED\r`                            | ARQ session ended                            |
 | `PTT ON\r`                                  | Radio transmitter keyed                      |
 | `PTT OFF\r`                                 | Radio transmitter unkeyed                    |
@@ -251,10 +258,18 @@ Mercury returns to the idle/listening state.
 ### CONNECTED
 
 Sent when a session is successfully established (either outgoing CONNECT
-or incoming CALL accepted).  The `<bandwidth>` value is the effective
-configured VARA bandwidth token for this side (`500`, `2300`, or `2750`).
-`<sourcecall>` is always the station that initiated the session, and
-`<destcall>` is always the station that was called.
+or incoming CALL accepted). The `<bandwidth>` value is the negotiated session
+BW token from the `CALL` / `ACCEPT` exchange (`500`, `2300`, or `2750`).
+If either peer is `BW500`, both sides report `500`. If both peers stay wide,
+Mercury reports the lower of the two wide tokens, preserving `2750` only when
+both sides advertised it. `<sourcecall>` is always the station that initiated
+the session, and `<destcall>` is always the station that was called.
+
+### CQFRAME
+
+Sent when Mercury decodes a compact DATAC13 CQ frame on the air.
+`<sourcecall>` is the transmitting station and `<bandwidth>` is the BW token
+advertised inside that CQ frame (`500`, `2300`, or `2750`).
 
 ### DISCONNECTED
 

--- a/modem/framer.c
+++ b/modem/framer.c
@@ -19,36 +19,30 @@
  */
 
 #include <stdio.h>
-
-#include "crc6.h"
 #include "framer.h"
 
 /*
- * Framer byte layout (v3):
+ * Framer byte layout (v4):
  *   bits [7:5] = packet_type  (3 bits, PACKET_TYPE_* values)
- *   bits [4:0] = CRC5         (polynomial x^5+x^4+x^2+1 = 0x15, init=1)
+ *   bits [4:0] = extension    (packet-type-specific metadata)
  */
 
-int8_t parse_frame_header(uint8_t *data_frame, uint32_t frame_size)
+int8_t parse_frame_header(const uint8_t *data_frame, uint32_t frame_size, uint8_t *extension_out)
 {
-    if (frame_size < 2)
+    if (!data_frame || frame_size < 1)
         return -1;
 
-    uint8_t packet_type = (data_frame[0] >> PACKET_TYPE_SHIFT) & PACKET_TYPE_MASK;
-    uint8_t stored_crc  = data_frame[0] & CRC_MASK;
-    uint8_t calc_crc    = crc5_0X15(1, data_frame + HEADER_SIZE, (int)(frame_size - HEADER_SIZE));
+    if (extension_out)
+        *extension_out = frame_header_extension(data_frame[0]);
 
-    if (stored_crc != calc_crc)
-    {
-        printf("Packet received has CRC5 error!\n");
-        return -1;
-    }
-
-    return (int8_t)packet_type;
+    return (int8_t)frame_header_packet_type(data_frame[0]);
 }
 
-void write_frame_header(uint8_t *data, int packet_type, size_t frame_size)
+void write_frame_header(uint8_t *data, int packet_type, uint8_t extension)
 {
-    uint8_t crc = crc5_0X15(1, data + HEADER_SIZE, (int)(frame_size - HEADER_SIZE));
-    data[0] = (uint8_t)(((packet_type & PACKET_TYPE_MASK) << PACKET_TYPE_SHIFT) | (crc & CRC_MASK));
+    if (!data)
+        return;
+
+    data[0] = (uint8_t)(((packet_type & PACKET_TYPE_MASK) << PACKET_TYPE_SHIFT) |
+                        (extension & FRAME_EXT_MASK));
 }

--- a/modem/framer.h
+++ b/modem/framer.h
@@ -29,20 +29,31 @@
 #define PACKET_TYPE_ARQ_CALL          0x02  /* CALL/ACCEPT setup (compact layout) */
 #define PACKET_TYPE_BROADCAST_CONTROL 0x03  /* (was 0x02 in v2)                   */
 #define PACKET_TYPE_BROADCAST_DATA    0x04  /* (was 0x03 in v2)                   */
+#define PACKET_TYPE_ARQ_CQ            0x05  /* compact DATAC13 CQ metadata frame  */
 
 #define PACKET_TYPE_BITS   3    /* bits [7:5] of framer byte */
 #define PACKET_TYPE_SHIFT  5
 #define PACKET_TYPE_MASK   0x07
-#define CRC_BITS           5    /* bits [4:0] of framer byte */
-#define CRC_MASK           0x1f
+#define FRAME_EXT_BITS     5    /* bits [4:0] of framer byte */
+#define FRAME_EXT_MASK     0x1f
 
 #define HEADER_SIZE 1 // Size of the Hermes header
 #define BROADCAST_CONFIG_PACKET_SIZE 9 // hermes-broadcast RaptorQ config packet
 
-// Parse the frame header, validate CRC
-// Returns packet type or negative if CRC error
-int8_t parse_frame_header(uint8_t *data_frame, uint32_t frame_size);
-void write_frame_header(uint8_t *data, int packet_type, size_t frame_size);
+static inline uint8_t frame_header_packet_type(uint8_t header)
+{
+    return (uint8_t)((header >> PACKET_TYPE_SHIFT) & PACKET_TYPE_MASK);
+}
+
+static inline uint8_t frame_header_extension(uint8_t header)
+{
+    return (uint8_t)(header & FRAME_EXT_MASK);
+}
+
+// Parse the frame header and optionally return the extension field.
+// Returns packet type or negative on invalid input.
+int8_t parse_frame_header(const uint8_t *data_frame, uint32_t frame_size, uint8_t *extension_out);
+void write_frame_header(uint8_t *data, int packet_type, uint8_t extension);
 
 
 

--- a/modem/modem.c
+++ b/modem/modem.c
@@ -675,6 +675,25 @@ int send_modulated_data(generic_modem_t *g_modem, uint8_t *bytes_in, int frames_
     return 0;
 }
 
+static int send_modulated_data_with_cq_status(generic_modem_t *g_modem,
+                                              uint8_t *bytes_in,
+                                              int frames_per_burst)
+{
+    bool is_cq_frame = bytes_in != NULL &&
+                       frames_per_burst == 1 &&
+                       frame_header_packet_type(bytes_in[0]) == PACKET_TYPE_ARQ_CQ;
+
+    if (is_cq_frame)
+        arq_notify_cq_tx_started();
+
+    int rc = send_modulated_data(g_modem, bytes_in, frames_per_burst);
+
+    if (is_cq_frame)
+        arq_notify_cq_tx_complete();
+
+    return rc;
+}
+
 int receive_modulated_data(generic_modem_t *g_modem, uint8_t *bytes_out, size_t *nbytes_out)
 {
     struct freedv *freedv = NULL;
@@ -1195,8 +1214,10 @@ void *tx_thread(void *g_modem)
                     data_size = action_frame_size;
                 }
                 read_buffer(action_buffer, data, action_frame_size);
-                send_modulated_data(modem, data, 1);
-                sent_from_action = true;
+                if (send_modulated_data_with_cq_status(modem, data, 1) == 0)
+                    sent_from_action = true;
+                else
+                    HLOGW("modem-tx", "Failed to send queued TX action");
             }
         }
 
@@ -1207,7 +1228,8 @@ void *tx_thread(void *g_modem)
             {
                 read_buffer(arq_tx_buffer, data + (payload_bytes_per_modem_frame * i), payload_bytes_per_modem_frame);
             }
-            send_modulated_data(modem, data, tx_frames_per_burst);
+            if (send_modulated_data_with_cq_status(modem, data, tx_frames_per_burst) < 0)
+                HLOGW("modem-tx", "Failed to send ARQ buffered frame");
         }
 
         if (size_buffer(data_tx_buffer_broadcast) >= required)
@@ -1216,7 +1238,8 @@ void *tx_thread(void *g_modem)
             {
                 read_buffer(data_tx_buffer_broadcast, data + (payload_bytes_per_modem_frame * i), payload_bytes_per_modem_frame);
             }
-            send_modulated_data(modem, data, tx_frames_per_burst);
+            if (send_modulated_data_with_cq_status(modem, data, tx_frames_per_burst) < 0)
+                HLOGW("modem-tx", "Failed to send broadcast buffered frame");
         }
 
         if (!sent_from_action &&

--- a/modem/modem.c
+++ b/modem/modem.c
@@ -923,13 +923,17 @@ static void process_received_frame(const uint8_t *data,
     tnc_send_sn(snr_est);
     tnc_send_bitrate(bitrate_level_from_payload_mode(payload_mode), bitrate_bps);
 
-    frame_type = parse_frame_header((uint8_t *)data, payload_nbytes);
+    frame_type = parse_frame_header((const uint8_t *)data, payload_nbytes, NULL);
 
     switch (frame_type)
     {
     case PACKET_TYPE_ARQ_CALL:
         if (arq_policy_ready)
             arq_handle_incoming_connect_frame((uint8_t *)data, payload_nbytes);
+        break;
+    case PACKET_TYPE_ARQ_CQ:
+        if (arq_policy_ready)
+            arq_handle_incoming_cq_frame((uint8_t *)data, payload_nbytes);
         break;
     case PACKET_TYPE_ARQ_CONTROL:
     case PACKET_TYPE_ARQ_DATA:

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -1,7 +1,7 @@
 # Compiler and flags
 include ../config.mk
 
-CFLAGS = $(COMMON_CFLAGS) -Wextra -I../common
+CFLAGS = $(COMMON_CFLAGS) -Wextra -I../common -I../modem
 LDFLAGS = -pthread
 
 ifeq ($(OS),Windows_NT)
@@ -16,10 +16,10 @@ all: $(OUT)
 broadcast_test: broadcast_test.c kiss.c
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
-broadcast_diag_tx: broadcast_diag_tx.c kiss.c ../common/crc6.c
+broadcast_diag_tx: broadcast_diag_tx.c kiss.c ../modem/framer.c
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
-broadcast_diag_rx: broadcast_diag_rx.c kiss.c ../common/crc6.c
+broadcast_diag_rx: broadcast_diag_rx.c kiss.c ../modem/framer.c
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 # Clean up build artifacts

--- a/utils/broadcast_diag_rx.c
+++ b/utils/broadcast_diag_rx.c
@@ -21,7 +21,7 @@
 #endif
 
 #include "../common/os_interop.h"
-#include "crc6.h"
+#include "framer.h"
 #include "kiss.h"
 
 #define DEFAULT_IP "127.0.0.1"
@@ -66,13 +66,17 @@ static int create_tcp_socket(const char *ip, int port)
     return tcp_socket;
 }
 
-static uint16_t crc_len_for_type(uint8_t packet_type, size_t frame_size)
+static const char *packet_type_name(uint8_t packet_type)
 {
-    if (packet_type == 0x02 && frame_size >= CONFIG_PACKET_SIZE)
-        return CONFIG_PACKET_SIZE - 1;
-    if (frame_size > 0)
-        return frame_size - 1;
-    return 0;
+    switch (packet_type)
+    {
+    case PACKET_TYPE_BROADCAST_CONTROL:
+        return "BCAST_CTRL";
+    case PACKET_TYPE_BROADCAST_DATA:
+        return "BCAST_DATA";
+    default:
+        return "OTHER";
+    }
 }
 
 static void print_frame_debug(uint64_t frame_no, const uint8_t *frame, size_t frame_size)
@@ -83,14 +87,12 @@ static void print_frame_debug(uint64_t frame_no, const uint8_t *frame, size_t fr
         return;
     }
 
-    uint8_t packet_type = (frame[0] >> 6) & 0x3;
-    uint8_t crc_local = frame[0] & 0x3f;
-    uint16_t crc_len = crc_len_for_type(packet_type, frame_size);
-    uint8_t crc_calc = (uint8_t)crc6_0X6F(1, frame + 1, crc_len);
-    bool crc_ok = (crc_local == crc_calc);
+    uint8_t packet_type = frame_header_packet_type(frame[0]);
+    uint8_t extension = frame_header_extension(frame[0]);
 
-    printf("[RX] frame=%llu len=%zu type=0x%02x crc(local=0x%02x calc=0x%02x %s) first16=",
-           (unsigned long long)frame_no, frame_size, packet_type, crc_local, crc_calc, crc_ok ? "OK" : "BAD");
+    printf("[RX] frame=%llu len=%zu type=0x%02x(%s) ext=0x%02x first16=",
+           (unsigned long long)frame_no, frame_size, packet_type,
+           packet_type_name(packet_type), extension);
     for (size_t i = 0; i < frame_size && i < 16; i++)
     {
         printf("%02x ", frame[i]);
@@ -115,7 +117,7 @@ int main(int argc, char *argv[])
     uint8_t rx_buf[4096];
     uint8_t frame_buf[MAX_PAYLOAD];
     uint64_t frame_no = 0;
-    uint64_t t02 = 0, t03 = 0, bad_crc = 0;
+    uint64_t ctrl_frames = 0, data_frames = 0, other_frames = 0;
 
     while (running)
     {
@@ -143,20 +145,21 @@ int main(int argc, char *argv[])
             frame_no++;
             print_frame_debug(frame_no, frame_buf, (size_t)frame_len);
 
-            uint8_t packet_type = (frame_buf[0] >> 6) & 0x3;
-            uint8_t crc_local = frame_buf[0] & 0x3f;
-            uint8_t crc_calc = (uint8_t)crc6_0X6F(1, frame_buf + 1, crc_len_for_type(packet_type, (size_t)frame_len));
-            if (packet_type == 0x02) t02++;
-            if (packet_type == 0x03) t03++;
-            if (crc_local != crc_calc) bad_crc++;
+            uint8_t packet_type = frame_header_packet_type(frame_buf[0]);
+            if (packet_type == PACKET_TYPE_BROADCAST_CONTROL)
+                ctrl_frames++;
+            else if (packet_type == PACKET_TYPE_BROADCAST_DATA)
+                data_frames++;
+            else
+                other_frames++;
 
             if ((frame_no % 20) == 0)
             {
-                printf("[RX-SUM] frames=%llu type02=%llu type03=%llu bad_crc=%llu\n",
+                printf("[RX-SUM] frames=%llu ctrl=%llu data=%llu other=%llu\n",
                        (unsigned long long)frame_no,
-                       (unsigned long long)t02,
-                       (unsigned long long)t03,
-                       (unsigned long long)bad_crc);
+                       (unsigned long long)ctrl_frames,
+                       (unsigned long long)data_frames,
+                       (unsigned long long)other_frames);
             }
         }
     }

--- a/utils/broadcast_diag_tx.c
+++ b/utils/broadcast_diag_tx.c
@@ -21,7 +21,7 @@
 #endif
 
 #include "../common/os_interop.h"
-#include "crc6.h"
+#include "framer.h"
 #include "kiss.h"
 
 #define DEFAULT_IP "127.0.0.1"
@@ -89,13 +89,6 @@ static int send_all(int socket_fd, const uint8_t *buffer, size_t len)
     return 0;
 }
 
-static uint16_t crc_len_for_type(uint8_t packet_type, size_t frame_size)
-{
-    if (packet_type == 0x02 && frame_size >= CONFIG_PACKET_SIZE)
-        return CONFIG_PACKET_SIZE - 1;
-    return frame_size - 1;
-}
-
 static void fill_frame(uint8_t *frame, size_t frame_size, uint8_t packet_type, uint64_t seq)
 {
     memset(frame, 0, frame_size);
@@ -105,7 +98,8 @@ static void fill_frame(uint8_t *frame, size_t frame_size, uint8_t packet_type, u
         frame[i] = (uint8_t)((seq + (i * 17)) & 0xff);
     }
 
-    if (packet_type == 0x02 && frame_size >= CONFIG_PACKET_SIZE)
+    if (packet_type == PACKET_TYPE_BROADCAST_CONTROL &&
+        frame_size >= BROADCAST_CONFIG_PACKET_SIZE)
     {
         /* deterministic 8-byte config payload for debug */
         frame[1] = 0xAA;
@@ -118,20 +112,16 @@ static void fill_frame(uint8_t *frame, size_t frame_size, uint8_t packet_type, u
         frame[8] = 0x01;
     }
 
-    uint16_t crc_len = crc_len_for_type(packet_type, frame_size);
-    frame[0] = (uint8_t)((packet_type << 6) & 0xff);
-    frame[0] |= (uint8_t)crc6_0X6F(1, frame + 1, crc_len);
+    write_frame_header(frame, packet_type, 0);
 }
 
 static void print_frame_debug(const char *tag, const uint8_t *frame, size_t frame_size, int kiss_len, uint64_t seq)
 {
-    uint8_t packet_type = (frame[0] >> 6) & 0x3;
-    uint8_t crc_local = frame[0] & 0x3f;
-    uint16_t crc_len = crc_len_for_type(packet_type, frame_size);
-    uint8_t crc_calc = (uint8_t)crc6_0X6F(1, frame + 1, crc_len);
+    uint8_t packet_type = frame_header_packet_type(frame[0]);
+    uint8_t extension = frame_header_extension(frame[0]);
 
-    printf("[%s] seq=%llu type=0x%02x frame=%zu kiss=%d crc(local=0x%02x calc=0x%02x) first16=",
-           tag, (unsigned long long)seq, packet_type, frame_size, kiss_len, crc_local, crc_calc);
+    printf("[%s] seq=%llu type=0x%02x ext=0x%02x frame=%zu kiss=%d first16=",
+           tag, (unsigned long long)seq, packet_type, extension, frame_size, kiss_len);
     for (size_t i = 0; i < frame_size && i < 16; i++)
     {
         printf("%02x ", frame[i]);
@@ -180,7 +170,7 @@ int main(int argc, char *argv[])
     uint64_t seq = 0;
     while (running)
     {
-        fill_frame(frame, frame_size, 0x02, seq);
+        fill_frame(frame, frame_size, PACKET_TYPE_BROADCAST_CONTROL, seq);
         int kiss_len = kiss_write_frame(frame, (int)frame_size, kiss_frame);
         print_frame_debug("TX", frame, frame_size, kiss_len, seq);
         if (send_all(tcp_socket, kiss_frame, (size_t)kiss_len) < 0)
@@ -189,7 +179,7 @@ int main(int argc, char *argv[])
             break;
         }
 
-        fill_frame(frame, frame_size, 0x03, seq);
+        fill_frame(frame, frame_size, PACKET_TYPE_BROADCAST_DATA, seq);
         kiss_len = kiss_write_frame(frame, (int)frame_size, kiss_frame);
         print_frame_debug("TX", frame, frame_size, kiss_len, seq);
         if (send_all(tcp_socket, kiss_frame, (size_t)kiss_len) < 0)


### PR DESCRIPTION
This pull request introduces protocol version 4 for ARQ, adding explicit bandwidth negotiation and reporting to ARQ connect, accept, and CQ frames. The changes improve compatibility and session management by ensuring both peers negotiate and report bandwidth tokens, and also add support for CQ frame handling and notification. Several internal functions and data structures are updated to support these enhancements.

**Protocol and Bandwidth Negotiation Enhancements:**

* Updated ARQ protocol to version 4, introducing a framer extension field for bandwidth tokens. (`datalink_arq/arq_protocol.h`, `README.md`) [[1]](diffhunk://#diff-dbf8f89dc99793aa122ef347d6480d96da526711cf3f0203cd0eae94d2c6c4a1L21-R21) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76-R79)
* Added bandwidth negotiation to connect and accept frames, using explicit tokens for `BW500`, `BW2300`, and `BW2750`. Bandwidth is now tracked in both configured (`bw`) and negotiated (`session_bw`) fields in `arq_conn`. (`datalink_arq/arq.h`, `datalink_arq/arq.c`) [[1]](diffhunk://#diff-2f64703cb14e88d9ab6dc2162643746a9fc338ef01d110ce02b93d07ab66d476L57-R58) [[2]](diffhunk://#diff-2f64703cb14e88d9ab6dc2162643746a9fc338ef01d110ce02b93d07ab66d476R209-R216) [[3]](diffhunk://#diff-0e923cf7f9fce6994a9e672a59b70634997fb4c06941bc4b1b029f1383a43df8R56) [[4]](diffhunk://#diff-0e923cf7f9fce6994a9e672a59b70634997fb4c06941bc4b1b029f1383a43df8R198) [[5]](diffhunk://#diff-0e923cf7f9fce6994a9e672a59b70634997fb4c06941bc4b1b029f1383a43df8R627) [[6]](diffhunk://#diff-0e923cf7f9fce6994a9e672a59b70634997fb4c06941bc4b1b029f1383a43df8R255-R283) [[7]](diffhunk://#diff-0e923cf7f9fce6994a9e672a59b70634997fb4c06941bc4b1b029f1383a43df8L295-R310) [[8]](diffhunk://#diff-0e923cf7f9fce6994a9e672a59b70634997fb4c06941bc4b1b029f1383a43df8R331) [[9]](diffhunk://#diff-0e923cf7f9fce6994a9e672a59b70634997fb4c06941bc4b1b029f1383a43df8R458-R462) [[10]](diffhunk://#diff-0e923cf7f9fce6994a9e672a59b70634997fb4c06941bc4b1b029f1383a43df8R487-R514)
* Modified connect/accept frame build and parse functions to include bandwidth tokens, and updated normalization and reporting logic for session bandwidth. (`datalink_arq/arq_protocol.c`, `datalink_arq/arq_fsm.c`) [[1]](diffhunk://#diff-0789d6a4ff50695bdd16bdc305733287abd15b6042370b855493cfc4efa0933eL94-R94) [[2]](diffhunk://#diff-0789d6a4ff50695bdd16bdc305733287abd15b6042370b855493cfc4efa0933eL110-R111) [[3]](diffhunk://#diff-0789d6a4ff50695bdd16bdc305733287abd15b6042370b855493cfc4efa0933eR122-R151) [[4]](diffhunk://#diff-0789d6a4ff50695bdd16bdc305733287abd15b6042370b855493cfc4efa0933eL191-R222) [[5]](diffhunk://#diff-0789d6a4ff50695bdd16bdc305733287abd15b6042370b855493cfc4efa0933eL297-R328) [[6]](diffhunk://#diff-0789d6a4ff50695bdd16bdc305733287abd15b6042370b855493cfc4efa0933eR413-R469) [[7]](diffhunk://#diff-0789d6a4ff50695bdd16bdc305733287abd15b6042370b855493cfc4efa0933eL401-R509) [[8]](diffhunk://#diff-0789d6a4ff50695bdd16bdc305733287abd15b6042370b855493cfc4efa0933eL435-R572) [[9]](diffhunk://#diff-b2157680865594094651322ae1dc90524c7337704d3ba15400ddc439ef32b26dR439-R445) [[10]](diffhunk://#diff-b2157680865594094651322ae1dc90524c7337704d3ba15400ddc439ef32b26dL198-R198)

**CQ Frame Support:**

* Added CQ frame build and parse functions, plus handling logic to decode CQ frames and notify the host with source callsign and bandwidth. (`datalink_arq/arq_protocol.c`, `datalink_arq/arq.c`, `data_interfaces/tcp_interfaces.c`, `data_interfaces/tcp_interfaces.h`) [[1]](diffhunk://#diff-0789d6a4ff50695bdd16bdc305733287abd15b6042370b855493cfc4efa0933eL435-R572) [[2]](diffhunk://#diff-0e923cf7f9fce6994a9e672a59b70634997fb4c06941bc4b1b029f1383a43df8R487-R514) [[3]](diffhunk://#diff-1da1704969bd78bbbd054bec7a9424bc4f869a5960e557338a93867dd68d1db2R976-R987) [[4]](diffhunk://#diff-679c6e96f8a3d187259747917be012c0ff5fa8b45b9c500250268c1cad90c73cR54)

**Internal API and Data Structure Updates:**

* Added and updated function signatures and internal APIs to support session bandwidth tracking and CQ frame notification. (`datalink_arq/arq.h`, `datalink_arq/arq.c`, `data_interfaces/tcp_interfaces.h`) [[1]](diffhunk://#diff-2f64703cb14e88d9ab6dc2162643746a9fc338ef01d110ce02b93d07ab66d476R209-R216) [[2]](diffhunk://#diff-0e923cf7f9fce6994a9e672a59b70634997fb4c06941bc4b1b029f1383a43df8R56) [[3]](diffhunk://#diff-679c6e96f8a3d187259747917be012c0ff5fa8b45b9c500250268c1cad90c73cR54)

**Documentation:**

* Updated `README.md` to clarify bandwidth negotiation and reporting behavior in connect/accept flows and CQ frames.

These changes collectively make bandwidth negotiation explicit and visible in ARQ sessions, improve compatibility, and add CQ frame support for better session discovery and notification.