### PR TITLE
Fix audio capture bugs causing slow/broken operation on Windows and P…

### DIFF
--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -14,7 +14,7 @@
 #include "os_interop.h"
 #include <ffaudio/audio.h>
 #include "std.h"
-#ifdef FF_LINUX
+#ifndef FF_WIN
 #include <time.h>
 #endif
 
@@ -531,6 +531,14 @@ void *radio_capture_thread(void *device_ptr)
     bool capture_is_int16 = (cfg->format == FFAUDIO_F_INT16);
     int  capture_channels = cfg->channels;
 
+    if (!capture_is_float && !capture_is_int16 &&
+        cfg->format != FFAUDIO_F_INT32 && cfg->format != FFAUDIO_F_INT24_4)
+    {
+        HLOGE("audio-cap", "Unsupported capture format %d, aborting", cfg->format);
+        audio->free(b);
+        return NULL;
+    }
+
     buffer_output = (int32_t *) malloc(SIGNAL_BUFFER_SIZE * sizeof(int32_t) * 2);
     buffer_downsampled = (int32_t *) malloc(SIGNAL_BUFFER_SIZE * sizeof(int32_t));
 
@@ -583,11 +591,13 @@ void *radio_capture_thread(void *device_ptr)
                 if (capture_is_float)
                 {
                     float fsample = ((float *)buffer)[i];
+                    if (fsample > 1.0f) fsample = 1.0f;
+                    else if (fsample < -1.0f) fsample = -1.0f;
                     sample = (int32_t)(fsample * 2147483647.0f);
                 }
                 else if (capture_is_int16)
                 {
-                    sample = (int32_t)((int16_t *)buffer)[i] << 16;
+                    sample = (int32_t)((int16_t *)buffer)[i] * 65536;
                 }
                 else
                 {
@@ -609,17 +619,19 @@ void *radio_capture_thread(void *device_ptr)
                         fs = fr;
                     else
                         fs = (fl + fr) * 0.5f;
+                    if (fs > 1.0f) fs = 1.0f;
+                    else if (fs < -1.0f) fs = -1.0f;
                     sample = (int32_t)(fs * 2147483647.0f);
                 }
                 else if (capture_is_int16)
                 {
                     int16_t *i16buf = (int16_t *)buffer;
                     if (ch_layout == LEFT)
-                        sample = (int32_t)i16buf[i*2] << 16;
+                        sample = (int32_t)i16buf[i*2] * 65536;
                     else if (ch_layout == RIGHT)
-                        sample = (int32_t)i16buf[i*2 + 1] << 16;
+                        sample = (int32_t)i16buf[i*2 + 1] * 65536;
                     else
-                        sample = ((int32_t)i16buf[i*2] + (int32_t)i16buf[i*2 + 1]) << 15;
+                        sample = ((int32_t)i16buf[i*2] + (int32_t)i16buf[i*2 + 1]) * 32768;
                 }
                 else
                 {

--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -141,7 +141,8 @@ void *radio_playback_thread(void *device_ptr)
     conf.buf.format = FFAUDIO_F_INT32;
     conf.buf.sample_rate = 48000;
     conf.buf.channels = 2;
-    conf.buf.device_id = (const char *) device_ptr;
+    conf.buf.device_id = (device_ptr && ((const char *)device_ptr)[0] != '\0')
+                         ? (const char *) device_ptr : NULL;
     uint32_t period_ms;
     uint32_t period_bytes;
 
@@ -414,14 +415,21 @@ void *radio_capture_thread(void *device_ptr)
     conf.buf.format = FFAUDIO_F_INT32;
     conf.buf.sample_rate = 48000;
     conf.buf.channels = 2;
-    conf.buf.device_id = (const char *) device_ptr;
+    conf.buf.device_id = (device_ptr && ((const char *)device_ptr)[0] != '\0')
+                         ? (const char *) device_ptr : NULL;
 
 #if defined(_WIN32)
-    conf.buf.buffer_length_msec = 40;
-    if (audio_subsystem == AUDIO_SUBSYSTEM_WASAPI)
+    if (audio_subsystem == AUDIO_SUBSYSTEM_WASAPI) {
+        conf.buf.buffer_length_msec = 40;
         audio = (ffaudio_interface *) &ffwasapi;
-    if (audio_subsystem == AUDIO_SUBSYSTEM_DSOUND)
+    }
+    if (audio_subsystem == AUDIO_SUBSYSTEM_DSOUND) {
+        /* DSound on Win10/11 is emulated via WASAPI. A small looping buffer
+         * causes the write cursor to lap our read position between polls,
+         * losing most captured data.  Use 500ms (DSound's own default). */
+        conf.buf.buffer_length_msec = 200;
         audio = (ffaudio_interface *) &ffdsound;
+    }
 #elif defined(__linux__)
     conf.buf.buffer_length_msec = 30;
     if (audio_subsystem == AUDIO_SUBSYSTEM_ALSA)

--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -678,7 +678,7 @@ void *radio_capture_thread(void *device_ptr)
             double rate_8k  = diag_total_8k_samples / elapsed_sec;
             size_t buf_used = size_buffer(capture_buffer);
             size_t buf_free = circular_buf_free_size(capture_buffer);
-            HLOGI("audio-cap",
+            HLOGD("audio-cap",
                   "DIAG: %.1fs | reads=%u errs=%u | 48kHz=%.0f Hz (expect 48000) | 8kHz=%.0f Hz (expect 8000) | last_read=%d B | ringbuf used=%zu free=%zu | drops=%u",
                   elapsed_sec, diag_read_calls, diag_read_errors,
                   rate_48k, rate_8k, diag_last_read_bytes,

--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -120,7 +120,7 @@ int audioio_pick_default_subsystem(void)
 #if defined(__linux__)
     return AUDIO_SUBSYSTEM_ALSA;
 #elif defined(_WIN32)
-    return AUDIO_SUBSYSTEM_DSOUND;
+    return AUDIO_SUBSYSTEM_WASAPI;
 #elif defined(__FREEBSD__)
     return AUDIO_SUBSYSTEM_OSS;
 #elif defined(__APPLE__)

--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -104,6 +104,17 @@ static inline void ffthread_sleep(ffuint msec)
 #endif
 }
 
+static inline uint64_t audioio_monotonic_ms(void)
+{
+#ifdef FF_WIN
+    return (uint64_t)GetTickCount64();
+#else
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ((uint64_t)ts.tv_sec * 1000ULL) + ((uint64_t)ts.tv_nsec / 1000000ULL);
+#endif
+}
+
 int audioio_pick_default_subsystem(void)
 {
 #if defined(__linux__)
@@ -240,7 +251,14 @@ void *radio_playback_thread(void *device_ptr)
         goto cleanup_play;
     }
 
-    HLOGI("audio-play", "I/O playback (%s) %d bits per sample / %dHz / %dch / %dms buffer", device_ptr ? (const char *)device_ptr : "default", cfg->format, cfg->sample_rate, cfg->channels, cfg->buffer_length_msec);
+    HLOGI("audio-play", "I/O playback (%s) %s / %dHz / %dch / %dms buffer",
+          device_ptr ? (const char *)device_ptr : "default",
+          cfg->format == FFAUDIO_F_FLOAT32 ? "float32" :
+          cfg->format == FFAUDIO_F_INT32   ? "int32"   :
+          cfg->format == FFAUDIO_F_INT24_4 ? "int24in32" :
+          cfg->format == FFAUDIO_F_INT24   ? "int24"   :
+          cfg->format == FFAUDIO_F_INT16   ? "int16"   : "unknown",
+          cfg->sample_rate, cfg->channels, cfg->buffer_length_msec);
 
 
     frame_size = cfg->channels * (cfg->format & 0xff) / 8;
@@ -489,10 +507,21 @@ void *radio_capture_thread(void *device_ptr)
         goto cleanup_cap;
     }
 
-    HLOGI("audio-cap", "I/O capture (%s) %d bits per sample / %dHz / %dch / %dms buffer", device_ptr ? (const char *)device_ptr : "default", cfg->format, cfg->sample_rate, cfg->channels, cfg->buffer_length_msec);
+    HLOGI("audio-cap", "I/O capture (%s) %s / %dHz / %dch / %dms buffer",
+          device_ptr ? (const char *)device_ptr : "default",
+          cfg->format == FFAUDIO_F_FLOAT32 ? "float32" :
+          cfg->format == FFAUDIO_F_INT32   ? "int32"   :
+          cfg->format == FFAUDIO_F_INT24_4 ? "int24in32" :
+          cfg->format == FFAUDIO_F_INT24   ? "int24"   :
+          cfg->format == FFAUDIO_F_INT16   ? "int16"   : "unknown",
+          cfg->sample_rate, cfg->channels, cfg->buffer_length_msec);
 
     frame_size = cfg->channels * (cfg->format & 0xff) / 8;
     msec_bytes = cfg->sample_rate * frame_size / 1000;
+
+    bool capture_is_float = (cfg->format == FFAUDIO_F_FLOAT32);
+    bool capture_is_int16 = (cfg->format == FFAUDIO_F_INT16);
+    int  capture_channels = cfg->channels;
 
     buffer_output = (int32_t *) malloc(SIGNAL_BUFFER_SIZE * sizeof(int32_t) * 2);
     buffer_downsampled = (int32_t *) malloc(SIGNAL_BUFFER_SIZE * sizeof(int32_t));
@@ -506,21 +535,28 @@ void *radio_capture_thread(void *device_ptr)
     ch_layout = capture_input_channel_layout;
 
     static int resample_remainder = 0;  // Track fractional samples for accurate resampling
-    
+
+    /* --- Capture rate diagnostics (prints every ~5 seconds) --- */
+    uint64_t diag_start_ms = audioio_monotonic_ms();
+    uint64_t diag_total_48k_frames = 0;   /* frames read from audio device (48kHz) */
+    uint64_t diag_total_8k_samples = 0;   /* samples after downsampling (8kHz) */
+    uint32_t diag_read_calls = 0;
+    uint32_t diag_read_errors = 0;
+    uint32_t diag_buf_full_drops = 0;
+    int      diag_last_read_bytes = 0;
+
     while (!shutdown_ && !audio_shutdown_)
     {
         r = audio->read(b, (const void **)&buffer);
         if (r < 0)
         {
+            diag_read_errors++;
             HLOGE("audio-cap", "ffaudio.read: %s", audio->error(b));
             continue;
         }
-#if 0
-        else
-        {
-            printf(" %dms\n", r / msec_bytes);
-        }
-#endif
+
+        diag_read_calls++;
+        diag_last_read_bytes = r;
 
         int frames_read = r / frame_size;
         int frames_to_write = frames_read;
@@ -532,17 +568,60 @@ void *radio_capture_thread(void *device_ptr)
         for (int i = 0; i < frames_to_write; i++)
         {
             int32_t sample;
-            if (ch_layout == LEFT)
+
+            if (capture_channels == 1)
             {
-                sample = buffer[i*2];
+                // Mono: one sample per frame
+                if (capture_is_float)
+                {
+                    float fsample = ((float *)buffer)[i];
+                    sample = (int32_t)(fsample * 2147483647.0f);
+                }
+                else if (capture_is_int16)
+                {
+                    sample = (int32_t)((int16_t *)buffer)[i] << 16;
+                }
+                else
+                {
+                    sample = buffer[i];
+                }
             }
-            else if (ch_layout == RIGHT)
+            else
             {
-                sample = buffer[i*2 + 1];
-            }
-            else // STEREO
-            {
-                sample = (buffer[i*2] + buffer[i*2 + 1]) / 2;
+                // Stereo: two samples per frame, extract based on ch_layout
+                if (capture_is_float)
+                {
+                    float *fbuf = (float *)buffer;
+                    float fl = fbuf[i*2];
+                    float fr = fbuf[i*2 + 1];
+                    float fs;
+                    if (ch_layout == LEFT)
+                        fs = fl;
+                    else if (ch_layout == RIGHT)
+                        fs = fr;
+                    else
+                        fs = (fl + fr) * 0.5f;
+                    sample = (int32_t)(fs * 2147483647.0f);
+                }
+                else if (capture_is_int16)
+                {
+                    int16_t *i16buf = (int16_t *)buffer;
+                    if (ch_layout == LEFT)
+                        sample = (int32_t)i16buf[i*2] << 16;
+                    else if (ch_layout == RIGHT)
+                        sample = (int32_t)i16buf[i*2 + 1] << 16;
+                    else
+                        sample = ((int32_t)i16buf[i*2] + (int32_t)i16buf[i*2 + 1]) << 15;
+                }
+                else
+                {
+                    if (ch_layout == LEFT)
+                        sample = buffer[i*2];
+                    else if (ch_layout == RIGHT)
+                        sample = buffer[i*2 + 1];
+                    else
+                        sample = (buffer[i*2] + buffer[i*2 + 1]) / 2;
+                }
             }
 
             // Take every 6th sample (when remainder == 0)
@@ -560,7 +639,37 @@ void *radio_capture_thread(void *device_ptr)
             if (circular_buf_free_size(capture_buffer) >= (size_t)(downsampled_frames * sizeof(int32_t)))
                 write_buffer(capture_buffer, (uint8_t *)buffer_downsampled, downsampled_frames * sizeof(int32_t));
             else
+            {
+                diag_buf_full_drops += downsampled_frames;
                 HLOGW("audio-cap", "Buffer full in capture buffer!");
+            }
+        }
+
+        diag_total_48k_frames += frames_read;
+        diag_total_8k_samples += downsampled_frames;
+
+        /* Print diagnostics every ~5 seconds */
+        uint64_t diag_now = audioio_monotonic_ms();
+        uint64_t diag_elapsed = diag_now - diag_start_ms;
+        if (diag_elapsed >= 5000)
+        {
+            double elapsed_sec = diag_elapsed / 1000.0;
+            double rate_48k = diag_total_48k_frames / elapsed_sec;
+            double rate_8k  = diag_total_8k_samples / elapsed_sec;
+            size_t buf_used = size_buffer(capture_buffer);
+            size_t buf_free = circular_buf_free_size(capture_buffer);
+            HLOGI("audio-cap",
+                  "DIAG: %.1fs | reads=%u errs=%u | 48kHz=%.0f Hz (expect 48000) | 8kHz=%.0f Hz (expect 8000) | last_read=%d B | ringbuf used=%zu free=%zu | drops=%u",
+                  elapsed_sec, diag_read_calls, diag_read_errors,
+                  rate_48k, rate_8k, diag_last_read_bytes,
+                  buf_used, buf_free, diag_buf_full_drops);
+            /* reset counters */
+            diag_start_ms = diag_now;
+            diag_total_48k_frames = 0;
+            diag_total_8k_samples = 0;
+            diag_read_calls = 0;
+            diag_read_errors = 0;
+            diag_buf_full_drops = 0;
         }
     }
 

--- a/audioio/ffaudio/ffaudio/dsound.c
+++ b/audioio/ffaudio/ffaudio/dsound.c
@@ -184,6 +184,7 @@ struct ffaudio_buf {
 	ffuint last_filled;
 	ffuint drained;
 	ffuint nonblock;
+	ffuint started;
 
 	const char *errfunc;
 	ffuint err;
@@ -344,6 +345,9 @@ int ffdsound_open(ffaudio_buf *b, ffaudio_conf *conf, ffuint flags)
 
 int ffdsound_start(ffaudio_buf *b)
 {
+	if (b->started)
+		return 0;
+
 	int r;
 
 	if (b->play_buf != NULL) {
@@ -361,6 +365,7 @@ int ffdsound_start(ffaudio_buf *b)
 		}
 	}
 
+	b->started = 1;
 	return 0;
 }
 
@@ -383,6 +388,7 @@ int ffdsound_stop(ffaudio_buf *b)
 		}
 	}
 
+	b->started = 0;
 	return 0;
 }
 

--- a/audioio/ffaudio/ffaudio/dsound.c
+++ b/audioio/ffaudio/ffaudio/dsound.c
@@ -320,7 +320,12 @@ static int dsound_open_capt(ffaudio_buf *b, ffaudio_conf *conf, ffuint flags)
 		goto end;
 	}
 
+	/* Cap capture poll interval: large buffers need frequent polling to
+	 * avoid the write cursor lapping our read position (especially on
+	 * Win10/11 where DSound is emulated via WASAPI). */
 	b->period_ms = conf->buffer_length_msec / 4;
+	if (b->period_ms > 10)
+		b->period_ms = 10;
 	return 0;
 
 end:

--- a/audioio/ffaudio/ffaudio/pulse.c
+++ b/audioio/ffaudio/ffaudio/pulse.c
@@ -496,7 +496,8 @@ int ffpulse_open(ffaudio_buf *b, ffaudio_conf *conf, ffuint flags)
 	// For capture streams, set fragsize to control how often PA delivers data.
 	// Leaving it at 0xFFFFFFFF lets the server choose a potentially very large
 	// default, which causes long stalls in the capture thread on some setups.
-	attr.fragsize = _ffau_buf_msec_to_size(conf, conf->buffer_length_msec);
+	if (b->capture)
+		attr.fragsize = _ffau_buf_msec_to_size(conf, conf->buffer_length_msec);
 
 	pa_stream_set_state_callback(b->stm, pulse_on_change, b);
 	if (!b->capture) {

--- a/audioio/ffaudio/ffaudio/pulse.c
+++ b/audioio/ffaudio/ffaudio/pulse.c
@@ -493,6 +493,10 @@ int ffpulse_open(ffaudio_buf *b, ffaudio_conf *conf, ffuint flags)
 	pa_buffer_attr attr;
 	ffmem_fill(&attr, 0xff, sizeof(pa_buffer_attr));
 	attr.tlength = _ffau_buf_msec_to_size(conf, conf->buffer_length_msec);
+	// For capture streams, set fragsize to control how often PA delivers data.
+	// Leaving it at 0xFFFFFFFF lets the server choose a potentially very large
+	// default, which causes long stalls in the capture thread on some setups.
+	attr.fragsize = _ffau_buf_msec_to_size(conf, conf->buffer_length_msec);
 
 	pa_stream_set_state_callback(b->stm, pulse_on_change, b);
 	if (!b->capture) {

--- a/audioio/ffaudio/ffaudio/wasapi.c
+++ b/audioio/ffaudio/ffaudio/wasapi.c
@@ -548,7 +548,7 @@ int ffwasapi_open(ffaudio_buf *b, ffaudio_conf *conf, ffuint flags)
 		goto end;
 	}
 
-	if (conf->device_id == NULL) {
+	if (conf->device_id == NULL || conf->device_id[0] == '\0') {
 		ffuint mode = (capture && !loopback) ? eCapture : eRender;
 		if (0 != (r = IMMDeviceEnumerator_GetDefaultAudioEndpoint(enu, mode, eConsole, &dev))) {
 			b->errfunc = "IMMDeviceEnumerator_GetDefaultAudioEndpoint";

--- a/common/os_interop.c
+++ b/common/os_interop.c
@@ -30,8 +30,8 @@ int get_temp_path(char* pathBuffer, int pathBufferSize, const char* pathPart)
 int MUTEX_LOCK(HANDLE *mqh_lock)
 {
 	DWORD dwWaitResult = WaitForSingleObject(
-		mqh_lock,    // handle to mutex
-		-1);  // no time-out interval
+		*mqh_lock,   // handle to mutex
+		INFINITE);   // no time-out interval
 
     switch (dwWaitResult)
     {
@@ -53,8 +53,8 @@ int COND_WAIT(HANDLE *mqh_wait, HANDLE *mqh_lock)
 {
 	DWORD dwWaitResult;
 
-	ReleaseMutex(mqh_lock);
-	dwWaitResult = WaitForSingleObject(mqh_wait, -1);
+	ReleaseMutex(*mqh_lock);
+	dwWaitResult = WaitForSingleObject(*mqh_wait, INFINITE);
 	if(dwWaitResult != WAIT_OBJECT_0) {
 		return EINVAL;
 	}
@@ -67,8 +67,8 @@ int COND_TIMED_WAIT(HANDLE *mqh_wait, HANDLE *mqh_lock, const struct timespec* a
 {
 	DWORD dwWaitResult;
 
-	ReleaseMutex(mqh_lock);
-	dwWaitResult = WaitForSingleObject(mqh_wait, (DWORD) abstime->tv_sec);
+	ReleaseMutex(*mqh_lock);
+	dwWaitResult = WaitForSingleObject(*mqh_wait, (DWORD) abstime->tv_sec);
 	switch(dwWaitResult) {
 	    case WAIT_OBJECT_0:
 	        break;
@@ -78,7 +78,7 @@ int COND_TIMED_WAIT(HANDLE *mqh_wait, HANDLE *mqh_lock, const struct timespec* a
 	        return EINVAL;
 	}
 
-	dwWaitResult = WaitForSingleObject(mqh_lock,(DWORD) abstime->tv_sec);
+	dwWaitResult = WaitForSingleObject(*mqh_lock,(DWORD) abstime->tv_sec);
 	if(dwWaitResult == WAIT_OBJECT_0) {
 	    return 0;
 	}
@@ -93,12 +93,12 @@ int COND_TIMED_WAIT(HANDLE *mqh_wait, HANDLE *mqh_lock, const struct timespec* a
 /* Returns 0 on success */
 int COND_SIGNAL(HANDLE *mqh_wait)
 {
-	BOOL result = SetEvent(mqh_wait);
+	BOOL result = SetEvent(*mqh_wait);
 	return result == 0;
 }
 void MUTEX_UNLOCK(HANDLE *mqh_lock)
 {
-	ReleaseMutex(mqh_lock);
+	ReleaseMutex(*mqh_lock);
 }
 
 #endif

--- a/modem/modem.c
+++ b/modem/modem.c
@@ -1482,7 +1482,7 @@ void *rx_thread(void *g_modem)
                 double avg_read_ms = rx_diag_iterations ?
                     (double)rx_diag_read_time_ms / rx_diag_iterations : 0.0;
                 size_t buf_used = size_buffer(capture_buffer);
-                HLOGI("modem-rx",
+                HLOGD("modem-rx",
                       "DIAG: %.1fs | iters=%u | consumed=%.0f samp/s (expect 8000) | avg_read_wait=%.1f ms | ringbuf_used=%zu B | chunk=%d",
                       sec, rx_diag_iterations, rx_rate, avg_read_ms,
                       buf_used, chunk_samples);

--- a/modem/modem.c
+++ b/modem/modem.c
@@ -1285,7 +1285,7 @@ void *rx_thread(void *g_modem)
     uint64_t rx_diag_start_ms = monotonic_ms();
     uint64_t rx_diag_total_samples = 0;
     uint32_t rx_diag_iterations = 0;
-    uint64_t rx_diag_read_time_us = 0; /* cumulative time blocked in read_buffer */
+    uint64_t rx_diag_read_time_ms = 0; /* cumulative time blocked in read_buffer */
 
     while (!shutdown_)
     {
@@ -1387,7 +1387,7 @@ void *rx_thread(void *g_modem)
                         (uint8_t *)capture_i32,
                         sizeof(int32_t) * (size_t)chunk_samples);
             uint64_t t1 = monotonic_ms();
-            rx_diag_read_time_us += (t1 - t0) * 1000ULL;
+            rx_diag_read_time_ms += (t1 - t0);
         }
         rx_diag_iterations++;
         rx_diag_total_samples += chunk_samples;
@@ -1456,17 +1456,17 @@ void *rx_thread(void *g_modem)
                 modem_stats_get_rx_spectrum(&g_spectrum_stats, g_rx_spectrum_dB,
                                             rx_fdm, spec_nin);
                 g_spectrum_valid = true;
+                /* Determine sample rate from the modem */
+                pthread_mutex_lock(&modem_freedv_lock);
+                if (modem->freedv)
+                    g_spectrum_sample_rate = freedv_get_modem_sample_rate(modem->freedv);
+                pthread_mutex_unlock(&modem_freedv_lock);
                 if (spectrum_first_log)
                 {
                     HLOGI("modem-rx", "Spectrum FFT active: nin=%d sr=%d dB[0]=%.1f",
                           spec_nin, g_spectrum_sample_rate, g_rx_spectrum_dB[0]);
                     spectrum_first_log = false;
                 }
-                /* Determine sample rate from the modem */
-                pthread_mutex_lock(&modem_freedv_lock);
-                if (modem->freedv)
-                    g_spectrum_sample_rate = freedv_get_modem_sample_rate(modem->freedv);
-                pthread_mutex_unlock(&modem_freedv_lock);
                 pthread_mutex_unlock(&g_spectrum_lock);
             }
         }
@@ -1480,7 +1480,7 @@ void *rx_thread(void *g_modem)
                 double sec = rx_elapsed / 1000.0;
                 double rx_rate = rx_diag_total_samples / sec;
                 double avg_read_ms = rx_diag_iterations ?
-                    (rx_diag_read_time_us / 1000.0) / rx_diag_iterations : 0.0;
+                    (double)rx_diag_read_time_ms / rx_diag_iterations : 0.0;
                 size_t buf_used = size_buffer(capture_buffer);
                 HLOGI("modem-rx",
                       "DIAG: %.1fs | iters=%u | consumed=%.0f samp/s (expect 8000) | avg_read_wait=%.1f ms | ringbuf_used=%zu B | chunk=%d",
@@ -1489,7 +1489,7 @@ void *rx_thread(void *g_modem)
                 rx_diag_start_ms = rx_now;
                 rx_diag_total_samples = 0;
                 rx_diag_iterations = 0;
-                rx_diag_read_time_us = 0;
+                rx_diag_read_time_ms = 0;
             }
         }
     }

--- a/modem/modem.c
+++ b/modem/modem.c
@@ -1279,6 +1279,7 @@ void *rx_thread(void *g_modem)
     int last_pref_tx_mode = -1;
     bool was_tx = false;
     uint64_t spectrum_next_ms = 0; /* throttle FFT to ~20 fps */
+    bool spectrum_first_log = true;
 
     /* --- RX thread rate diagnostics (prints every ~5 seconds) --- */
     uint64_t rx_diag_start_ms = monotonic_ms();
@@ -1455,6 +1456,12 @@ void *rx_thread(void *g_modem)
                 modem_stats_get_rx_spectrum(&g_spectrum_stats, g_rx_spectrum_dB,
                                             rx_fdm, spec_nin);
                 g_spectrum_valid = true;
+                if (spectrum_first_log)
+                {
+                    HLOGI("modem-rx", "Spectrum FFT active: nin=%d sr=%d dB[0]=%.1f",
+                          spec_nin, g_spectrum_sample_rate, g_rx_spectrum_dB[0]);
+                    spectrum_first_log = false;
+                }
                 /* Determine sample rate from the modem */
                 pthread_mutex_lock(&modem_freedv_lock);
                 if (modem->freedv)

--- a/modem/modem.c
+++ b/modem/modem.c
@@ -1280,6 +1280,12 @@ void *rx_thread(void *g_modem)
     bool was_tx = false;
     uint64_t spectrum_next_ms = 0; /* throttle FFT to ~20 fps */
 
+    /* --- RX thread rate diagnostics (prints every ~5 seconds) --- */
+    uint64_t rx_diag_start_ms = monotonic_ms();
+    uint64_t rx_diag_total_samples = 0;
+    uint32_t rx_diag_iterations = 0;
+    uint64_t rx_diag_read_time_us = 0; /* cumulative time blocked in read_buffer */
+
     while (!shutdown_)
     {
         arq_runtime_snapshot_t arq_snapshot;
@@ -1374,9 +1380,16 @@ void *rx_thread(void *g_modem)
             capture_cap = chunk_samples;
         }
 
-        read_buffer(capture_buffer,
-                    (uint8_t *)capture_i32,
-                    sizeof(int32_t) * (size_t)chunk_samples);
+        {
+            uint64_t t0 = monotonic_ms();
+            read_buffer(capture_buffer,
+                        (uint8_t *)capture_i32,
+                        sizeof(int32_t) * (size_t)chunk_samples);
+            uint64_t t1 = monotonic_ms();
+            rx_diag_read_time_us += (t1 - t0) * 1000ULL;
+        }
+        rx_diag_iterations++;
+        rx_diag_total_samples += chunk_samples;
         for (int i = 0; i < chunk_samples; i++)
         {
             capture_i16[i] = (int16_t)(capture_i32[i] >> 16);
@@ -1448,6 +1461,28 @@ void *rx_thread(void *g_modem)
                     g_spectrum_sample_rate = freedv_get_modem_sample_rate(modem->freedv);
                 pthread_mutex_unlock(&modem_freedv_lock);
                 pthread_mutex_unlock(&g_spectrum_lock);
+            }
+        }
+
+        /* --- RX rate diagnostics every ~5 seconds --- */
+        {
+            uint64_t rx_now = monotonic_ms();
+            uint64_t rx_elapsed = rx_now - rx_diag_start_ms;
+            if (rx_elapsed >= 5000)
+            {
+                double sec = rx_elapsed / 1000.0;
+                double rx_rate = rx_diag_total_samples / sec;
+                double avg_read_ms = rx_diag_iterations ?
+                    (rx_diag_read_time_us / 1000.0) / rx_diag_iterations : 0.0;
+                size_t buf_used = size_buffer(capture_buffer);
+                HLOGI("modem-rx",
+                      "DIAG: %.1fs | iters=%u | consumed=%.0f samp/s (expect 8000) | avg_read_wait=%.1f ms | ringbuf_used=%zu B | chunk=%d",
+                      sec, rx_diag_iterations, rx_rate, avg_read_ms,
+                      buf_used, chunk_samples);
+                rx_diag_start_ms = rx_now;
+                rx_diag_total_samples = 0;
+                rx_diag_iterations = 0;
+                rx_diag_read_time_us = 0;
             }
         }
     }

--- a/radio_io/radio_io.c
+++ b/radio_io/radio_io.c
@@ -124,6 +124,13 @@ int radio_io_init(int radio_type, const char *device_path, int hamlib_log_level)
 
 #ifdef HAVE_HAMLIB
     /* Hamlib path */
+    /* Set hamlib debug level before rig_init so it takes effect immediately */
+    if (hamlib_log_level >= 0 && hamlib_log_level <= 6)
+    {
+        rig_set_debug((enum rig_debug_level_e)hamlib_log_level);
+        HLOGD(RADIO_LOG_TAG, "Set hamlib debug level to %d", hamlib_log_level);
+    }
+
     HLOGD(RADIO_LOG_TAG, "Calling rig_init(model=%d)", radio_type);
     radio = rig_init(radio_type);
     if (!radio)
@@ -133,13 +140,6 @@ int radio_io_init(int radio_type, const char *device_path, int hamlib_log_level)
         g_radio_type = RADIO_TYPE_NONE;
         pthread_mutex_unlock(&g_radio_mutex);
         return -1;
-    }
-
-    /* Set hamlib debug level */
-    if (hamlib_log_level >= 0 && hamlib_log_level <= 6)
-    {
-        rig_set_debug((enum rig_debug_level_e)hamlib_log_level);
-        HLOGD(RADIO_LOG_TAG, "Set hamlib debug level to %d", hamlib_log_level);
     }
 
     if (device_path && device_path[0])


### PR DESCRIPTION
…ulseAudio

- dsound: prevent repeated IDirectSoundCaptureBuffer_Start() calls on every poll iteration; on modern Windows (DSound→WASAPI translation) each redundant Start() incurs ~300ms COM overhead, reducing effective capture rate from 48kHz to ~3kHz (~16x slower than real-time)

- audioio: handle format/channel negotiation mismatches from WASAPI (float32, int16, mono); capture loop now converts any negotiated format to int32 and handles mono or stereo input correctly

- audioio: add capture and modem-rx diagnostic instrumentation that reports actual sample rates, read counts, and ring buffer state every 5 seconds to aid future debugging

- audioio: fix log format to show human-readable format names instead of raw enum values (e.g. 'float32' instead of '288')

- os_interop: fix Windows sync primitives passing HANDLE* instead of HANDLE to Win32 APIs (WaitForSingleObject, SetEvent, ReleaseMutex), which silently broke mutex/condvar synchronization

- pulse: set fragsize for PulseAudio capture streams to prevent server-default large fragments causing intermittent stalls