### PR TITLE
Implement IRS inactivity timeout and keepalive probing

### DIFF
--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -1381,7 +1381,6 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
         {
             if (g_cbs.tx_backlog && g_cbs.tx_backlog() > 0)
             {
-                sess->irs_idle_count = 0;
                 send_ctrl_frame(sess, ARQ_SUBTYPE_TURN_REQ);
                 sess->tx_retries_left = ARQ_TURN_REQ_RETRIES;
                 tm = arq_protocol_mode_timing(sess->control_mode);
@@ -1389,15 +1388,17 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                             deadline_from_s(tm ? tm->retry_interval_s : 7.0f),
                             ARQ_EV_TIMER_RETRY);
             }
-            else if (++sess->irs_idle_count >= ARQ_IRS_INACTIVITY_LIMIT)
+            else if (sess->last_rx_ms > 0 &&
+                     hermes_uptime_ms() - sess->last_rx_ms >=
+                         (uint64_t)ARQ_IRS_INACTIVITY_S * 1000)
             {
                 /* Peer has been silent too long - probe with keepalive.
                  * If the peer responds, keepalive_miss_count resets and
                  * we return to IDLE_IRS.  If not, the keepalive retry
                  * loop disconnects after ARQ_KEEPALIVE_MISS_LIMIT misses. */
-                HLOGW(LOG_COMP, "IRS inactivity limit (%d cycles) - sending keepalive",
-                      sess->irs_idle_count);
-                sess->irs_idle_count = 0;
+                HLOGW(LOG_COMP, "IRS inactivity (%ds without RX) - sending keepalive",
+                      (int)((hermes_uptime_ms() - sess->last_rx_ms) / 1000));
+                sess->keepalive_miss_count = 0;
                 send_ctrl_frame(sess, ARQ_SUBTYPE_KEEPALIVE);
                 tm = arq_protocol_mode_timing(sess->control_mode);
                 dflow_enter(sess, ARQ_DFLOW_KEEPALIVE_TX,
@@ -1733,7 +1734,7 @@ void arq_fsm_dispatch(arq_session_t *sess, const arq_event_t *ev)
           arq_dflow_state_name(sess->dflow_state),
           arq_event_name(ev->id));
 
-    /* Track last RX time from any received frame and reset IRS idle counter */
+    /* Track last RX time from any received frame */
     switch (ev->id)
     {
     case ARQ_EV_RX_DATA:
@@ -1746,7 +1747,6 @@ void arq_fsm_dispatch(arq_session_t *sess, const arq_event_t *ev)
     case ARQ_EV_RX_KEEPALIVE:
     case ARQ_EV_RX_KEEPALIVE_ACK:
         sess->last_rx_ms = hermes_uptime_ms();
-        sess->irs_idle_count = 0;
         /* Session ID validation: drop frames from a different session when
          * we are in CONNECTED or DISCONNECTING state (CALL/ACCEPT frames
          * are handled separately and carry session_id in their own format). */

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -1379,18 +1379,12 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
         }
         else if (ev->id == ARQ_EV_TIMER_PEER_BACKLOG)
         {
-            if (g_cbs.tx_backlog && g_cbs.tx_backlog() > 0)
-            {
-                send_ctrl_frame(sess, ARQ_SUBTYPE_TURN_REQ);
-                sess->tx_retries_left = ARQ_TURN_REQ_RETRIES;
-                tm = arq_protocol_mode_timing(sess->control_mode);
-                dflow_enter(sess, ARQ_DFLOW_TURN_REQ_TX,
-                            deadline_from_s(tm ? tm->retry_interval_s : 7.0f),
-                            ARQ_EV_TIMER_RETRY);
-            }
-            else if (sess->last_rx_ms > 0 &&
-                     hermes_uptime_ms() - sess->last_rx_ms >=
-                         (uint64_t)ARQ_IRS_INACTIVITY_S * 1000)
+            /* Inactivity check FIRST - must fire regardless of local
+             * tx_backlog, otherwise TURN_REQ retries loop forever when
+             * the peer disappears while we have pending data. */
+            if (sess->last_rx_ms > 0 &&
+                hermes_uptime_ms() - sess->last_rx_ms >=
+                    (uint64_t)ARQ_IRS_INACTIVITY_S * 1000)
             {
                 /* Peer has been silent too long - probe with keepalive.
                  * If the peer responds, keepalive_miss_count resets and
@@ -1402,6 +1396,15 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                 send_ctrl_frame(sess, ARQ_SUBTYPE_KEEPALIVE);
                 tm = arq_protocol_mode_timing(sess->control_mode);
                 dflow_enter(sess, ARQ_DFLOW_KEEPALIVE_TX,
+                            deadline_from_s(tm ? tm->retry_interval_s : 7.0f),
+                            ARQ_EV_TIMER_RETRY);
+            }
+            else if (g_cbs.tx_backlog && g_cbs.tx_backlog() > 0)
+            {
+                send_ctrl_frame(sess, ARQ_SUBTYPE_TURN_REQ);
+                sess->tx_retries_left = ARQ_TURN_REQ_RETRIES;
+                tm = arq_protocol_mode_timing(sess->control_mode);
+                dflow_enter(sess, ARQ_DFLOW_TURN_REQ_TX,
                             deadline_from_s(tm ? tm->retry_interval_s : 7.0f),
                             ARQ_EV_TIMER_RETRY);
             }

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -1381,10 +1381,26 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
         {
             if (g_cbs.tx_backlog && g_cbs.tx_backlog() > 0)
             {
+                sess->irs_idle_count = 0;
                 send_ctrl_frame(sess, ARQ_SUBTYPE_TURN_REQ);
                 sess->tx_retries_left = ARQ_TURN_REQ_RETRIES;
                 tm = arq_protocol_mode_timing(sess->control_mode);
                 dflow_enter(sess, ARQ_DFLOW_TURN_REQ_TX,
+                            deadline_from_s(tm ? tm->retry_interval_s : 7.0f),
+                            ARQ_EV_TIMER_RETRY);
+            }
+            else if (++sess->irs_idle_count >= ARQ_IRS_INACTIVITY_LIMIT)
+            {
+                /* Peer has been silent too long - probe with keepalive.
+                 * If the peer responds, keepalive_miss_count resets and
+                 * we return to IDLE_IRS.  If not, the keepalive retry
+                 * loop disconnects after ARQ_KEEPALIVE_MISS_LIMIT misses. */
+                HLOGW(LOG_COMP, "IRS inactivity limit (%d cycles) - sending keepalive",
+                      sess->irs_idle_count);
+                sess->irs_idle_count = 0;
+                send_ctrl_frame(sess, ARQ_SUBTYPE_KEEPALIVE);
+                tm = arq_protocol_mode_timing(sess->control_mode);
+                dflow_enter(sess, ARQ_DFLOW_KEEPALIVE_TX,
                             deadline_from_s(tm ? tm->retry_interval_s : 7.0f),
                             ARQ_EV_TIMER_RETRY);
             }
@@ -1717,7 +1733,7 @@ void arq_fsm_dispatch(arq_session_t *sess, const arq_event_t *ev)
           arq_dflow_state_name(sess->dflow_state),
           arq_event_name(ev->id));
 
-    /* Track last RX time from any received frame */
+    /* Track last RX time from any received frame and reset IRS idle counter */
     switch (ev->id)
     {
     case ARQ_EV_RX_DATA:
@@ -1730,6 +1746,7 @@ void arq_fsm_dispatch(arq_session_t *sess, const arq_event_t *ev)
     case ARQ_EV_RX_KEEPALIVE:
     case ARQ_EV_RX_KEEPALIVE_ACK:
         sess->last_rx_ms = hermes_uptime_ms();
+        sess->irs_idle_count = 0;
         /* Session ID validation: drop frames from a different session when
          * we are in CONNECTED or DISCONNECTING state (CALL/ACCEPT frames
          * are handled separately and carry session_id in their own format). */

--- a/datalink_arq/arq_fsm.h
+++ b/datalink_arq/arq_fsm.h
@@ -229,9 +229,6 @@ typedef struct
 
     /* --- Keepalive tracking --- */
     int      keepalive_miss_count;
-    int      irs_idle_count;           /* consecutive TIMER_PEER_BACKLOG cycles
-                                       * with no RX -> triggers keepalive probe
-                                       * when it reaches ARQ_IRS_INACTIVITY_LIMIT */
     uint64_t last_rx_ms;              /* last successful frame decode time     */
 
     /* --- Timer mechanism --- */

--- a/datalink_arq/arq_fsm.h
+++ b/datalink_arq/arq_fsm.h
@@ -229,6 +229,9 @@ typedef struct
 
     /* --- Keepalive tracking --- */
     int      keepalive_miss_count;
+    int      irs_idle_count;           /* consecutive TIMER_PEER_BACKLOG cycles
+                                       * with no RX -> triggers keepalive probe
+                                       * when it reaches ARQ_IRS_INACTIVITY_LIMIT */
     uint64_t last_rx_ms;              /* last successful frame decode time     */
 
     /* --- Timer mechanism --- */

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -212,12 +212,14 @@ extern _Atomic int arq_disconnect_retry_slots;
 #define ARQ_KEEPALIVE_MISS_LIMIT      5     /* missed keepalives before disconnect */
 #define ARQ_TURN_REQ_RETRIES          2
 #define ARQ_MODE_REQ_RETRIES          2
-#define ARQ_IRS_INACTIVITY_S          75    /* seconds without RX before IRS
-                                            * initiates a keepalive probe      */
+#define ARQ_PEER_PAYLOAD_HOLD_S       15    /* hold peer payload mode after activity */
+#define ARQ_IRS_INACTIVITY_CYCLES     5     /* TIMER_PEER_BACKLOG cycles without
+                                            * RX before IRS keepalive probe    */
+#define ARQ_IRS_INACTIVITY_S          (ARQ_PEER_PAYLOAD_HOLD_S * \
+                                       ARQ_IRS_INACTIVITY_CYCLES)
 #define ARQ_MODE_SWITCH_HYST_COUNT    1     /* SNR provides stability gate; 1 = immediate */
 #define ARQ_STARTUP_MAX_S             8     /* DATAC13-only startup window         */
 #define ARQ_STARTUP_ACKS_REQUIRED     1
-#define ARQ_PEER_PAYLOAD_HOLD_S       15    /* hold peer payload mode after activity */
 #define ARQ_SNR_HYST_DB               1.0f
 #define ARQ_SNR_MIN_DATAC4_DB        -4.0f  /* target MPP SNR (codec2 README) */
 #define ARQ_SNR_MIN_DATAC3_DB        -1.0f

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -212,8 +212,8 @@ extern _Atomic int arq_disconnect_retry_slots;
 #define ARQ_KEEPALIVE_MISS_LIMIT      5     /* missed keepalives before disconnect */
 #define ARQ_TURN_REQ_RETRIES          2
 #define ARQ_MODE_REQ_RETRIES          2
-#define ARQ_IRS_INACTIVITY_LIMIT      5     /* TIMER_PEER_BACKLOG cycles (×15s)
-                                            * without RX before keepalive probe */
+#define ARQ_IRS_INACTIVITY_S          75    /* seconds without RX before IRS
+                                            * initiates a keepalive probe      */
 #define ARQ_MODE_SWITCH_HYST_COUNT    1     /* SNR provides stability gate; 1 = immediate */
 #define ARQ_STARTUP_MAX_S             8     /* DATAC13-only startup window         */
 #define ARQ_STARTUP_ACKS_REQUIRED     1

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -212,6 +212,8 @@ extern _Atomic int arq_disconnect_retry_slots;
 #define ARQ_KEEPALIVE_MISS_LIMIT      5     /* missed keepalives before disconnect */
 #define ARQ_TURN_REQ_RETRIES          2
 #define ARQ_MODE_REQ_RETRIES          2
+#define ARQ_IRS_INACTIVITY_LIMIT      5     /* TIMER_PEER_BACKLOG cycles (×15s)
+                                            * without RX before keepalive probe */
 #define ARQ_MODE_SWITCH_HYST_COUNT    1     /* SNR provides stability gate; 1 = immediate */
 #define ARQ_STARTUP_MAX_S             8     /* DATAC13-only startup window         */
 #define ARQ_STARTUP_ACKS_REQUIRED     1


### PR DESCRIPTION
Test scenarios + evidences:
- Power cut off in IRS during middle of transmission and disconnect successfully (first try): [logs_0e1fd2e_lab1](https://wiki.hermes.radio/reports/logs_0e1fd2e_lab1/)
- Power cut off in IRS during middle of transmission and disconnect successfully (second try): [logs_0e1fd2e_lab1_1](https://wiki.hermes.radio/reports/logs_0e1fd2e_lab1_1/)
- Power cut off at  09:33:51 in IRS during middle of transmission and disconnect successfully (third try): [logs_0e1fd2e_lab1_2](https://wiki.hermes.radio/reports/logs_0e1fd2e_lab1_2/)
- Power back in IRS, all files have been re-transmitted successfully: [logs_0e1fd2e_lab1_3](https://wiki.hermes.radio/reports/logs_0e1fd2e_lab1_3/)
- Power cut off at 09:57:31 in IRS during middle of transmission, then power back on at 09:57:43 in IRS (power off for 12s) and complete transmission successfully: [logs_0e1fd2e_lab1_4](https://wiki.hermes.radio/reports/logs_0e1fd2e_lab1_4/)
- Power cut off at 10:19:36 in ISS during middle of transmission and disconnect successfully: [logs_0e1fd2e_lab1_5](https://wiki.hermes.radio/reports/logs_0e1fd2e_lab1_5/)