### PR TITLE
Added CALLINT command

### DIFF
--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -344,6 +344,19 @@ static void execute_control_command(char *buffer)
         return;
     }
 
+    if (!memcmp(buffer, "CALLINT", strlen("CALLINT")))
+    {
+        memset(&cmd, 0, sizeof(cmd));
+        cmd.type = ARQ_CMD_SET_CALLINT;
+        if (sscanf(buffer, "CALLINT %d", &cmd.value) == 1 &&
+            cmd.value >= 0 &&
+            arq_submit_tcp_cmd(&cmd) == 0)
+            tcp_write(CTL_TCP_PORT, (uint8_t *)"OK\r", 3);
+        else
+            tcp_write(CTL_TCP_PORT, (uint8_t *)"WRONG\r", 6);
+        return;
+    }
+
     if (!memcmp(buffer, "BUFFER", strlen("BUFFER")))
     {
         int buffered = arq_buffered_bytes_snapshot();

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -345,8 +345,10 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
         if (msg->value <= 0)
         {
             atomic_store(&arq_callint_override_s, ARQ_CALLINT_DEFAULT_S);
+            const arq_mode_timing_t *datac13 =
+                arq_protocol_mode_timing(FREEDV_MODE_DATAC13);
             HLOGI(LOG_COMP, "CALLINT reset to default (%.1fs)",
-                  arq_mode_table[0].retry_interval_s);
+                  datac13 ? datac13->retry_interval_s : 7.0f);
         }
         else
         {

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -341,6 +341,22 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
         arq_set_retry_slots(msg->value);
         return;
 
+    case ARQ_CMD_SET_CALLINT:
+        if (msg->value <= 0)
+        {
+            atomic_store(&arq_callint_override_s, ARQ_CALLINT_DEFAULT_S);
+            HLOGI(LOG_COMP, "CALLINT reset to default (%.1fs)",
+                  arq_mode_table[0].retry_interval_s);
+        }
+        else
+        {
+            float v = (float)msg->value;
+            if (v < ARQ_CALLINT_MIN_S) v = ARQ_CALLINT_MIN_S;
+            atomic_store(&arq_callint_override_s, v);
+            HLOGI(LOG_COMP, "CALLINT set to %.1fs", v);
+        }
+        return;
+
     case ARQ_CMD_LISTEN_ON:
         arq_conn.listen = true;
         ev.id = ARQ_EV_APP_LISTEN;

--- a/datalink_arq/arq_events.h
+++ b/datalink_arq/arq_events.h
@@ -33,7 +33,8 @@ typedef enum
     ARQ_CMD_SEND_CQ = 11,
     ARQ_CMD_ADD_SECONDARY_CALLSIGN = 12,
     ARQ_CMD_CLEAR_SECONDARY_CALLSIGNS = 13,
-    ARQ_CMD_ABORT = 14
+    ARQ_CMD_ABORT = 14,
+    ARQ_CMD_SET_CALLINT = 15
 } arq_cmd_type_t;
 
 typedef enum

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -701,13 +701,9 @@ static void fsm_disconnected(arq_session_t *sess, const arq_event_t *ev)
         sess->consecutive_retries = 0;
         sess->mode_hold_until_ms = 0;
         send_call_accept(sess, false);
-        {
-            const arq_mode_timing_t *tm =
-                arq_protocol_mode_timing(sess->control_mode);
-            float interval = tm ? tm->retry_interval_s : 7.0f;
-            sess_enter(sess, ARQ_CONN_CALLING,
-                       deadline_from_s(interval), ARQ_EV_TIMER_RETRY);
-        }
+        sess_enter(sess, ARQ_CONN_CALLING,
+                   deadline_from_s(arq_protocol_call_interval_s()),
+                   ARQ_EV_TIMER_RETRY);
         break;
 
     default:
@@ -811,8 +807,6 @@ static void fsm_listening(arq_session_t *sess, const arq_event_t *ev)
 
 static void fsm_calling(arq_session_t *sess, const arq_event_t *ev)
 {
-    const arq_mode_timing_t *tm;
-
     switch (ev->id)
     {
     case ARQ_EV_RX_ACCEPT:
@@ -861,8 +855,7 @@ static void fsm_calling(arq_session_t *sess, const arq_event_t *ev)
         {
             sess->tx_retries_left--;
             send_call_accept(sess, false);
-            tm = arq_protocol_mode_timing(sess->control_mode);
-            sess->deadline_ms = deadline_from_s(tm ? tm->retry_interval_s : 7.0f);
+            sess->deadline_ms = deadline_from_s(arq_protocol_call_interval_s());
         }
         else
         {
@@ -883,8 +876,6 @@ static void fsm_calling(arq_session_t *sess, const arq_event_t *ev)
 
 static void fsm_accepting(arq_session_t *sess, const arq_event_t *ev)
 {
-    const arq_mode_timing_t *tm;
-
     switch (ev->id)
     {
     case ARQ_EV_RX_DATA:
@@ -939,8 +930,7 @@ static void fsm_accepting(arq_session_t *sess, const arq_event_t *ev)
             send_call_accept(sess, true);
             /* deadline is now managed via TX_COMPLETE above; set a generous
              * fallback here in case TX_COMPLETE is missed for any reason */
-            tm = arq_protocol_mode_timing(sess->control_mode);
-            sess->deadline_ms = deadline_from_s(tm ? tm->retry_interval_s : 7.0f);
+            sess->deadline_ms = deadline_from_s(arq_protocol_call_interval_s());
         }
         else
         {

--- a/datalink_arq/arq_protocol.c
+++ b/datalink_arq/arq_protocol.c
@@ -71,12 +71,32 @@ const int arq_mode_table_count =
  * Mode timing lookup
  * ====================================================================== */
 
+/* Runtime-configurable DATAC13 call interval (set via CALLINT TCP command).
+ * 0.0 = use compiled default from arq_mode_table. */
+_Atomic float arq_callint_override_s = 0.0f;
+
 const arq_mode_timing_t *arq_protocol_mode_timing(int freedv_mode)
 {
     for (int i = 0; i < arq_mode_table_count; i++)
     {
         if (arq_mode_table[i].freedv_mode == freedv_mode)
+        {
+            if (freedv_mode == FREEDV_MODE_DATAC13)
+            {
+                float override = atomic_load(&arq_callint_override_s);
+                if (override > 0.0f)
+                {
+                    /* Return a patched copy with the overridden interval.
+                     * Static local — safe because the event loop is single-
+                     * threaded and only reads the pointer synchronously. */
+                    static arq_mode_timing_t patched;
+                    patched = arq_mode_table[i];
+                    patched.retry_interval_s = override;
+                    return &patched;
+                }
+            }
             return &arq_mode_table[i];
+        }
     }
     return NULL;
 }

--- a/datalink_arq/arq_protocol.c
+++ b/datalink_arq/arq_protocol.c
@@ -71,8 +71,10 @@ const int arq_mode_table_count =
  * Mode timing lookup
  * ====================================================================== */
 
-/* Runtime-configurable DATAC13 call interval (set via CALLINT TCP command).
- * 0.0 = use compiled default from arq_mode_table. */
+/* Runtime-configurable CALL/ACCEPT retry interval in seconds (set via
+ * CALLINT TCP command).  0.0 = use compiled default from arq_mode_table.
+ * Only affects CALL/ACCEPT retry scheduling — all other DATAC13 control
+ * frames (keepalive, disconnect, turn_req) use the immutable table values. */
 _Atomic float arq_callint_override_s = 0.0f;
 
 const arq_mode_timing_t *arq_protocol_mode_timing(int freedv_mode)
@@ -80,25 +82,19 @@ const arq_mode_timing_t *arq_protocol_mode_timing(int freedv_mode)
     for (int i = 0; i < arq_mode_table_count; i++)
     {
         if (arq_mode_table[i].freedv_mode == freedv_mode)
-        {
-            if (freedv_mode == FREEDV_MODE_DATAC13)
-            {
-                float override = atomic_load(&arq_callint_override_s);
-                if (override > 0.0f)
-                {
-                    /* Return a patched copy with the overridden interval.
-                     * Static local — safe because the event loop is single-
-                     * threaded and only reads the pointer synchronously. */
-                    static arq_mode_timing_t patched;
-                    patched = arq_mode_table[i];
-                    patched.retry_interval_s = override;
-                    return &patched;
-                }
-            }
             return &arq_mode_table[i];
-        }
     }
     return NULL;
+}
+
+float arq_protocol_call_interval_s(void)
+{
+    float override = atomic_load(&arq_callint_override_s);
+    if (override > 0.0f)
+        return override;
+
+    const arq_mode_timing_t *tm = arq_protocol_mode_timing(FREEDV_MODE_DATAC13);
+    return tm ? tm->retry_interval_s : 7.0f;
 }
 
 /* ======================================================================

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -202,9 +202,10 @@ extern _Atomic int arq_accept_retry_slots;
 extern _Atomic int arq_data_retry_slots;
 extern _Atomic int arq_disconnect_retry_slots;
 
-/* Runtime-configurable DATAC13 call interval in seconds (set via CALLINT TCP
- * command).  0.0 = use compiled default (7.0s).  Minimum enforced: 4.0s.
- * This timer starts at the start of the transmission not the end. */
+/* Runtime-configurable CALL/ACCEPT retry interval in seconds (set via CALLINT
+ * TCP command).  0.0 = use compiled default (7.0s).  Minimum enforced: 4.0s.
+ * Only affects CALL/ACCEPT retry scheduling during connection setup — all
+ * other DATAC13 control frames use the immutable table values. */
 #define ARQ_CALLINT_MIN_S      4.0f
 #define ARQ_CALLINT_DEFAULT_S  0.0f   /* 0 = use table default */
 extern _Atomic float arq_callint_override_s;
@@ -306,6 +307,12 @@ uint32_t arq_protocol_decode_ack_delay(uint8_t raw);
  * @return Pointer to timing entry, or NULL if mode is unknown.
  */
 const arq_mode_timing_t *arq_protocol_mode_timing(int freedv_mode);
+
+/**
+ * Return the CALL/ACCEPT retry interval in seconds, applying any
+ * CALLINT override.  Falls back to the DATAC13 table default (7.0s).
+ */
+float arq_protocol_call_interval_s(void);
 
 /**
  * @brief Compute CRC16-CCITT of an uppercase-normalised callsign.

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -202,6 +202,12 @@ extern _Atomic int arq_accept_retry_slots;
 extern _Atomic int arq_data_retry_slots;
 extern _Atomic int arq_disconnect_retry_slots;
 
+/* Runtime-configurable DATAC13 call interval in seconds (set via CALLINT TCP
+ * command).  0.0 = use compiled default (7.0s).  Minimum enforced: 3.0s. */
+#define ARQ_CALLINT_MIN_S      3.0f
+#define ARQ_CALLINT_DEFAULT_S  0.0f   /* 0 = use table default */
+extern _Atomic float arq_callint_override_s;
+
 #define ARQ_CALL_RETRY_SLOTS       atomic_load(&arq_call_retry_slots)
 #define ARQ_ACCEPT_RETRY_SLOTS     atomic_load(&arq_accept_retry_slots)
 #define ARQ_DATA_RETRY_SLOTS       atomic_load(&arq_data_retry_slots)

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -203,8 +203,9 @@ extern _Atomic int arq_data_retry_slots;
 extern _Atomic int arq_disconnect_retry_slots;
 
 /* Runtime-configurable DATAC13 call interval in seconds (set via CALLINT TCP
- * command).  0.0 = use compiled default (7.0s).  Minimum enforced: 3.0s. */
-#define ARQ_CALLINT_MIN_S      3.0f
+ * command).  0.0 = use compiled default (7.0s).  Minimum enforced: 4.0s.
+ * This timer starts at the start of the transmission not the end. */
+#define ARQ_CALLINT_MIN_S      4.0f
 #define ARQ_CALLINT_DEFAULT_S  0.0f   /* 0 = use table default */
 extern _Atomic float arq_callint_override_s;
 

--- a/docs/TNC.md
+++ b/docs/TNC.md
@@ -306,11 +306,10 @@ RETRIES 10\r
 
 ### CALLINT
 
-Override the interval in **whole seconds** between successive CALL frame
-attempts during connection setup.  This only affects the DATAC13 control
-channel used for CALL/ACCEPT — it has no effect on data frame retry timing
-once a session is established.  This timer starts at the beginning of the
-transmission cycle.
+Override the interval in **whole seconds** between successive CALL/ACCEPT
+frame retries during connection setup.  This has no effect on other control
+frame timing (keepalive, disconnect, turn request) or on data frame retry
+timing once a session is established.
 
 Send `0` to restore the compiled default (7 seconds).  The minimum
 enforced value is 4 seconds; values below 4 are clamped to 4 to avoid

--- a/docs/TNC.md
+++ b/docs/TNC.md
@@ -304,6 +304,26 @@ RETRIES 10\r
 
 ---
 
+### CALLINT
+
+Override the interval in **whole seconds** between successive CALL frame
+attempts during connection setup.  This only affects the DATAC13 control
+channel used for CALL/ACCEPT — it has no effect on data frame retry timing
+once a session is established.
+
+Send `0` to restore the compiled default (7 seconds).  The minimum
+enforced value is 3 seconds; values below 3 are clamped to 3 to avoid
+firing a retry before a valid ACCEPT can return over the air.
+
+```
+CALLINT 5\r
+CALLINT 0\r
+```
+
+**Response:** `OK\r` on success, `WRONG\r` on error.
+
+---
+
 
 ## Asynchronous Responses (Mercury → Client)
 

--- a/docs/TNC.md
+++ b/docs/TNC.md
@@ -309,10 +309,11 @@ RETRIES 10\r
 Override the interval in **whole seconds** between successive CALL frame
 attempts during connection setup.  This only affects the DATAC13 control
 channel used for CALL/ACCEPT — it has no effect on data frame retry timing
-once a session is established.
+once a session is established.  This timer starts at the beginning of the
+transmission cycle.
 
 Send `0` to restore the compiled default (7 seconds).  The minimum
-enforced value is 3 seconds; values below 3 are clamped to 3 to avoid
+enforced value is 4 seconds; values below 4 are clamped to 4 to avoid
 firing a retry before a valid ACCEPT can return over the air.
 
 ```

--- a/tests/data_interfaces/test_tcp_interfaces.c
+++ b/tests/data_interfaces/test_tcp_interfaces.c
@@ -498,6 +498,52 @@ void test_cmd_listen_cq(void)
     TEST_ASSERT_EQUAL_INT(ARQ_CMD_LISTEN_ON, captured_cmd.type);
 }
 
+/* ---- CALLINT command tests ---- */
+
+void test_cmd_callint_valid(void)
+{
+    char cmd[] = "CALLINT 5";
+    execute_control_command(cmd);
+
+    assert_ok_response();
+    TEST_ASSERT_EQUAL_INT(ARQ_CMD_SET_CALLINT, captured_cmd.type);
+    TEST_ASSERT_EQUAL_INT(5, captured_cmd.value);
+}
+
+void test_cmd_callint_zero(void)
+{
+    char cmd[] = "CALLINT 0";
+    execute_control_command(cmd);
+
+    assert_ok_response();
+    TEST_ASSERT_EQUAL_INT(ARQ_CMD_SET_CALLINT, captured_cmd.type);
+    TEST_ASSERT_EQUAL_INT(0, captured_cmd.value);
+}
+
+void test_cmd_callint_no_arg(void)
+{
+    char cmd[] = "CALLINT";
+    execute_control_command(cmd);
+
+    assert_wrong_response();
+}
+
+void test_cmd_callint_nonnumeric(void)
+{
+    char cmd[] = "CALLINT abc";
+    execute_control_command(cmd);
+
+    assert_wrong_response();
+}
+
+void test_cmd_callint_negative(void)
+{
+    char cmd[] = "CALLINT -1";
+    execute_control_command(cmd);
+
+    assert_wrong_response();
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -523,6 +569,12 @@ int main(void)
     RUN_TEST(test_cmd_version);
     RUN_TEST(test_cmd_ignorekissdcd);
     RUN_TEST(test_cmd_listen_cq);
+    /* CALLINT command tests */
+    RUN_TEST(test_cmd_callint_valid);
+    RUN_TEST(test_cmd_callint_zero);
+    RUN_TEST(test_cmd_callint_no_arg);
+    RUN_TEST(test_cmd_callint_nonnumeric);
+    RUN_TEST(test_cmd_callint_negative);
     RUN_TEST(test_process_control_bytes_multiline);
     /* Status emitter tests */
     RUN_TEST(test_tnc_send_disconnected);

--- a/tests/datalink_arq/test_arq_protocol.c
+++ b/tests/datalink_arq/test_arq_protocol.c
@@ -10,6 +10,7 @@
 
 #include <string.h>
 #include <stdint.h>
+#include <stdatomic.h>
 
 #include "unity.h"
 #include "arq_protocol.h"
@@ -17,7 +18,12 @@
 #include "framer.h"
 #include "freedv/freedv_api.h"
 
-void setUp(void) { }
+void setUp(void)
+{
+    /* Reset CALLINT override before each test so tests are isolated */
+    atomic_store(&arq_callint_override_s, 0.0f);
+}
+
 void tearDown(void) { }
 
 /* ---- Header encode/decode ---- */
@@ -191,6 +197,45 @@ void test_mode_timing_invalid(void)
     TEST_ASSERT_NULL(t);
 }
 
+/* ---- CALLINT / call interval override ---- */
+
+void test_call_interval_default(void)
+{
+    /* Override is 0 (default) → should return DATAC13 table value (7.0s) */
+    float interval = arq_protocol_call_interval_s();
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 7.0f, interval);
+}
+
+void test_call_interval_override(void)
+{
+    /* Set override to 5.0s → should return 5.0s */
+    atomic_store(&arq_callint_override_s, 5.0f);
+    float interval = arq_protocol_call_interval_s();
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 5.0f, interval);
+}
+
+void test_call_interval_reset(void)
+{
+    /* Set override, then reset to 0 → should return table default */
+    atomic_store(&arq_callint_override_s, 5.0f);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 5.0f, arq_protocol_call_interval_s());
+
+    atomic_store(&arq_callint_override_s, ARQ_CALLINT_DEFAULT_S);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 7.0f, arq_protocol_call_interval_s());
+}
+
+void test_mode_timing_datac13_unaffected_by_override(void)
+{
+    /* Even with CALLINT override active, arq_protocol_mode_timing() must
+     * return the immutable table entry — the override only takes effect
+     * through arq_protocol_call_interval_s(). */
+    atomic_store(&arq_callint_override_s, 5.0f);
+
+    const arq_mode_timing_t *t = arq_protocol_mode_timing(FREEDV_MODE_DATAC13);
+    TEST_ASSERT_NOT_NULL(t);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 7.0f, t->retry_interval_s);
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -214,5 +259,10 @@ int main(void)
     /* Mode timing */
     RUN_TEST(test_mode_timing_datac4);
     RUN_TEST(test_mode_timing_invalid);
+    /* CALLINT / call interval override */
+    RUN_TEST(test_call_interval_default);
+    RUN_TEST(test_call_interval_override);
+    RUN_TEST(test_call_interval_reset);
+    RUN_TEST(test_mode_timing_datac13_unaffected_by_override);
     return UNITY_END();
 }


### PR DESCRIPTION
This command allows us to adjust the timing between connection requests.

It is probably only useful to those of us using a BBS with mercury to adjust the wait time for a connection ACK before sending the next one.   If this window is too long (default) in some cases our radios may have changed frequency as we run systems that scan frequencies by changing the vfo every X seconds.  In my cause I use 7 for the scan duration as I found it works best with the now 5 modems here that are possible to use on my node/bbs.
So the pause CALLINT should be around 4-5 here in my case.
