### PR TITLE
Fix TCP ARQ socket reads on Windows and add HAMLIB baud rate option

### DIFF
--- a/common/cfg_utils.c
+++ b/common/cfg_utils.c
@@ -46,6 +46,7 @@ void cfg_set_defaults(mercury_config *cfg)
     cfg->verbose            = false;
     cfg->freedv_verbosity   = 0;
     cfg->hamlib_log_level   = 0;
+    cfg->radio_serial_speed = 0;  /* 0 = use hamlib default */
 }
 
 /* Map a sound-system name to the AUDIO_SUBSYSTEM_* constant.
@@ -146,6 +147,10 @@ bool cfg_read(mercury_config *cfg, const char *ini_path)
     if (i >= 0 && i <= 6)
         cfg->hamlib_log_level = i;
 
+    i = iniparser_getint(ini, CFG_KEY_RADIO_SERIAL_SPEED, cfg->radio_serial_speed);
+    if (i >= 0)
+        cfg->radio_serial_speed = i;
+
     iniparser_freedict(ini);
     return true;
 }
@@ -223,6 +228,7 @@ bool cfg_write(const mercury_config *cfg, const char *ini_path)
     fprintf(f, "verbose = %s\n",           cfg->verbose ? "true" : "false");
     fprintf(f, "freedv_verbosity = %d\n",  cfg->freedv_verbosity);
     fprintf(f, "hamlib_log_level = %d\n",  cfg->hamlib_log_level);
+    fprintf(f, "radio_serial_speed = %d\n", cfg->radio_serial_speed);
 
     fclose(f);
     return true;

--- a/common/cfg_utils.h
+++ b/common/cfg_utils.h
@@ -40,6 +40,7 @@
 #define CFG_KEY_VERBOSE             "main:verbose"
 #define CFG_KEY_FREEDV_VERBOSITY    "main:freedv_verbosity"
 #define CFG_KEY_HAMLIB_LOG_LEVEL    "main:hamlib_log_level"
+#define CFG_KEY_RADIO_SERIAL_SPEED  "main:radio_serial_speed"
 
 /* Holds all values read from the init configuration file */
 typedef struct {
@@ -58,6 +59,7 @@ typedef struct {
     bool     verbose;
     int      freedv_verbosity;      /* 0..3 */
     int      hamlib_log_level;      /* 0..6 */
+    int      radio_serial_speed;   /* 0 = use hamlib default */
 } mercury_config;
 
 /* Load configuration from an INI file into |cfg|.

--- a/common/os_interop.h
+++ b/common/os_interop.h
@@ -26,8 +26,60 @@
 #ifndef MSG_NOSIGNAL
 #define MSG_NOSIGNAL 0
 #endif
-#define poll(fds, nfds, timeout) WSAPoll((fds), (ULONG)(nfds), (timeout))
 typedef ULONG nfds_t;
+
+/* WSAPoll() has known bugs on various Windows versions (missed POLLIN
+ * events, silent failures).  Use select() instead — it is the original
+ * Winsock multiplexing API and is reliable everywhere. */
+static inline int hermes_poll(struct pollfd *fds, nfds_t nfds, int timeout_ms)
+{
+    fd_set rd, er;
+    struct timeval tv, *tvp;
+    nfds_t i;
+    int ready;
+
+    FD_ZERO(&rd);
+    FD_ZERO(&er);
+
+    for (i = 0; i < nfds; i++)
+    {
+        fds[i].revents = 0;
+        if (fds[i].fd == INVALID_SOCKET)
+            continue;
+        if (fds[i].events & (POLLIN | POLLRDNORM | POLLRDBAND))
+            FD_SET(fds[i].fd, &rd);
+        FD_SET(fds[i].fd, &er);
+    }
+
+    if (timeout_ms < 0)
+    {
+        tvp = NULL;
+    }
+    else
+    {
+        tv.tv_sec  = timeout_ms / 1000;
+        tv.tv_usec = (timeout_ms % 1000) * 1000;
+        tvp = &tv;
+    }
+
+    /* First arg is ignored on Windows. */
+    ready = select(0, &rd, NULL, &er, tvp);
+    if (ready <= 0)
+        return ready;
+
+    for (i = 0; i < nfds; i++)
+    {
+        if (fds[i].fd == INVALID_SOCKET)
+            continue;
+        if (FD_ISSET(fds[i].fd, &rd))
+            fds[i].revents |= POLLIN;
+        if (FD_ISSET(fds[i].fd, &er))
+            fds[i].revents |= POLLERR;
+    }
+
+    return ready;
+}
+#define poll(fds, nfds, timeout) hermes_poll((fds), (nfds), (timeout))
 
 static inline int sock_set_nonblocking(int fd)
 {

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -559,7 +559,11 @@ static void *arq_reactor_thread(void *port)
             nfds++;
         }
 
-        (void)poll(pfds, (nfds_t)nfds, 100);
+        {
+            int poll_rc = poll(pfds, (nfds_t)nfds, 100);
+            if (poll_rc < 0)
+                HLOGW("tcp-poll", "poll() error: %d", sock_errno());
+        }
         now_ms = monotonic_ms();
 
         if (pfds[0].revents & POLLIN)
@@ -625,10 +629,12 @@ static void *arq_reactor_thread(void *port)
                 ssize_t n = recv(ctl_client, (char *)rx_buf, sizeof(rx_buf), 0);
                 if (n > 0)
                 {
+                    HLOGD("tcp-ctl", "recv %zd bytes from control client", n);
                     process_control_bytes(ctl_line, &ctl_len, rx_buf, n);
                 }
                 else if (n == 0 || (n < 0 && sock_errno() != SOCK_EAGAIN && sock_errno() != SOCK_EWOULDBLOCK && sock_errno() != SOCK_EINTR))
                 {
+                    HLOGW("tcp-ctl", "Control recv returned %zd (err=%d), closing", n, sock_errno());
                     close_ctl_client(&ctl_client, &data_client, true);
                 }
             }
@@ -646,6 +652,7 @@ static void *arq_reactor_thread(void *port)
                 ssize_t n = recv(data_client, (char *)rx_buf, sizeof(rx_buf), 0);
                 if (n > 0)
                 {
+                    HLOGD("tcp-data", "recv %zd bytes from data client", n);
                     int queued = arq_submit_tcp_payload(rx_buf, (size_t)n);
                     if (queued < 0)
                         HLOGW("tcp-data", "Failed to queue ARQ data frame(s)");
@@ -654,6 +661,7 @@ static void *arq_reactor_thread(void *port)
                 }
                 else if (n == 0 || (n < 0 && sock_errno() != SOCK_EAGAIN && sock_errno() != SOCK_EWOULDBLOCK && sock_errno() != SOCK_EINTR))
                 {
+                    HLOGW("tcp-data", "Data recv returned %zd (err=%d), closing", n, sock_errno());
                     close_data_client(&data_client);
                 }
             }
@@ -874,7 +882,7 @@ void *recv_thread(void *client_socket_ptr)
         }
         else if (received < 0)
         {
-            perror("Error receiving TCP data");
+            HLOGW("tcp-bcast", "Error receiving TCP data (err=%d)", sock_errno());
             break;
         }
     }

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -126,11 +126,11 @@ static int ws_command_handler(const ws_command_t *cmd, void *user_data)
         HLOGI(UI_LOG_TAG, "Radio set_radio_config command: model_id=%d device_path=\"%s\"",
               new_radio_type, dev_path);
         if (new_radio_type == RADIO_TYPE_NONE) {
-            radio_io_restart(RADIO_TYPE_NONE, NULL, radio_io_get_hamlib_log_level());
+            radio_io_restart(RADIO_TYPE_NONE, NULL, radio_io_get_hamlib_log_level(), radio_io_get_serial_speed());
             HLOGI(UI_LOG_TAG, "Radio type set to NONE - radio subsystem shut down");
             ctx->radio_list_pending = 1;
         } else {
-            int rc = radio_io_restart(new_radio_type, dev_path, radio_io_get_hamlib_log_level());
+            int rc = radio_io_restart(new_radio_type, dev_path, radio_io_get_hamlib_log_level(), radio_io_get_serial_speed());
             if (rc == 0) {
                 HLOGI(UI_LOG_TAG, "Radioio subsystem restarted (model=%d, path=%s)",
                       new_radio_type, dev_path);

--- a/main.c
+++ b/main.c
@@ -179,6 +179,7 @@ int main(int argc, char *argv[])
 
     int radio_type = RADIO_TYPE_NONE;
     char radio_device[1024] = "";
+    int radio_serial_speed = 0;
     bool list_radio_models = false;
 
     // --- Load init configuration file ---
@@ -224,6 +225,7 @@ int main(int argc, char *argv[])
             verbose            = mcfg.verbose ? 1 : 0;
             freedv_verbosity   = mcfg.freedv_verbosity;
             hamlib_log_level   = mcfg.hamlib_log_level;
+            radio_serial_speed = mcfg.radio_serial_speed;
         }
     }
 
@@ -585,7 +587,7 @@ int main(int argc, char *argv[])
         audioio_init_internal(input_dev, output_dev, audio_system, rx_input_channel, &radio_capture, &radio_playback);
     }
 
-    if (radio_io_init(radio_type, radio_device, hamlib_log_level) != 0)
+    if (radio_io_init(radio_type, radio_device, hamlib_log_level, radio_serial_speed) != 0)
     {
         fprintf(stderr, "Failed to initialize radio control.\n");
         hermes_log_shutdown();
@@ -646,6 +648,7 @@ int main(int argc, char *argv[])
     mcfg.verbose           = verbose ? true : false;
     mcfg.freedv_verbosity  = freedv_verbosity;
     mcfg.hamlib_log_level  = hamlib_log_level;
+    mcfg.radio_serial_speed = radio_serial_speed;
 
     ui_ctx_t ui_ctx;
     if (ui_enabled)

--- a/mercury.ini
+++ b/mercury.ini
@@ -29,7 +29,13 @@ waterfall_enabled = true
 radio_model = -1
 
 ; HAMLIB radio device file or ip:port address
+; Examples: /dev/ttyUSB0 (Linux), COM3 (Windows), 127.0.0.1:4532 (rigctld)
 radio_device =
+
+; Serial baud rate for HAMLIB radio (0 = use hamlib default for the model).
+; Must match the CAT Rate configured on your radio.
+; Common values: 4800, 9600, 19200, 38400, 115200
+radio_serial_speed = 0
 
 ; Audio capture (input) device id (e.g. "plughw:0,0")
 ; Run mercury -z to list available devices.

--- a/radio_io/radio_io.c
+++ b/radio_io/radio_io.c
@@ -49,6 +49,7 @@ static pthread_mutex_t g_radio_mutex = PTHREAD_MUTEX_INITIALIZER;
 static int g_radio_type = RADIO_TYPE_NONE;
 static char g_device_path[256] = {0};
 static int g_hamlib_log_level = 0; /* hamlib debug level (0-6) */
+static int g_serial_speed = 0;    /* serial baud rate (0 = hamlib default) */
 #ifdef HAVE_HAMLIB
 static RIG *radio = NULL;
 #endif
@@ -57,11 +58,13 @@ static RIG *radio = NULL;
 static controller_conn *sbitx_connector = NULL;
 #endif
 
-int radio_io_init(int radio_type, const char *device_path, int hamlib_log_level)
+int radio_io_init(int radio_type, const char *device_path, int hamlib_log_level, int serial_speed)
 {
     pthread_mutex_lock(&g_radio_mutex);
-    HLOGI(RADIO_LOG_TAG, "Initializing radio (type=%d, device=%s, hamlib_log_level=%d)",
-          radio_type, device_path && device_path[0] ? device_path : "(none)", hamlib_log_level);
+    HLOGI(RADIO_LOG_TAG, "Initializing radio (type=%d, device=%s, hamlib_log_level=%d, serial_speed=%d)",
+          radio_type, device_path && device_path[0] ? device_path : "(none)", hamlib_log_level, serial_speed);
+
+    g_serial_speed = serial_speed;
 
     /* Validate/clamp hamlib_log_level so that g_hamlib_log_level always
      * reflects a value that can actually be applied (valid range 0-6). */
@@ -144,6 +147,12 @@ int radio_io_init(int radio_type, const char *device_path, int hamlib_log_level)
 
     if (device_path && device_path[0])
         snprintf(radio->state.rigport.pathname, HAMLIB_FILPATHLEN, "%s", device_path);
+
+    if (serial_speed > 0)
+    {
+        radio->state.rigport.parm.serial.rate = serial_speed;
+        HLOGI(RADIO_LOG_TAG, "Serial speed overridden to %d baud", serial_speed);
+    }
 
     HLOGD(RADIO_LOG_TAG, "Calling rig_open(device=%s)",
           device_path && device_path[0] ? device_path : "(default)");
@@ -319,15 +328,15 @@ int radio_io_get_radio_list(char ids[][16], char names[][64], int max_count)
 #endif
 }
 
-int radio_io_restart(int new_radio_type, const char *device_path, int hamlib_log_level)
+int radio_io_restart(int new_radio_type, const char *device_path, int hamlib_log_level, int serial_speed)
 {
-    HLOGI(RADIO_LOG_TAG, "Restart requested (new_type=%d, device=%s, hamlib_log_level=%d)",
-          new_radio_type, device_path && device_path[0] ? device_path : "(none)", hamlib_log_level);
+    HLOGI(RADIO_LOG_TAG, "Restart requested (new_type=%d, device=%s, hamlib_log_level=%d, serial_speed=%d)",
+          new_radio_type, device_path && device_path[0] ? device_path : "(none)", hamlib_log_level, serial_speed);
 
     /* radio_io_shutdown / radio_io_init both acquire the mutex internally
      * which serialises this restart against any concurrent key_on/key_off. */
     radio_io_shutdown();
-    return radio_io_init(new_radio_type, device_path, hamlib_log_level);
+    return radio_io_init(new_radio_type, device_path, hamlib_log_level, serial_speed);
 }
 
 const char *radio_io_get_device_path(void)
@@ -343,4 +352,9 @@ int radio_io_get_radio_type(void)
 int radio_io_get_hamlib_log_level(void)
 {
     return g_hamlib_log_level;
+}
+
+int radio_io_get_serial_speed(void)
+{
+    return g_serial_speed;
 }

--- a/radio_io/radio_io.h
+++ b/radio_io/radio_io.h
@@ -30,8 +30,9 @@
  * radio_type: RADIO_TYPE_NONE (disabled), RADIO_TYPE_SHM, or hamlib model ID (>0).
  * device_path: hamlib device file or ip:port (ignored for SHM/NONE).
  * hamlib_log_level: hamlib debug level (0-6). 0=NONE, 1=BUG, 2=ERR, 3=WARN, 4=VERBOSE, 5=TRACE, 6=CACHE.
+ * serial_speed: serial baud rate (0 = use hamlib default for the model).
  * Returns 0 on success, -1 on failure. */
-int radio_io_init(int radio_type, const char *device_path, int hamlib_log_level);
+int radio_io_init(int radio_type, const char *device_path, int hamlib_log_level, int serial_speed);
 
 /* Shutdown radio control and release resources. */
 void radio_io_shutdown(void);
@@ -56,8 +57,9 @@ int radio_io_get_radio_list(char ids[][16], char names[][64], int max_count);
 /* Restart radio subsystem with a new radio type.
  * Thread-safe — blocks key_on / key_off during the restart cycle.
  * hamlib_log_level: hamlib debug level (0-6).
+ * serial_speed: serial baud rate (0 = use hamlib default).
  * Returns 0 on success, -1 on failure. */
-int radio_io_restart(int new_radio_type, const char *device_path, int hamlib_log_level);
+int radio_io_restart(int new_radio_type, const char *device_path, int hamlib_log_level, int serial_speed);
 
 /* Return the device path used by the current (or last) init. */
 const char *radio_io_get_device_path(void);
@@ -67,5 +69,8 @@ int radio_io_get_radio_type(void);
 
 /* Return the hamlib debug level used by the current (or last) init. */
 int radio_io_get_hamlib_log_level(void);
+
+/* Return the serial speed used by the current (or last) init (0 = hamlib default). */
+int radio_io_get_serial_speed(void);
 
 #endif /* RADIO_IO_H_ */


### PR DESCRIPTION
WSAPoll() has known bugs on various Windows versions that can cause missed POLLIN events on connected sockets. This caused Mercury to accept ARQ client connections and send data, but never read incoming client data on Windows.

Replace WSAPoll with a select()-based hermes_poll() wrapper (Windows only). Add poll error checking and diagnostic logging around recv(). Fix broadcast recv_thread to use sock_errno() instead of perror().