### PR TITLE
Include in-flight unACKed bytes in BUFFER count

### DIFF
--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -232,8 +232,6 @@ static int cb_tx_backlog(void)
     pthread_mutex_lock(&g_app_tx_mtx);
     int n = (int)size_buffer(g_app_tx_buf);
     pthread_mutex_unlock(&g_app_tx_mtx);
-    /* Include payload bytes in the unACKed in-flight frame */
-    n += g_sess.tx_inflight_bytes;
     return n;
 }
 
@@ -825,7 +823,7 @@ bool arq_get_runtime_snapshot(arq_runtime_snapshot_t *snapshot)
     snapshot->initialized      = true;
     snapshot->connected        = arq_is_link_connected();
     snapshot->trx              = arq_conn.TRX;
-    snapshot->tx_backlog_bytes = cb_tx_backlog();
+    snapshot->tx_backlog_bytes = cb_tx_backlog() + g_sess.tx_inflight_bytes;
     snapshot->speed_level      = g_sess.speed_level;
     snapshot->payload_mode      = g_sess.payload_mode;
     snapshot->peer_tx_mode      = g_sess.peer_tx_mode;

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -232,6 +232,8 @@ static int cb_tx_backlog(void)
     pthread_mutex_lock(&g_app_tx_mtx);
     int n = (int)size_buffer(g_app_tx_buf);
     pthread_mutex_unlock(&g_app_tx_mtx);
+    /* Include payload bytes in the unACKed in-flight frame */
+    n += g_sess.tx_inflight_bytes;
     return n;
 }
 

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -165,8 +165,9 @@ static void sess_enter(arq_session_t *sess, arq_conn_state_t new_state,
      * before entering ACCEPTING/CALLING. */
     if (new_state == ARQ_CONN_DISCONNECTED || new_state == ARQ_CONN_LISTENING)
     {
-        sess->dflow_state  = ARQ_DFLOW_IDLE_ISS;
-        sess->peer_tx_mode = sess->initial_payload_mode;
+        sess->dflow_state       = ARQ_DFLOW_IDLE_ISS;
+        sess->peer_tx_mode      = sess->initial_payload_mode;
+        sess->tx_inflight_bytes = 0;
     }
 }
 

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -535,8 +535,6 @@ static void send_data_frame(arq_session_t *sess)
     if (payload_len <= 0)
         return;  /* no data and no saved frame */
 
-    sess->tx_inflight_bytes = payload_len;
-
     /* 0 = full frame; else = exact valid byte count (receiver trims).
      * payload_len can exceed 255 for DATAC1 (up to 502 bytes), so we
      * cannot fit it in uint8_t directly.  Carry bit 8 of the count in
@@ -566,6 +564,8 @@ static void send_data_frame(arq_session_t *sess)
                                     payload, user_bytes);
     if (n <= 0)
         return;
+
+    sess->tx_inflight_bytes = payload_len;
 
     /* Save for potential retransmission if ACK is lost. */
     if ((size_t)n <= sizeof(sess->tx_retransmit_buf))

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -534,6 +534,8 @@ static void send_data_frame(arq_session_t *sess)
     if (payload_len <= 0)
         return;  /* no data and no saved frame */
 
+    sess->tx_inflight_bytes = payload_len;
+
     /* 0 = full frame; else = exact valid byte count (receiver trims).
      * payload_len can exceed 255 for DATAC1 (up to 502 bytes), so we
      * cannot fit it in uint8_t directly.  Carry bit 8 of the count in
@@ -780,6 +782,7 @@ static void fsm_listening(arq_session_t *sess, const arq_event_t *ev)
             sess->tx_seq      = 0;
             sess->rx_expected = 0;
             sess->tx_retransmit_len = 0;
+            sess->tx_inflight_bytes = 0;
             sess->tx_retries_left = ARQ_DATA_RETRY_SLOTS;
             sess->payload_mode       = FREEDV_MODE_DATAC4;
             sess->peer_tx_mode       = FREEDV_MODE_DATAC4;
@@ -819,6 +822,7 @@ static void fsm_calling(arq_session_t *sess, const arq_event_t *ev)
             sess->tx_seq      = 0;
             sess->rx_expected = 0;
             sess->tx_retransmit_len = 0;  /* discard any stale retransmit buf from prior session */
+            sess->tx_inflight_bytes = 0;
             sess->tx_retries_left = ARQ_DATA_RETRY_SLOTS;
             sess->payload_mode       = FREEDV_MODE_DATAC4;   /* reset mode state from prior session */
             sess->peer_tx_mode       = FREEDV_MODE_DATAC4;
@@ -888,6 +892,7 @@ static void fsm_accepting(arq_session_t *sess, const arq_event_t *ev)
         sess->tx_seq      = 0;
         sess->rx_expected = 0;
         sess->tx_retransmit_len = 0;  /* discard any stale retransmit buf from prior session */
+        sess->tx_inflight_bytes = 0;
         sess->tx_retries_left = ARQ_DATA_RETRY_SLOTS;
         sess->payload_mode       = FREEDV_MODE_DATAC4;   /* reset mode state from prior session */
         sess->peer_tx_mode       = FREEDV_MODE_DATAC4;
@@ -1201,6 +1206,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                                          sess->peer_snr_x10);
             sess->tx_seq++;
             sess->tx_retransmit_len = 0;  /* ACKed — discard retransmit buffer */
+            sess->tx_inflight_bytes = 0;  /* payload confirmed by peer */
             sess->tx_retries_left   = ARQ_DATA_RETRY_SLOTS;  /* fresh counter for next seq */
             sess->peer_has_data = (ev->rx_flags & ARQ_FLAG_HAS_DATA) != 0;
             if (g_cbs.send_buffer_status)
@@ -1277,6 +1283,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                 record_tx_outcome(sess, sess->tx_retries_left == ARQ_DATA_RETRY_SLOTS);
                 sess->tx_seq++;
                 sess->tx_retransmit_len = 0;
+                sess->tx_inflight_bytes = 0;
                 sess->tx_retries_left   = ARQ_DATA_RETRY_SLOTS;
                 sess->peer_has_data = (ev->rx_flags & ARQ_FLAG_HAS_DATA) != 0;
                 if (g_cbs.send_buffer_status)
@@ -1324,6 +1331,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                 record_tx_outcome(sess, sess->tx_retries_left == ARQ_DATA_RETRY_SLOTS);
                 sess->tx_seq++;
                 sess->tx_retransmit_len = 0;
+                sess->tx_inflight_bytes = 0;
                 sess->tx_retries_left   = ARQ_DATA_RETRY_SLOTS;
                 if (g_cbs.send_buffer_status)
                     g_cbs.send_buffer_status(g_cbs.tx_backlog ? g_cbs.tx_backlog() : 0);

--- a/datalink_arq/arq_fsm.h
+++ b/datalink_arq/arq_fsm.h
@@ -225,6 +225,7 @@ typedef struct
                                        * ring bytes, corrupting byte stream)  */
     int      tx_retransmit_len;       /* 0 = no saved frame                   */
     uint8_t  tx_retransmit_seq;       /* tx_seq the saved frame belongs to    */
+    int      tx_inflight_bytes;      /* payload bytes in unACKed frame       */
 
     /* --- Keepalive tracking --- */
     int      keepalive_miss_count;


### PR DESCRIPTION
BUFFER (tx_backlog) previously dropped as soon as the ARQ FSM read bytes from the app TX ring buffer to build a frame. This made BUFFER show 0 while data was still in flight and unACKed.

Add tx_inflight_bytes to arq_session_t: set to payload_len when a fresh DATA frame is built from the ring buffer, cleared on ACK (explicit or implicit) and on session reset. cb_tx_backlog() now returns ring buffer size + tx_inflight_bytes, so BUFFER accurately reflects all unsent and unconfirmed data.