### PR TITLE
Add implementation plan for ARQ robustness and TX gain control

### DIFF
--- a/common/cfg_utils.c
+++ b/common/cfg_utils.c
@@ -49,6 +49,7 @@ void cfg_set_defaults(mercury_config *cfg)
     cfg->hamlib_log_level   = 0;
     cfg->radio_serial_speed = 0;  /* 0 = use hamlib default */
     cfg->no_progress_timeout_s = ARQ_NO_PROGRESS_TIMEOUT_S_DEFAULT;
+    cfg->tx_gain_db            = 0.0f;
 }
 
 /* Map a sound-system name to the AUDIO_SUBSYSTEM_* constant.
@@ -157,6 +158,11 @@ bool cfg_read(mercury_config *cfg, const char *ini_path)
     if (i > 0)
         cfg->no_progress_timeout_s = i;
 
+    double d = iniparser_getdouble(ini, CFG_KEY_TX_GAIN_DB, (double)cfg->tx_gain_db);
+    if (d < -20.0) d = -20.0;
+    if (d >  20.0) d =  20.0;
+    cfg->tx_gain_db = (float)d;
+
     iniparser_freedict(ini);
     return true;
 }
@@ -238,6 +244,9 @@ bool cfg_write(const mercury_config *cfg, const char *ini_path)
 
     fprintf(f, "\n[arq]\n");
     fprintf(f, "no_progress_timeout_s = %d\n", cfg->no_progress_timeout_s);
+
+    fprintf(f, "\n[audio]\n");
+    fprintf(f, "tx_gain_db = %.2f\n", cfg->tx_gain_db);
 
     fclose(f);
     return true;

--- a/common/cfg_utils.c
+++ b/common/cfg_utils.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <math.h>
 
 #include "cfg_utils.h"
 #include "../audioio/audioio.h"
@@ -164,6 +165,7 @@ bool cfg_read(mercury_config *cfg, const char *ini_path)
         cfg->disconnect_drain_timeout_s = i;
 
     double d = iniparser_getdouble(ini, CFG_KEY_TX_GAIN_DB, (double)cfg->tx_gain_db);
+    if (!isfinite(d)) d = 0.0;  /* malformed/non-finite INI value -> default */
     if (d < -20.0) d = -20.0;
     if (d >  20.0) d =  20.0;
     cfg->tx_gain_db = (float)d;

--- a/common/cfg_utils.c
+++ b/common/cfg_utils.c
@@ -28,6 +28,7 @@
 #include "../radio_io/radio_io.h"
 #include "../data_interfaces/tcp_interfaces.h"
 #include "../gui_interface/ui_communication.h"
+#include "../datalink_arq/arq_protocol.h"
 
 void cfg_set_defaults(mercury_config *cfg)
 {
@@ -47,6 +48,7 @@ void cfg_set_defaults(mercury_config *cfg)
     cfg->freedv_verbosity   = 0;
     cfg->hamlib_log_level   = 0;
     cfg->radio_serial_speed = 0;  /* 0 = use hamlib default */
+    cfg->no_progress_timeout_s = ARQ_NO_PROGRESS_TIMEOUT_S_DEFAULT;
 }
 
 /* Map a sound-system name to the AUDIO_SUBSYSTEM_* constant.
@@ -151,6 +153,10 @@ bool cfg_read(mercury_config *cfg, const char *ini_path)
     if (i >= 0)
         cfg->radio_serial_speed = i;
 
+    i = iniparser_getint(ini, CFG_KEY_NO_PROGRESS_TIMEOUT_S, cfg->no_progress_timeout_s);
+    if (i > 0)
+        cfg->no_progress_timeout_s = i;
+
     iniparser_freedict(ini);
     return true;
 }
@@ -229,6 +235,9 @@ bool cfg_write(const mercury_config *cfg, const char *ini_path)
     fprintf(f, "freedv_verbosity = %d\n",  cfg->freedv_verbosity);
     fprintf(f, "hamlib_log_level = %d\n",  cfg->hamlib_log_level);
     fprintf(f, "radio_serial_speed = %d\n", cfg->radio_serial_speed);
+
+    fprintf(f, "\n[arq]\n");
+    fprintf(f, "no_progress_timeout_s = %d\n", cfg->no_progress_timeout_s);
 
     fclose(f);
     return true;

--- a/common/cfg_utils.c
+++ b/common/cfg_utils.c
@@ -49,6 +49,7 @@ void cfg_set_defaults(mercury_config *cfg)
     cfg->hamlib_log_level   = 0;
     cfg->radio_serial_speed = 0;  /* 0 = use hamlib default */
     cfg->no_progress_timeout_s = ARQ_NO_PROGRESS_TIMEOUT_S_DEFAULT;
+    cfg->disconnect_drain_timeout_s = ARQ_DISCONNECT_DRAIN_TIMEOUT_S_DEFAULT;
     cfg->tx_gain_db            = 0.0f;
 }
 
@@ -158,6 +159,10 @@ bool cfg_read(mercury_config *cfg, const char *ini_path)
     if (i > 0)
         cfg->no_progress_timeout_s = i;
 
+    i = iniparser_getint(ini, CFG_KEY_DISCONNECT_DRAIN_TIMEOUT_S, cfg->disconnect_drain_timeout_s);
+    if (i > 0)
+        cfg->disconnect_drain_timeout_s = i;
+
     double d = iniparser_getdouble(ini, CFG_KEY_TX_GAIN_DB, (double)cfg->tx_gain_db);
     if (d < -20.0) d = -20.0;
     if (d >  20.0) d =  20.0;
@@ -244,6 +249,7 @@ bool cfg_write(const mercury_config *cfg, const char *ini_path)
 
     fprintf(f, "\n[arq]\n");
     fprintf(f, "no_progress_timeout_s = %d\n", cfg->no_progress_timeout_s);
+    fprintf(f, "disconnect_drain_timeout_s = %d\n", cfg->disconnect_drain_timeout_s);
 
     fprintf(f, "\n[audio]\n");
     fprintf(f, "tx_gain_db = %.2f\n", cfg->tx_gain_db);

--- a/common/cfg_utils.h
+++ b/common/cfg_utils.h
@@ -65,7 +65,7 @@ typedef struct {
     int      radio_serial_speed;   /* 0 = use hamlib default */
     int      no_progress_timeout_s;/* ARQ: disconnect when no forward progress
                                     * (no advancing ACK) for this many seconds
-                                    * after data-retry exhaustion. Default 600. */
+                                    * after data-retry exhaustion. Default 180. */
     int      disconnect_drain_timeout_s;/* ARQ: absolute cap (s) on how long an
                                     * app DISCONNECT stays deferred while
                                     * draining the last TX bytes. Default 30. */

--- a/common/cfg_utils.h
+++ b/common/cfg_utils.h
@@ -41,6 +41,7 @@
 #define CFG_KEY_FREEDV_VERBOSITY    "main:freedv_verbosity"
 #define CFG_KEY_HAMLIB_LOG_LEVEL    "main:hamlib_log_level"
 #define CFG_KEY_RADIO_SERIAL_SPEED  "main:radio_serial_speed"
+#define CFG_KEY_NO_PROGRESS_TIMEOUT_S "arq:no_progress_timeout_s"
 
 /* Holds all values read from the init configuration file */
 typedef struct {
@@ -60,6 +61,9 @@ typedef struct {
     int      freedv_verbosity;      /* 0..3 */
     int      hamlib_log_level;      /* 0..6 */
     int      radio_serial_speed;   /* 0 = use hamlib default */
+    int      no_progress_timeout_s;/* ARQ: disconnect when no forward progress
+                                    * (no advancing ACK) for this many seconds
+                                    * after data-retry exhaustion. Default 600. */
 } mercury_config;
 
 /* Load configuration from an INI file into |cfg|.

--- a/common/cfg_utils.h
+++ b/common/cfg_utils.h
@@ -42,6 +42,7 @@
 #define CFG_KEY_HAMLIB_LOG_LEVEL    "main:hamlib_log_level"
 #define CFG_KEY_RADIO_SERIAL_SPEED  "main:radio_serial_speed"
 #define CFG_KEY_NO_PROGRESS_TIMEOUT_S "arq:no_progress_timeout_s"
+#define CFG_KEY_TX_GAIN_DB          "audio:tx_gain_db"
 
 /* Holds all values read from the init configuration file */
 typedef struct {
@@ -64,6 +65,9 @@ typedef struct {
     int      no_progress_timeout_s;/* ARQ: disconnect when no forward progress
                                     * (no advancing ACK) for this many seconds
                                     * after data-retry exhaustion. Default 600. */
+    float    tx_gain_db;            /* Linear-equivalent gain on the modulator
+                                    * TX samples, in dB. 0.0 = no change.
+                                    * Range -20.0 .. +20.0 (clamped). */
 } mercury_config;
 
 /* Load configuration from an INI file into |cfg|.

--- a/common/cfg_utils.h
+++ b/common/cfg_utils.h
@@ -42,6 +42,7 @@
 #define CFG_KEY_HAMLIB_LOG_LEVEL    "main:hamlib_log_level"
 #define CFG_KEY_RADIO_SERIAL_SPEED  "main:radio_serial_speed"
 #define CFG_KEY_NO_PROGRESS_TIMEOUT_S "arq:no_progress_timeout_s"
+#define CFG_KEY_DISCONNECT_DRAIN_TIMEOUT_S "arq:disconnect_drain_timeout_s"
 #define CFG_KEY_TX_GAIN_DB          "audio:tx_gain_db"
 
 /* Holds all values read from the init configuration file */
@@ -65,6 +66,9 @@ typedef struct {
     int      no_progress_timeout_s;/* ARQ: disconnect when no forward progress
                                     * (no advancing ACK) for this many seconds
                                     * after data-retry exhaustion. Default 600. */
+    int      disconnect_drain_timeout_s;/* ARQ: absolute cap (s) on how long an
+                                    * app DISCONNECT stays deferred while
+                                    * draining the last TX bytes. Default 30. */
     float    tx_gain_db;            /* Linear-equivalent gain on the modulator
                                     * TX samples, in dB. 0.0 = no change.
                                     * Range -20.0 .. +20.0 (clamped). */

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -912,6 +912,16 @@ void clear_connection_data(void)
     clear_buffer(data_tx_buffer_arq_control);
 }
 
+void arq_set_no_progress_timeout_s(int seconds)
+{
+    if (seconds > 0)
+        atomic_store(&arq_no_progress_timeout_s, seconds);
+    else
+        atomic_store(&arq_no_progress_timeout_s, ARQ_NO_PROGRESS_TIMEOUT_S_DEFAULT);
+    HLOGI(LOG_COMP, "ARQ no-progress timeout: %ds",
+          atomic_load(&arq_no_progress_timeout_s));
+}
+
 void arq_set_retry_slots(int slots)
 {
     if (slots <= 0)

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -396,13 +396,14 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
     }
 
     case ARQ_CMD_DISCONNECT:
-        /* VARA TNC spec: notify host immediately. */
+        /* VARA TNC spec: send DISCONNECTED to host immediately on receiving
+         * DISCONNECT command, before the over-the-air exchange completes.
+         * This lets the host close the socket cleanly while the FSM handles
+         * the air-side teardown.  We deliberately do NOT clear g_app_tx_buf
+         * here: the FSM drains any bytes still queued, then completes a clean
+         * air-side DISCONNECT handshake.  The retry-exhaustion path bounds the
+         * drain so a dead channel still tears down quickly (see arq_fsm.c). */
         tnc_send_disconnected();
-        /* Clear app TX buffer so FSM sees no pending data and does not
-        * defer the DISCONNECT while trying to drain bytes already abandoned. */
-        pthread_mutex_lock(&g_app_tx_mtx);
-        clear_buffer(g_app_tx_buf);
-        pthread_mutex_unlock(&g_app_tx_mtx);
         ev.id = ARQ_EV_APP_DISCONNECT;
         break;
 
@@ -416,9 +417,6 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
         break;
 
     case ARQ_CMD_CLIENT_DISCONNECT:
-        pthread_mutex_lock(&g_app_tx_mtx);
-        clear_buffer(g_app_tx_buf);
-        pthread_mutex_unlock(&g_app_tx_mtx);
         ev.id = ARQ_EV_APP_DISCONNECT;
         break;
 

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -925,6 +925,17 @@ void arq_set_no_progress_timeout_s(int seconds)
           atomic_load(&arq_no_progress_timeout_s));
 }
 
+void arq_set_disconnect_drain_timeout_s(int seconds)
+{
+    if (seconds > 0)
+        atomic_store(&arq_disconnect_drain_timeout_s, seconds);
+    else
+        atomic_store(&arq_disconnect_drain_timeout_s,
+                     ARQ_DISCONNECT_DRAIN_TIMEOUT_S_DEFAULT);
+    HLOGI(LOG_COMP, "ARQ disconnect drain timeout: %ds",
+          atomic_load(&arq_disconnect_drain_timeout_s));
+}
+
 void arq_set_retry_slots(int slots)
 {
     if (slots <= 0)

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -396,11 +396,13 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
     }
 
     case ARQ_CMD_DISCONNECT:
-        /* VARA TNC spec: send DISCONNECTED to host immediately on receiving
-         * DISCONNECT command, before the over-the-air exchange completes.
-         * This lets the host close the socket cleanly while the FSM handles
-         * the air-side teardown. */
+        /* VARA TNC spec: notify host immediately. */
         tnc_send_disconnected();
+        /* Clear app TX buffer so FSM sees no pending data and does not
+        * defer the DISCONNECT while trying to drain bytes already abandoned. */
+        pthread_mutex_lock(&g_app_tx_mtx);
+        clear_buffer(g_app_tx_buf);
+        pthread_mutex_unlock(&g_app_tx_mtx);
         ev.id = ARQ_EV_APP_DISCONNECT;
         break;
 
@@ -414,6 +416,9 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
         break;
 
     case ARQ_CMD_CLIENT_DISCONNECT:
+        pthread_mutex_lock(&g_app_tx_mtx);
+        clear_buffer(g_app_tx_buf);
+        pthread_mutex_unlock(&g_app_tx_mtx);
         ev.id = ARQ_EV_APP_DISCONNECT;
         break;
 

--- a/datalink_arq/arq.h
+++ b/datalink_arq/arq.h
@@ -172,6 +172,14 @@ int arq_get_tx_backlog_bytes(void);
 void arq_set_no_progress_timeout_s(int seconds);
 
 /**
+ * @brief Set the absolute cap on how long an app DISCONNECT may stay deferred
+ *        while draining the last TX bytes.
+ * @param seconds Window in seconds.  Values <= 0 reset to the compiled
+ *                default (ARQ_DISCONNECT_DRAIN_TIMEOUT_S_DEFAULT).
+ */
+void arq_set_disconnect_drain_timeout_s(int seconds);
+
+/**
  * @brief Get current ARQ speed level (gear).
  * @return Speed level index.
  */

--- a/datalink_arq/arq.h
+++ b/datalink_arq/arq.h
@@ -165,6 +165,13 @@ int arq_queue_data(const uint8_t *data, size_t len);
 int arq_get_tx_backlog_bytes(void);
 
 /**
+ * @brief Set the ARQ no-progress disconnect budget.
+ * @param seconds Budget in seconds.  Values <= 0 reset to the compiled
+ *                default (ARQ_NO_PROGRESS_TIMEOUT_S_DEFAULT).
+ */
+void arq_set_no_progress_timeout_s(int seconds);
+
+/**
  * @brief Get current ARQ speed level (gear).
  * @return Speed level index.
  */

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -1257,12 +1257,24 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                 uint64_t budget_ms = (uint64_t)ARQ_NO_PROGRESS_TIMEOUT_S * 1000ULL;
                 bool no_progress_dead = sess->last_tx_progress_ms != 0 &&
                                         (now - sess->last_tx_progress_ms) >= budget_ms;
-                if (no_progress_dead)
+                /* The application has already asked to disconnect and we are
+                 * only draining its final bytes.  Persistence is for data the
+                 * app still wants delivered; once it has said "disconnect",
+                 * the contract is bounded effort then a CLEAN air-side
+                 * teardown.  Hammering the channel for the full no-progress
+                 * budget here leaves BPQ32 thinking it disconnected cleanly
+                 * while Mercury keys the rig for minutes and the peer times
+                 * out — the "dirty disconnect" Gary/K7EK reported.  So treat a
+                 * pending disconnect like the dead-channel case: stop draining
+                 * and complete the DISCONNECT handshake now. */
+                if (no_progress_dead || sess->pending_disconnect)
                 {
                     HLOGW(LOG_COMP,
-                          "Data retry exhausted seq=%d, no progress for %llus — disconnecting",
+                          "Data retry exhausted seq=%d (%s) — disconnecting",
                           (int)sess->tx_seq,
-                          (unsigned long long)((now - sess->last_tx_progress_ms) / 1000));
+                          sess->pending_disconnect ? "app disconnect pending"
+                                                   : "no forward progress");
+                    sess->pending_disconnect = false;
                     send_ctrl_frame(sess, ARQ_SUBTYPE_DISCONNECT);
                     sess->tx_retries_left = ARQ_DISCONNECT_RETRY_SLOTS;
                     tm = arq_protocol_mode_timing(sess->control_mode);

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -158,6 +158,17 @@ static void sess_enter(arq_session_t *sess, arq_conn_state_t new_state,
         sess->pending_connect_confirm = false;
         sess->need_initial_guard = false;
     }
+    else
+    {
+        /* Seed the no-progress clock at connection establishment so the
+         * wall-clock disconnect budget always has a baseline.  Without this,
+         * a session that never lands an advancing ACK (e.g. one-way TX
+         * failure while peer keepalives still arrive) would leave
+         * last_tx_progress_ms at 0 and persist forever after retry
+         * exhaustion.  Advancing ACKs refresh this timestamp during data
+         * flow (see fsm_dflow). */
+        sess->last_tx_progress_ms = hermes_uptime_ms();
+    }
     /* Reset data-flow and mode state when returning to idle connection states.
      * Restore peer_tx_mode to initial_payload_mode (= broadcast mode) so the
      * payload decoder can receive broadcast frames while LISTENING.  The
@@ -1040,11 +1051,15 @@ static void fsm_connected(arq_session_t *sess, const arq_event_t *ev)
     switch (ev->id)
     {
     case ARQ_EV_APP_DISCONNECT:
-        /* Defer DISCONNECT only while a frame is physically being transmitted
-         * (PTT on) or the TX buffer still has unsent bytes.  We must NOT defer
-         * when in WAIT_ACK: the frame is already sent (PTT off) and the peer
-         * may never ACK it; waiting up to 10×12 s before honouring the
-         * application's explicit disconnect request is unacceptable. */
+        /* Defer DISCONNECT while a frame is physically being transmitted
+         * (PTT on, DATA_TX) or the TX buffer still has unsent bytes, so the
+         * last application bytes get delivered before teardown.  The deferral
+         * is bounded three ways and can never hang: (1) retry exhaustion with
+         * a pending disconnect tears down immediately, (2) the absolute
+         * disconnect_drain_timeout_s deadline armed below forces teardown
+         * regardless of FSM state, and (3) a drained buffer fires the
+         * deferred disconnect at the next idle-ISS entry.  An idle WAIT_ACK
+         * with no backlog falls through to immediate teardown below. */
         if ((g_cbs.tx_backlog && g_cbs.tx_backlog() > 0) ||
             sess->dflow_state == ARQ_DFLOW_DATA_TX)
         {

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -1199,6 +1199,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
             sess->tx_retransmit_len = 0;  /* ACKed — discard retransmit buffer */
             sess->tx_inflight_bytes = 0;  /* payload confirmed by peer */
             sess->tx_retries_left   = ARQ_DATA_RETRY_SLOTS;  /* fresh counter for next seq */
+            sess->last_tx_progress_ms = hermes_uptime_ms();  /* forward progress */
             sess->peer_has_data = (ev->rx_flags & ARQ_FLAG_HAS_DATA) != 0;
             if (g_cbs.send_buffer_status)
                 g_cbs.send_buffer_status(g_cbs.tx_backlog ? g_cbs.tx_backlog() : 0);
@@ -1246,14 +1247,47 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
             }
             else
             {
-                HLOGW(LOG_COMP, "Data retry exhausted seq=%d — disconnecting",
-                      (int)sess->tx_seq);
-                send_ctrl_frame(sess, ARQ_SUBTYPE_DISCONNECT);
-                sess->tx_retries_left = ARQ_DISCONNECT_RETRY_SLOTS;
-                tm = arq_protocol_mode_timing(sess->control_mode);
-                sess_enter(sess, ARQ_CONN_DISCONNECTING,
-                           deadline_from_s(tm ? tm->retry_interval_s : 7.0f),
-                           ARQ_EV_TIMER_RETRY);
+                /* Retry budget exhausted — disconnect only if we're past the
+                 * absolute no-progress wall-clock budget.  Otherwise reset the
+                 * retry counter and keep banging at the channel: VARA-like
+                 * persistence beats Pactor-like give-up.  Bumping
+                 * consecutive_retries lets select_best_mode pull us down to a
+                 * more robust mode the next time a decision point runs. */
+                uint64_t now = hermes_uptime_ms();
+                uint64_t budget_ms = (uint64_t)ARQ_NO_PROGRESS_TIMEOUT_S * 1000ULL;
+                bool no_progress_dead = sess->last_tx_progress_ms != 0 &&
+                                        (now - sess->last_tx_progress_ms) >= budget_ms;
+                if (no_progress_dead)
+                {
+                    HLOGW(LOG_COMP,
+                          "Data retry exhausted seq=%d, no progress for %llus — disconnecting",
+                          (int)sess->tx_seq,
+                          (unsigned long long)((now - sess->last_tx_progress_ms) / 1000));
+                    send_ctrl_frame(sess, ARQ_SUBTYPE_DISCONNECT);
+                    sess->tx_retries_left = ARQ_DISCONNECT_RETRY_SLOTS;
+                    tm = arq_protocol_mode_timing(sess->control_mode);
+                    sess_enter(sess, ARQ_CONN_DISCONNECTING,
+                               deadline_from_s(tm ? tm->retry_interval_s : 7.0f),
+                               ARQ_EV_TIMER_RETRY);
+                }
+                else
+                {
+                    unsigned long long since_s =
+                        sess->last_tx_progress_ms != 0
+                        ? (unsigned long long)((now - sess->last_tx_progress_ms) / 1000)
+                        : 0ULL;
+                    HLOGI(LOG_COMP,
+                          "Data retry exhausted seq=%d, persisting (%llus / %ds budget)",
+                          (int)sess->tx_seq, since_s, ARQ_NO_PROGRESS_TIMEOUT_S);
+                    if (g_timing)
+                        arq_timing_record_retry(g_timing, (int)sess->tx_seq,
+                                                ARQ_DATA_RETRY_SLOTS,
+                                                "persist_after_exhaust");
+                    sess->tx_retries_left = ARQ_DATA_RETRY_SLOTS;
+                    sess->consecutive_retries++;
+                    dflow_enter(sess, ARQ_DFLOW_DATA_TX, UINT64_MAX, ARQ_EV_TIMER_RETRY);
+                    send_data_frame(sess);
+                }
             }
         }
         else if (ev->id == ARQ_EV_RX_DATA)
@@ -1276,6 +1310,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                 sess->tx_retransmit_len = 0;
                 sess->tx_inflight_bytes = 0;
                 sess->tx_retries_left   = ARQ_DATA_RETRY_SLOTS;
+                sess->last_tx_progress_ms = hermes_uptime_ms();
                 sess->peer_has_data = (ev->rx_flags & ARQ_FLAG_HAS_DATA) != 0;
                 if (g_cbs.send_buffer_status)
                     g_cbs.send_buffer_status(g_cbs.tx_backlog ? g_cbs.tx_backlog() : 0);

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -377,8 +377,15 @@ static bool maybe_upgrade_mode(arq_session_t *sess)
     if (hermes_uptime_ms() < sess->startup_deadline_ms)
         return false;
 
-    /* Need at least one valid SNR reading from the peer before deciding. */
-    if (sess->peer_snr_x10 == 0)
+    /* Normally we need at least one valid peer SNR reading before deciding.
+     * Exception: a retry-forced downgrade is driven purely by delivery
+     * failure (consecutive_retries), not SNR — select_best_mode's safety net
+     * steps the mode down regardless of SNR.  Allow it through even with no
+     * SNR estimate, otherwise a link that never lands an advancing ACK (so
+     * peer_snr_x10 stays 0) would keep retransmitting at a too-fast mode
+     * forever, defeating the persist-after-exhaustion downgrade. */
+    if (sess->peer_snr_x10 == 0 &&
+        sess->consecutive_retries < ARQ_RETRY_DOWNGRADE_THRESHOLD)
         return false;
 
     int backlog = g_cbs.tx_backlog ? g_cbs.tx_backlog() : 0;

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -693,6 +693,7 @@ static void fsm_disconnected(arq_session_t *sess, const arq_event_t *ev)
         sess->session_id      = (uint8_t)(hermes_uptime_ms() & 0x7F) | 0x01;
         sess->tx_retries_left = ARQ_CALL_RETRY_SLOTS;
         sess->pending_disconnect = false;  /* clear stale deferred disconnect from prior session */
+        sess->disconnect_deadline_ms = 0;
         /* Reset mode state for new session */
         sess->payload_mode       = FREEDV_MODE_DATAC4;
         sess->peer_tx_mode       = FREEDV_MODE_DATAC4;
@@ -1014,6 +1015,28 @@ static void fsm_connected(arq_session_t *sess, const arq_event_t *ev)
 {
     const arq_mode_timing_t *tm;
 
+    /* Fallback for a deferred APP_DISCONNECT that the normal fire points
+     * (idle-ISS entry, WAIT_ACK ack-timer, retry exhaustion) never reach —
+     * e.g. a session stuck ping-ponging keepalives or pinned as IRS.  Once
+     * the drain deadline elapses, force a clean air-side teardown regardless
+     * of role or backlog so the rig is never keyed indefinitely after the
+     * host has disconnected (K7EK "Mercury kept hanging on"). */
+    if (sess->pending_disconnect && sess->disconnect_deadline_ms != 0 &&
+        hermes_uptime_ms() >= sess->disconnect_deadline_ms)
+    {
+        HLOGW(LOG_COMP,
+              "Deferred DISCONNECT drain timeout (%ds) — forcing teardown",
+              ARQ_DISCONNECT_DRAIN_TIMEOUT_S);
+        sess->pending_disconnect      = false;
+        sess->disconnect_deadline_ms  = 0;
+        sess->tx_retries_left         = ARQ_DISCONNECT_RETRY_SLOTS;
+        sess->disconnect_to_no_client = false;
+        sess_enter(sess, ARQ_CONN_DISCONNECTING,
+                   hermes_uptime_ms() + ARQ_CHANNEL_GUARD_MS,
+                   ARQ_EV_TIMER_ACK);
+        return;
+    }
+
     switch (ev->id)
     {
     case ARQ_EV_APP_DISCONNECT:
@@ -1030,6 +1053,9 @@ static void fsm_connected(arq_session_t *sess, const arq_event_t *ev)
                   g_cbs.tx_backlog ? g_cbs.tx_backlog() : 0,
                   arq_dflow_state_name(sess->dflow_state));
             sess->pending_disconnect = true;
+            sess->disconnect_deadline_ms =
+                hermes_uptime_ms() +
+                (uint64_t)ARQ_DISCONNECT_DRAIN_TIMEOUT_S * 1000ULL;
             return;
         }
         sess->pending_disconnect      = false;

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -1303,8 +1303,8 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                  * more robust mode the next time a decision point runs. */
                 uint64_t now = hermes_uptime_ms();
                 uint64_t budget_ms = (uint64_t)ARQ_NO_PROGRESS_TIMEOUT_S * 1000ULL;
-                bool no_progress_dead = sess->last_tx_progress_ms != 0 &&
-                                        (now - sess->last_tx_progress_ms) >= budget_ms;
+                bool no_progress_dead =
+                    (now - sess->last_tx_progress_ms) >= budget_ms;
                 /* The application has already asked to disconnect and we are
                  * only draining its final bytes.  Persistence is for data the
                  * app still wants delivered; once it has said "disconnect",
@@ -1333,9 +1333,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                 else
                 {
                     unsigned long long since_s =
-                        sess->last_tx_progress_ms != 0
-                        ? (unsigned long long)((now - sess->last_tx_progress_ms) / 1000)
-                        : 0ULL;
+                        (unsigned long long)((now - sess->last_tx_progress_ms) / 1000);
                     HLOGI(LOG_COMP,
                           "Data retry exhausted seq=%d, persisting (%llus / %ds budget)",
                           (int)sess->tx_seq, since_s, ARQ_NO_PROGRESS_TIMEOUT_S);

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -1284,7 +1284,21 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                                                 ARQ_DATA_RETRY_SLOTS,
                                                 "persist_after_exhaust");
                     sess->tx_retries_left = ARQ_DATA_RETRY_SLOTS;
-                    sess->consecutive_retries++;
+
+                    /* Channel couldn't deliver a frame in ARQ_DATA_RETRY_SLOTS
+                     * attempts — force the delivery-feedback safety net to
+                     * threshold so select_best_mode pulls payload_mode one
+                     * step lower.  maybe_upgrade_mode handles the MODE_REQ /
+                     * MODE_ACK negotiation; on success the FSM is now in
+                     * MODE_REQ_TX state and will resume DATA_TX at the lower
+                     * mode after MODE_ACK.  On failure (no peer SNR yet,
+                     * MODE_REQ retries exhaust, already at slowest mode)
+                     * fall through and retransmit at the current mode. */
+                    if (sess->consecutive_retries < ARQ_RETRY_DOWNGRADE_THRESHOLD)
+                        sess->consecutive_retries = ARQ_RETRY_DOWNGRADE_THRESHOLD;
+                    if (maybe_upgrade_mode(sess))
+                        return;
+
                     dflow_enter(sess, ARQ_DFLOW_DATA_TX, UINT64_MAX, ARQ_EV_TIMER_RETRY);
                     send_data_frame(sess);
                 }

--- a/datalink_arq/arq_fsm.h
+++ b/datalink_arq/arq_fsm.h
@@ -233,10 +233,9 @@ typedef struct
     /* --- Keepalive tracking --- */
     int      keepalive_miss_count;
     uint64_t last_rx_ms;              /* last successful frame decode time     */
-    uint64_t last_tx_progress_ms;     /* last time tx_seq advanced (forward
-                                       * progress).  0 = no progress yet — used
-                                       * by the no-progress disconnect budget
-                                       * in the data-retry-exhausted path.    */
+    uint64_t last_tx_progress_ms;     /* baseline for the no-progress budget:
+                                       * seeded on CONNECTED entry and refreshed
+                                       * whenever tx_seq advances.             */
 
     /* --- Timer mechanism --- */
     uint64_t       deadline_ms;       /* absolute monotonic deadline           */

--- a/datalink_arq/arq_fsm.h
+++ b/datalink_arq/arq_fsm.h
@@ -230,6 +230,10 @@ typedef struct
     /* --- Keepalive tracking --- */
     int      keepalive_miss_count;
     uint64_t last_rx_ms;              /* last successful frame decode time     */
+    uint64_t last_tx_progress_ms;     /* last time tx_seq advanced (forward
+                                       * progress).  0 = no progress yet — used
+                                       * by the no-progress disconnect budget
+                                       * in the data-retry-exhausted path.    */
 
     /* --- Timer mechanism --- */
     uint64_t       deadline_ms;       /* absolute monotonic deadline           */

--- a/datalink_arq/arq_fsm.h
+++ b/datalink_arq/arq_fsm.h
@@ -200,6 +200,9 @@ typedef struct
     bool     disconnect_to_no_client;  /* after disconnect: clear arq_info     */
     bool     pending_disconnect_notify;/* defer notify_disconnected until TX done */
     bool     pending_disconnect;       /* APP_DISCONNECT deferred until TX buf empty */
+    uint64_t disconnect_deadline_ms;   /* absolute time by which a deferred
+                                        * APP_DISCONNECT must resolve into a
+                                        * clean teardown. 0 = none armed. */
 
     /* --- Initial connect guard --- */
     bool     pending_connect_confirm;  /* caller must ACK ACCEPT when no initial

--- a/datalink_arq/arq_protocol.c
+++ b/datalink_arq/arq_protocol.c
@@ -17,6 +17,7 @@ _Atomic int arq_call_retry_slots       = ARQ_CALL_RETRY_SLOTS_DEFAULT;
 _Atomic int arq_accept_retry_slots     = ARQ_ACCEPT_RETRY_SLOTS_DEFAULT;
 _Atomic int arq_data_retry_slots       = ARQ_DATA_RETRY_SLOTS_DEFAULT;
 _Atomic int arq_disconnect_retry_slots = ARQ_DISCONNECT_RETRY_SLOTS_DEFAULT;
+_Atomic int arq_no_progress_timeout_s  = ARQ_NO_PROGRESS_TIMEOUT_S_DEFAULT;
 
 /* Include FreeDV mode constants */
 #include "../modem/freedv/freedv_api.h"

--- a/datalink_arq/arq_protocol.c
+++ b/datalink_arq/arq_protocol.c
@@ -18,6 +18,7 @@ _Atomic int arq_accept_retry_slots     = ARQ_ACCEPT_RETRY_SLOTS_DEFAULT;
 _Atomic int arq_data_retry_slots       = ARQ_DATA_RETRY_SLOTS_DEFAULT;
 _Atomic int arq_disconnect_retry_slots = ARQ_DISCONNECT_RETRY_SLOTS_DEFAULT;
 _Atomic int arq_no_progress_timeout_s  = ARQ_NO_PROGRESS_TIMEOUT_S_DEFAULT;
+_Atomic int arq_disconnect_drain_timeout_s = ARQ_DISCONNECT_DRAIN_TIMEOUT_S_DEFAULT;
 
 /* Include FreeDV mode constants */
 #include "../modem/freedv/freedv_api.h"

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -240,6 +240,15 @@ extern _Atomic float arq_callint_override_s;
 #define ARQ_RETRY_DOWNGRADE_THRESHOLD 2     /* consecutive retries to force downgrade */
 #define ARQ_MODE_HOLD_AFTER_DOWNGRADE_S 15  /* hold lower mode after forced downgrade */
 
+/* No-progress disconnect budget (seconds).  When data retries exhaust we no
+ * longer disconnect immediately — instead we reset the retry counter and keep
+ * trying.  Disconnect only fires when wall-clock since the last forward
+ * progress (an ACK that advanced tx_seq) exceeds this budget, OR when the
+ * keepalive miss limit is reached. */
+#define ARQ_NO_PROGRESS_TIMEOUT_S_DEFAULT 600
+extern _Atomic int arq_no_progress_timeout_s;
+#define ARQ_NO_PROGRESS_TIMEOUT_S atomic_load(&arq_no_progress_timeout_s)
+
 /* In DATA frames the ack_delay byte is repurposed to carry payload_valid:
  *   0               = full frame (all user bytes are valid data)
  *   1 .. user_bytes = only this many leading bytes are valid; rest is padding

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -252,6 +252,17 @@ extern _Atomic float arq_callint_override_s;
 extern _Atomic int arq_no_progress_timeout_s;
 #define ARQ_NO_PROGRESS_TIMEOUT_S atomic_load(&arq_no_progress_timeout_s)
 
+/* Absolute cap on how long an APP_DISCONNECT may stay deferred while the FSM
+ * tries to drain the last app bytes.  Once the application has asked to
+ * disconnect, the deferral must always resolve into a clean air-side
+ * DISCONNECT handshake within this window — otherwise a stuck/ping-ponging
+ * session keeps keying the rig forever (the K7EK "Mercury kept hanging on"
+ * report).  On a healthy link the drain completes in seconds via idle-ISS, so
+ * this only bites when the FSM would otherwise be starved. */
+#define ARQ_DISCONNECT_DRAIN_TIMEOUT_S_DEFAULT 30
+extern _Atomic int arq_disconnect_drain_timeout_s;
+#define ARQ_DISCONNECT_DRAIN_TIMEOUT_S atomic_load(&arq_disconnect_drain_timeout_s)
+
 /* In DATA frames the ack_delay byte is repurposed to carry payload_valid:
  *   0               = full frame (all user bytes are valid data)
  *   1 .. user_bytes = only this many leading bytes are valid; rest is padding

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -236,9 +236,9 @@ extern _Atomic float arq_callint_override_s;
 #define ARQ_BACKLOG_MIN_DATAC1        126
 #define ARQ_BACKLOG_MIN_BIDIR_UPGRADE 48    /* > DATAC4 payload capacity          */
 #define ARQ_LADDER_LEVELS             3     /* 0=DATAC4, 1=DATAC3, 2=DATAC1     */
-#define ARQ_LADDER_UP_SUCCESSES       4     /* clean ACKs required to step up    */
+#define ARQ_LADDER_UP_SUCCESSES       2     /* clean ACKs required to step up    */
 #define ARQ_RETRY_DOWNGRADE_THRESHOLD 2     /* consecutive retries to force downgrade */
-#define ARQ_MODE_HOLD_AFTER_DOWNGRADE_S 15  /* hold lower mode after forced downgrade */
+#define ARQ_MODE_HOLD_AFTER_DOWNGRADE_S 6   /* hold lower mode after forced downgrade */
 
 /* No-progress disconnect budget (seconds).  When data retries exhaust we no
  * longer disconnect immediately — instead we reset the retry counter and keep

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -244,8 +244,11 @@ extern _Atomic float arq_callint_override_s;
  * longer disconnect immediately — instead we reset the retry counter and keep
  * trying.  Disconnect only fires when wall-clock since the last forward
  * progress (an ACK that advanced tx_seq) exceeds this budget, OR when the
- * keepalive miss limit is reached. */
-#define ARQ_NO_PROGRESS_TIMEOUT_S_DEFAULT 600
+ * keepalive miss limit is reached.  Default sits just above the keepalive
+ * timeout (5 * 20 = 100s) — keepalive is the normal disconnect path; this
+ * is a safety net for the asymmetric case where peer keepalives still
+ * arrive but our TX direction has gone one-way. */
+#define ARQ_NO_PROGRESS_TIMEOUT_S_DEFAULT 180
 extern _Atomic int arq_no_progress_timeout_s;
 #define ARQ_NO_PROGRESS_TIMEOUT_S atomic_load(&arq_no_progress_timeout_s)
 

--- a/docs/PLAN-arq-robustness-tx-gain.md
+++ b/docs/PLAN-arq-robustness-tx-gain.md
@@ -1,0 +1,153 @@
+# Mercury HF Modem — Improvements Based on Gary K7EK Review
+
+## Context
+
+A field operator (Gary, K7EK) tested Mercury on real HF for several weeks and gave three concrete pieces of feedback. The codebase confirms each is a real gap, not a misperception:
+
+1. **Mercury gives up too easily on weak/noisy channels.** When SNR drops or fading hits, "data transfer stops and Mercury just sits there." A 10-retry hard cap then disconnects the link.
+2. **Gear shifting is slow.** Long silent gaps occur while internal timers count down. Mode upgrades require 4 consecutive clean ACKs; a 15-second mode-hold timer locks Mercury into the slowest gear after one bad burst.
+3. **TX audio output is too quiet.** No TX-gain control exists anywhere in the code. Operators are forced to crank Windows mixer to compensate, which then disrupts other modems sharing the rig.
+
+Goal: make Mercury behave more like VARA-HF in adverse conditions (persist, not disconnect; adapt fast, not stall) and give operators a per-modem TX level control.
+
+---
+
+## What the code actually does today (verified)
+
+### Robustness / gear shifting
+
+- `datalink_arq/arq_protocol.h:193-241` — all timing/threshold constants are compile-time `#define`s. None are exposed in `mercury.ini`.
+  - `ARQ_DATA_RETRY_SLOTS_DEFAULT = 10` → after 10 retries the FSM force-disconnects
+    (`datalink_arq/arq_fsm.c:1216-1257`).
+  - `ARQ_MODE_HOLD_AFTER_DOWNGRADE_S = 15` → after a retry-forced downgrade Mercury cannot upgrade for 15 s, even if the channel recovers.
+  - `ARQ_LADDER_UP_SUCCESSES = 4` → 4 consecutive clean ACKs required to step the speed ladder up.
+  - `ARQ_RETRY_DOWNGRADE_THRESHOLD = 2` → 2 consecutive retries force a payload-mode downgrade.
+  - `ARQ_SNR_HYST_DB = 1.0`, `ARQ_MODE_SWITCH_HYST_COUNT = 1`.
+  - `ARQ_KEEPALIVE_INTERVAL_S = 20`, `ARQ_KEEPALIVE_MISS_LIMIT = 5` → ~100 s before keepalive-driven disconnect.
+- `datalink_arq/arq_fsm.c:279-305` (`record_tx_outcome`) and `:316-416` (`select_best_mode` + `maybe_upgrade_mode`) implement the asymmetric down-fast / up-slow ladder.
+- Retry intervals (per-mode) live in `datalink_arq/arq_protocol.c:59-65`: DATAC4=13 s, DATAC3=10 s, DATAC1=12 s, DATAC13=7 s.
+- A few of these are already runtime-tunable via TCP commands (`RETRIES`, `CALLINT` — see `datalink_arq/arq.c:915-930` and `arq_protocol.h:198-211`), but never persisted and never reachable from the GUI/INI.
+
+### TX audio output
+
+- `modem/modem.c:619, 634, 642` — only place where modulated samples land in the playback buffer:
+  ```c
+  tx_buffer[total_samples++] = (int32_t)mod_out_short[i] << 16;
+  ```
+  No gain stage, no per-mode level, no clip protection. (The `<< 16` is the correct int16→int32 mapping; the issue isn't dynamic-range waste — it's that FreeDV's OFDM modes deliberately output a low-crest-factor signal and there is no user-tunable boost.)
+- `audioio/audioio.c:171-435` (`radio_playback_thread`) — upsamples 6:1 and writes to the soundcard with no scaling.
+- No `gain`, `volume`, `level`, `tx_level` parameter exists in `mercury.ini.example`, in the `mercury_config` struct (`common/cfg_utils.h:46-63`), or in any GUI handler.
+
+### Config / GUI plumbing (the easy part)
+
+- INI parser: `common/cfg_utils.{h,c}`. Adding a key = struct field + `CFG_KEY_*` macro + read/write glue in `cfg_read` / `cfg_write`.
+- WebSocket bridge: `gui_interface/ui_communication.c:76-168` already implements live `set_audio_config` and `set_radio_config` commands that update state, restart subsystems, and persist to INI. New runtime knobs slot in here.
+- PWA front-end: `gui_interface/websocket/web/mercury.html` (and `docs/app/index.html`).
+- TCP control plane: `data_interfaces/tcp_interfaces.c` already has the `RETRIES` / `CALLINT` precedent for parameter commands.
+
+---
+
+## Proposed improvements
+
+All three reviewer concerns are in scope (A, B, C). Each item lists the concrete change and why; ordered by impact-per-effort within each group.
+
+### A. Robustness: stop disconnecting when the channel is just slow
+
+**A1. Replace the hard 10-retry-and-drop with persistent retry + absolute no-progress budget.** *(highest impact, becomes the only behavior)*
+- Today, 10 DATA retries → `send_ctrl_frame(DISCONNECT)` (`arq_fsm.c:1249-1256`).
+- Change: when the existing per-frame retry budget exhausts, **force-downgrade one mode step (DATAC1→DATAC3→DATAC4), reset the retry counter, and keep going**. Only disconnect when (i) we are already in DATAC4 *and* the absolute no-progress wall-clock budget elapses, or (ii) keepalives miss `keepalive_miss_limit` in a row.
+- New INI key `no_progress_timeout_s` (default 600 s = 10 min) caps the total time without forward progress.
+- The old "drop after N retries" path is removed outright — pre-2.0, no compat shim. Matches VARA-HF "keep trying" behavior unconditionally.
+
+**A2. Make all retry / timeout / hysteresis values INI-tunable.**
+- Promote the constants in `arq_protocol.h:193-241` to fields of `mercury_config`, with the existing `#define`s as defaults. Add `[arq]` section to `mercury.ini.example`.
+- Most useful keys: `data_retry_slots`, `mode_hold_after_downgrade_s`, `ladder_up_successes`, `retry_downgrade_threshold`, `snr_hyst_db`, `keepalive_interval_s`, `keepalive_miss_limit`.
+- Existing `arq_call_retry_slots` / `arq_callint_override_s` atomics (already runtime-mutable) become the model — extend the same pattern to the rest.
+
+**A3. Shorten silent gaps between retries when the link is borderline.**
+- `ARQ_CHANNEL_GUARD_MS=700` and `ARQ_ISS_POST_ACK_GUARD_MS=900` are tuned for one specific TX/RX switching latency. Expose them as INI keys (`channel_guard_ms`, `post_ack_guard_ms`) so operators with faster radios can tighten the gap and reduce idle-air time. Keep current values as defaults.
+
+### B. Faster gear shifting
+
+**B1. Lower the post-downgrade mode-hold timer.**
+- `ARQ_MODE_HOLD_AFTER_DOWNGRADE_S = 15` is the single biggest source of "stuck in slow gear" behavior.
+- Lower the default to 6 s and expose via INI (item A2).
+- Stretch: make it adaptive — hold for `min(default, last_retry_burst_length × 2)` so isolated fades don't cost the full window.
+
+**B2. Loosen the up-step gate.**
+- `ARQ_LADDER_UP_SUCCESSES = 4` is conservative. With the existing SNR hysteresis already in place, 2 clean ACKs is usually enough signal.
+- Lower default to 2 (still INI-tunable). The asymmetric "down on 1 retry / up on N successes" stays, just with smaller N.
+
+**B3. Decouple SNR-driven upgrade from delivery-feedback ladder.**
+- `select_best_mode` already supports SNR-only upgrades — but `maybe_upgrade_mode` won't act unless `tx_success_count` is also high enough, because of how the speed_level ladder gates it. When peer SNR is solidly above threshold + hysteresis, allow the upgrade regardless of the success counter. (Code change in `arq_fsm.c:316-416`.)
+
+### C. TX audio gain control
+
+**C1. Add a TX gain stage in the modem TX path.**
+- New global `extern _Atomic float g_tx_gain`; default 1.0 (no change vs. today).
+- Apply at `modem/modem.c:619, 634, 642` with saturation:
+  ```c
+  int64_t v = (int64_t)((int32_t)mod_out_short[i] << 16) * g_tx_gain_q16 / 65536;
+  if (v >  INT32_MAX) v =  INT32_MAX;
+  if (v <  INT32_MIN) v =  INT32_MIN;
+  tx_buffer[total_samples++] = (int32_t)v;
+  ```
+  Use Q16 fixed-point or a `float` multiply guarded by `fminf/fmaxf` — pick whichever fits the surrounding style.
+
+**C2. Expose `tx_gain_db` in `mercury.ini`.**
+- Range: -20.0 … +20.0 dB, default 0.0 (= linear 1.0). Stored as float.
+- Add `CFG_KEY_TX_GAIN_DB`, struct field `float tx_gain_db`, read/write in `cfg_utils.c`. Convert dB → linear at modem startup.
+
+**C3. Add a TX-gain slider to the PWA.**
+- New WebSocket command `set_tx_gain` in `ui_communication.c` (mirror the `set_audio_config` pattern at `:85-127`): updates the atomic, persists to INI via `cfg_write`. Slider in `gui_interface/websocket/web/mercury.html` and `docs/app/index.html`, range -20 to +20 dB, step 0.5 dB. Live update, no restart needed.
+
+**C4. Add a TX peak/level indicator in the PWA.**
+- Track instantaneous peak of `tx_buffer` per burst (post-gain, pre-clip and pre-saturation) in `modem/modem.c` after the loops at `:617-620`, `:632-635`, `:640-643`.
+- Surface the peak through the existing waterfall/status WebSocket message stream (`gui_interface/ui_communication.c`) — add a `tx_peak_dbfs` field next to the existing waterfall payload so we don't add a new socket frame type.
+- PWA: render a horizontal bar meter above the gain slider with a held-peak hairline that decays over ~2 s. Color: green < -6 dBFS, yellow -6 to -1 dBFS, red ≥ -1 dBFS so operators can set gain just below clip without an external SDR.
+
+---
+
+## Critical files
+
+| File | Why |
+|---|---|
+| `datalink_arq/arq_protocol.h` | Promote `#define`s to runtime/INI-tunable values |
+| `datalink_arq/arq.c` | Atomic vars, TCP-command precedent (`RETRIES`, `CALLINT`) |
+| `datalink_arq/arq_fsm.c` | Retry-exhaustion path (`:1216-1257`), mode-hold logic (`:316-416`), ladder (`:279-305`) |
+| `datalink_arq/arq_protocol.c` | Per-mode retry intervals (`:59-65`) if A3 is in scope |
+| `modem/modem.c` | TX gain insertion point (`:619, 634, 642`) |
+| `common/cfg_utils.{h,c}` | Add struct fields + INI keys for all new knobs |
+| `mercury.ini.example` | Document new keys |
+| `gui_interface/ui_communication.c` | New `set_tx_gain` and (optionally) `set_arq_tuning` WebSocket commands |
+| `gui_interface/websocket/web/mercury.html` | TX gain slider + (optional) ARQ-tuning panel |
+| `docs/app/index.html` | Same UI additions for the docs PWA |
+
+---
+
+## Verification
+
+The hard part — these changes affect on-air behavior and must be tested against a real radio link.
+
+1. **Bench (no radio):**
+   - Run `make` (Makefile at repo root) and confirm no regressions.
+   - Existing test harness in `tests/` — run the ARQ round-trip tests; new INI keys should default to current `#define`s, so all tests must still pass unchanged.
+   - With two Mercury instances looped through `audioio`'s SHM mode (`sound_system = shm`), verify a clean transfer with default config matches today's behavior.
+
+2. **TX gain (loopback):**
+   - Use the existing `tap-capture.f64` / `tap-playback.f64` flow (see repo root) to record TX audio at gain = 0 dB and gain = +6 dB. Verify the second is exactly 2× peak amplitude with no clipping/wrap, and that gain = +20 dB clips cleanly without wrap-around (saturation works).
+   - The peak meter readout from C4 should match the offline-measured peak within ±0.5 dB.
+
+3. **GUI:**
+   - With `ui_enabled = true`, open the PWA, drag the TX gain slider, watch a TX burst on an external SDR or scope; level should change live without a restart. Confirm the new value is written back to `mercury.ini`.
+   - Confirm the peak meter tracks live, hold-and-decay works, and color zones flip at -6 dBFS / -1 dBFS thresholds.
+
+4. **On-air robustness (the real test) — São Roque ↔ Belo Horizonte field link:**
+   - Reproduce Gary's scenario on a marginal channel where today Mercury disconnects mid-transfer.
+   - Confirm the link force-downgrades through DATAC3→DATAC4 and stays connected, instead of dropping after 10 retries.
+   - Confirm `no_progress_timeout_s` *does* eventually drop the link when the channel is truly dead (e.g. unplug peer's antenna for >10 min).
+   - Tune `mode_hold_after_downgrade_s` from INI; observe shorter idle gaps and faster recovery after fades.
+   - Compare end-to-end transfer time and disconnect rate vs. today on the same channel.
+
+5. **Regression on a clean channel:**
+   - On a high-SNR link, confirm that with default config the throughput is no worse than today (i.e. the looser up-step gate doesn't cause harmful oscillation).

--- a/docs/PLAN-arq-robustness-tx-gain.md
+++ b/docs/PLAN-arq-robustness-tx-gain.md
@@ -56,7 +56,7 @@ All three reviewer concerns are in scope (A, B, C). Each item lists the concrete
 **A1. Replace the hard 10-retry-and-drop with persistent retry + absolute no-progress budget.** *(highest impact, becomes the only behavior)*
 - Today, 10 DATA retries → `send_ctrl_frame(DISCONNECT)` (`arq_fsm.c:1249-1256`).
 - Change: when the existing per-frame retry budget exhausts, **force-downgrade one mode step (DATAC1→DATAC3→DATAC4), reset the retry counter, and keep going**. Only disconnect when (i) we are already in DATAC4 *and* the absolute no-progress wall-clock budget elapses, or (ii) keepalives miss `keepalive_miss_limit` in a row.
-- New INI key `no_progress_timeout_s` (default 600 s = 10 min) caps the total time without forward progress.
+- New INI key `no_progress_timeout_s` (default 180 s = 3 min) caps the total time without forward progress.  Sits just above the keepalive timeout (5 × 20 = 100 s) so keepalive remains the normal disconnect path; this is a safety net for the asymmetric case where peer keepalives still arrive but our TX direction has gone one-way.
 - The old "drop after N retries" path is removed outright — pre-2.0, no compat shim. Matches VARA-HF "keep trying" behavior unconditionally.
 
 **A2. Make all retry / timeout / hysteresis values INI-tunable.**

--- a/docs/app/index.html
+++ b/docs/app/index.html
@@ -110,6 +110,32 @@ select option { background: #2d2d2d; color: #e6e6e6; }
 .status-dot.off { background: #c44; }
 .status-dot.na  { background: #888; }
 
+/* ===== TX gain slider + peak meter ===== */
+input[type="range"] {
+  width: 100%; accent-color: #ff8800; background: transparent;
+  margin: 2px 0;
+}
+.tx-meter {
+  position: relative; height: 14px; background: #121212;
+  border: 1px solid #464646; border-radius: 3px; overflow: hidden;
+  margin-top: 4px;
+}
+.tx-meter-fill {
+  position: absolute; left: 0; top: 0; bottom: 0; width: 0%;
+  background: #2c7; transition: width 0.1s linear;
+}
+.tx-meter-fill.warn   { background: #fc4; }
+.tx-meter-fill.danger { background: #f44; }
+.tx-meter-peak {
+  position: absolute; top: 0; bottom: 0; width: 2px; background: #fff;
+  left: 0%; transition: left 0.2s linear;
+}
+.tx-meter-scale {
+  display: flex; justify-content: space-between;
+  font-size: 10px; color: #777; margin-top: 1px;
+}
+.tx-meter-label { font-size: 11px; color: #aaa; margin-top: 2px; }
+
 /* ===== Waterfall Area ===== */
 .waterfall-area {
   padding: 0 !important; gap: 0; overflow: hidden;
@@ -176,6 +202,19 @@ select option { background: #2d2d2d; color: #e6e6e6; }
           <label for="inputChannelSelect">Capture Input Channel</label>
           <select id="inputChannelSelect"><option value="">--</option></select>
           <button class="apply-btn" id="audioApplyBtn">Apply</button>
+        </div>
+        <!-- TX Audio Level -->
+        <div class="control-section">
+          <label for="txGainSlider">TX Audio Level (<span id="txGainValue">0.0</span> dB)</label>
+          <input type="range" id="txGainSlider" min="-20" max="20" step="0.5" value="0">
+          <div class="tx-meter" title="Per-burst TX peak (dBFS, 0 = clip)">
+            <div class="tx-meter-fill" id="txMeterFill"></div>
+            <div class="tx-meter-peak" id="txMeterPeak"></div>
+          </div>
+          <div class="tx-meter-scale">
+            <span>-60</span><span>-30</span><span>-12</span><span>-6</span><span>0</span>
+          </div>
+          <div class="tx-meter-label">TX peak: <span id="txPeakValue">—</span> dBFS</div>
         </div>
         <!-- HAMLIB Radio -->
         <div class="control-section">
@@ -800,16 +839,79 @@ function handleStatus(msg) {
   if (msg.snr != null) snrValue = msg.snr;
   syncState = !!msg.sync;
 
-  // Update connection info (exclude type and waterfall meta fields)
+  // TX gain slider — only echo from backend when the user isn't dragging
+  if (msg.tx_gain_db != null && !txGainUserActive) {
+    const db = +msg.tx_gain_db;
+    if (Math.abs(db - parseFloat(txGainSliderEl.value)) >= 0.05) {
+      txGainSliderEl.value = db.toFixed(1);
+      txGainValueEl.textContent = db.toFixed(1);
+    }
+  }
+  // TX peak meter
+  if (msg.tx_peak_dbfs != null) updateTxMeter(+msg.tx_peak_dbfs);
+
+  // Update connection info (exclude type, waterfall, and meter-only fields)
   const infoData = {};
   for (const k in msg) {
-    if (k === "type" || k === "waterfall") continue;
+    if (k === "type" || k === "waterfall" ||
+        k === "tx_gain_db" || k === "tx_peak_dbfs") continue;
     infoData[k] = msg[k];
   }
   updateConnectionInfo(infoData);
 
   dirty = true;
 }
+
+/* ===========================================================================
+ *  TX gain slider + peak meter
+ * =========================================================================*/
+const txGainSliderEl = document.getElementById("txGainSlider");
+const txGainValueEl  = document.getElementById("txGainValue");
+const txMeterFillEl  = document.getElementById("txMeterFill");
+const txMeterPeakEl  = document.getElementById("txMeterPeak");
+const txPeakValueEl  = document.getElementById("txPeakValue");
+let txGainUserActive = false;       /* user is dragging — suppress echo */
+let txPeakHeldDbfs  = -120.0;      /* held-peak hairline, decays over time */
+let txPeakHoldUntil = 0;
+
+function dbfsToPct(dbfs) {
+  /* -60 .. 0 dBFS mapped linearly to 0..100% bar width */
+  const pct = ((dbfs + 60) / 60) * 100;
+  if (pct < 0)   return 0;
+  if (pct > 100) return 100;
+  return pct;
+}
+
+function updateTxMeter(dbfs) {
+  if (!isFinite(dbfs)) dbfs = -120;
+  const pct = dbfsToPct(dbfs);
+  txMeterFillEl.style.width = pct + "%";
+  txMeterFillEl.classList.remove("warn", "danger");
+  if (dbfs >= -1.0) txMeterFillEl.classList.add("danger");
+  else if (dbfs >= -6.0) txMeterFillEl.classList.add("warn");
+
+  txPeakValueEl.textContent = dbfs <= -120 ? "—" : dbfs.toFixed(1);
+
+  /* Held peak hairline: capture max, decay after 2 s of no new peak */
+  const now = performance.now();
+  if (dbfs > txPeakHeldDbfs) {
+    txPeakHeldDbfs = dbfs;
+    txPeakHoldUntil = now + 2000;
+  } else if (now > txPeakHoldUntil) {
+    txPeakHeldDbfs = Math.max(dbfs, txPeakHeldDbfs - 0.5);
+  }
+  txMeterPeakEl.style.left = dbfsToPct(txPeakHeldDbfs) + "%";
+}
+
+txGainSliderEl.addEventListener("input", function() {
+  txGainUserActive = true;
+  txGainValueEl.textContent = parseFloat(this.value).toFixed(1);
+});
+txGainSliderEl.addEventListener("change", function() {
+  const db = parseFloat(this.value);
+  sendJson({ command: "set_tx_gain", value: db.toFixed(2) });
+  setTimeout(function() { txGainUserActive = false; }, 600);
+});
 
 function handleJsonMessage(raw) {
   let msg;

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -165,6 +165,7 @@ static int ws_command_handler(const ws_command_t *cmd, void *user_data)
          * linear before pushing to the modulator.  Persist to INI so the
          * next start picks it up automatically. */
         float db = (float)atof(cmd->value);
+        if (!isfinite(db)) db = 0.0f;  /* reject NaN/Inf from a bad client */
         if (db < -20.0f) db = -20.0f;
         if (db >  20.0f) db =  20.0f;
         float linear = powf(10.0f, db / 20.0f);

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -29,6 +29,7 @@
 #include <time.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <math.h>
 
 #include "../common/os_interop.h"
 
@@ -159,6 +160,20 @@ static int ws_command_handler(const ws_command_t *cmd, void *user_data)
         if (ctx->cfg_path[0] && cfg_write(&ctx->cfg, ctx->cfg_path))
             HLOGI(UI_LOG_TAG, "Config saved to %s", ctx->cfg_path);
 
+    } else if (strcmp(cmd->command, "set_tx_gain") == 0) {
+        /* value carries the dB string; clamp to plan range and convert to
+         * linear before pushing to the modulator.  Persist to INI so the
+         * next start picks it up automatically. */
+        float db = (float)atof(cmd->value);
+        if (db < -20.0f) db = -20.0f;
+        if (db >  20.0f) db =  20.0f;
+        float linear = powf(10.0f, db / 20.0f);
+        modem_set_tx_gain(linear);
+        ctx->cfg.tx_gain_db = db;
+        HLOGI(UI_LOG_TAG, "TX gain set to %.2f dB (linear=%.4f)", db, linear);
+        if (ctx->cfg_path[0] && cfg_write(&ctx->cfg, ctx->cfg_path))
+            HLOGI(UI_LOG_TAG, "Config saved to %s", ctx->cfg_path);
+
     } else {
         HLOGW(UI_LOG_TAG, "Unknown UI command: %s", cmd->command);
         return -1;
@@ -245,6 +260,11 @@ void *ui_publisher_thread(void *arg)
 
         // --- Build and broadcast status JSON via WebSocket ---
         {
+            float tx_gain_linear = modem_get_tx_gain();
+            float tx_gain_db = (tx_gain_linear > 0.0f)
+                                ? 20.0f * log10f(tx_gain_linear)
+                                : -120.0f;
+            float tx_peak_dbfs = modem_get_tx_peak_dbfs();
             char buf[4096];
             int pos = 0;
             pos += snprintf(buf + pos, sizeof(buf) - pos,
@@ -258,6 +278,8 @@ void *ui_publisher_thread(void *arg)
                 "\"client_tcp_connected\":%s,"
                 "\"bytes_transmitted\":%ld,"
                 "\"bytes_received\":%ld,"
+                "\"tx_gain_db\":%.1f,"
+                "\"tx_peak_dbfs\":%.1f,"
                 "\"waterfall\":%s}",
                 bitrate, snr,
                 user_call ? user_call : "",
@@ -266,6 +288,7 @@ void *ui_publisher_thread(void *arg)
                 dir == DIR_TX ? "tx" : "rx",
                 tcp_connected ? "true" : "false",
                 bytes_tx, bytes_rx,
+                tx_gain_db, tx_peak_dbfs,
                 ctx->waterfall_enabled ? "true" : "false");
 
             ws_broadcast_json(&ctx->ws, buf);

--- a/gui_interface/websocket/web/mercury.html
+++ b/gui_interface/websocket/web/mercury.html
@@ -97,6 +97,32 @@ select option { background: #2d2d2d; color: #e6e6e6; }
 .status-dot.off { background: #c44; }
 .status-dot.na  { background: #888; }
 
+/* ===== TX gain slider + peak meter ===== */
+input[type="range"] {
+  width: 100%; accent-color: #ff8800; background: transparent;
+  margin: 2px 0;
+}
+.tx-meter {
+  position: relative; height: 14px; background: #121212;
+  border: 1px solid #464646; border-radius: 3px; overflow: hidden;
+  margin-top: 4px;
+}
+.tx-meter-fill {
+  position: absolute; left: 0; top: 0; bottom: 0; width: 0%;
+  background: #2c7; transition: width 0.1s linear;
+}
+.tx-meter-fill.warn   { background: #fc4; }
+.tx-meter-fill.danger { background: #f44; }
+.tx-meter-peak {
+  position: absolute; top: 0; bottom: 0; width: 2px; background: #fff;
+  left: 0%; transition: left 0.2s linear;
+}
+.tx-meter-scale {
+  display: flex; justify-content: space-between;
+  font-size: 10px; color: #777; margin-top: 1px;
+}
+.tx-meter-label { font-size: 11px; color: #aaa; margin-top: 2px; }
+
 /* ===== Waterfall Area ===== */
 .waterfall-area {
   padding: 0 !important; gap: 0; overflow: hidden;
@@ -163,6 +189,19 @@ select option { background: #2d2d2d; color: #e6e6e6; }
           <label for="inputChannelSelect">Capture Input Channel</label>
           <select id="inputChannelSelect"><option value="">--</option></select>
           <button class="apply-btn" id="audioApplyBtn">Apply</button>
+        </div>
+        <!-- TX Audio Level -->
+        <div class="control-section">
+          <label for="txGainSlider">TX Audio Level (<span id="txGainValue">0.0</span> dB)</label>
+          <input type="range" id="txGainSlider" min="-20" max="20" step="0.5" value="0">
+          <div class="tx-meter" title="Per-burst TX peak (dBFS, 0 = clip)">
+            <div class="tx-meter-fill" id="txMeterFill"></div>
+            <div class="tx-meter-peak" id="txMeterPeak"></div>
+          </div>
+          <div class="tx-meter-scale">
+            <span>-60</span><span>-30</span><span>-12</span><span>-6</span><span>0</span>
+          </div>
+          <div class="tx-meter-label">TX peak: <span id="txPeakValue">—</span> dBFS</div>
         </div>
         <!-- HAMLIB Radio -->
         <div class="control-section">
@@ -767,16 +806,81 @@ function handleStatus(msg) {
   if (msg.snr != null) snrValue = msg.snr;
   syncState = !!msg.sync;
 
-  // Update connection info (exclude type and waterfall meta fields)
+  // TX gain slider — only echo from backend when the user isn't dragging
+  if (msg.tx_gain_db != null && !txGainUserActive) {
+    const db = +msg.tx_gain_db;
+    if (Math.abs(db - parseFloat(txGainSliderEl.value)) >= 0.05) {
+      txGainSliderEl.value = db.toFixed(1);
+      txGainValueEl.textContent = db.toFixed(1);
+    }
+  }
+  // TX peak meter
+  if (msg.tx_peak_dbfs != null) updateTxMeter(+msg.tx_peak_dbfs);
+
+  // Update connection info (exclude type, waterfall, and meter-only fields)
   const infoData = {};
   for (const k in msg) {
-    if (k === "type" || k === "waterfall") continue;
+    if (k === "type" || k === "waterfall" ||
+        k === "tx_gain_db" || k === "tx_peak_dbfs") continue;
     infoData[k] = msg[k];
   }
   updateConnectionInfo(infoData);
 
   dirty = true;
 }
+
+/* ===========================================================================
+ *  TX gain slider + peak meter
+ * =========================================================================*/
+const txGainSliderEl = document.getElementById("txGainSlider");
+const txGainValueEl  = document.getElementById("txGainValue");
+const txMeterFillEl  = document.getElementById("txMeterFill");
+const txMeterPeakEl  = document.getElementById("txMeterPeak");
+const txPeakValueEl  = document.getElementById("txPeakValue");
+let txGainUserActive = false;       /* user is dragging — suppress echo */
+let txPeakHeldDbfs  = -120.0;      /* held-peak hairline, decays over time */
+let txPeakHoldUntil = 0;
+
+function dbfsToPct(dbfs) {
+  /* -60 .. 0 dBFS mapped linearly to 0..100% bar width */
+  const pct = ((dbfs + 60) / 60) * 100;
+  if (pct < 0)   return 0;
+  if (pct > 100) return 100;
+  return pct;
+}
+
+function updateTxMeter(dbfs) {
+  if (!isFinite(dbfs)) dbfs = -120;
+  const pct = dbfsToPct(dbfs);
+  txMeterFillEl.style.width = pct + "%";
+  txMeterFillEl.classList.remove("warn", "danger");
+  if (dbfs >= -1.0) txMeterFillEl.classList.add("danger");
+  else if (dbfs >= -6.0) txMeterFillEl.classList.add("warn");
+
+  txPeakValueEl.textContent = dbfs <= -120 ? "—" : dbfs.toFixed(1);
+
+  /* Held peak hairline: capture max, decay after 2 s of no new peak */
+  const now = performance.now();
+  if (dbfs > txPeakHeldDbfs) {
+    txPeakHeldDbfs = dbfs;
+    txPeakHoldUntil = now + 2000;
+  } else if (now > txPeakHoldUntil) {
+    txPeakHeldDbfs = Math.max(dbfs, txPeakHeldDbfs - 0.5);
+  }
+  txMeterPeakEl.style.left = dbfsToPct(txPeakHeldDbfs) + "%";
+}
+
+txGainSliderEl.addEventListener("input", function() {
+  txGainUserActive = true;
+  txGainValueEl.textContent = parseFloat(this.value).toFixed(1);
+});
+txGainSliderEl.addEventListener("change", function() {
+  const db = parseFloat(this.value);
+  sendJson({ command: "set_tx_gain", value: db.toFixed(2) });
+  /* Release the suppression a beat after we send so the next status echo
+   * (which carries the new value) doesn't fight us. */
+  setTimeout(function() { txGainUserActive = false; }, 600);
+});
 
 function handleJsonMessage(raw) {
   let msg;

--- a/main.c
+++ b/main.c
@@ -226,6 +226,7 @@ int main(int argc, char *argv[])
             freedv_verbosity   = mcfg.freedv_verbosity;
             hamlib_log_level   = mcfg.hamlib_log_level;
             radio_serial_speed = mcfg.radio_serial_speed;
+            arq_set_no_progress_timeout_s(mcfg.no_progress_timeout_s);
         }
     }
 

--- a/main.c
+++ b/main.c
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <signal.h>
+#include <math.h>
 
 #ifdef __linux__
 #include <sched.h>
@@ -227,6 +228,7 @@ int main(int argc, char *argv[])
             hamlib_log_level   = mcfg.hamlib_log_level;
             radio_serial_speed = mcfg.radio_serial_speed;
             arq_set_no_progress_timeout_s(mcfg.no_progress_timeout_s);
+            modem_set_tx_gain(powf(10.0f, mcfg.tx_gain_db / 20.0f));
         }
     }
 

--- a/main.c
+++ b/main.c
@@ -228,6 +228,7 @@ int main(int argc, char *argv[])
             hamlib_log_level   = mcfg.hamlib_log_level;
             radio_serial_speed = mcfg.radio_serial_speed;
             arq_set_no_progress_timeout_s(mcfg.no_progress_timeout_s);
+            arq_set_disconnect_drain_timeout_s(mcfg.disconnect_drain_timeout_s);
             modem_set_tx_gain(powf(10.0f, mcfg.tx_gain_db / 20.0f));
         }
     }

--- a/mercury.ini.example
+++ b/mercury.ini.example
@@ -91,3 +91,13 @@ tx_gain_db = 0.0
 ; keepalives still arrive but our TX direction has gone one-way.  Raise
 ; this for ultra-marginal NVIS work where forward progress can take longer.
 no_progress_timeout_s = 180
+
+; Absolute cap (seconds, default: 30) on how long an application DISCONNECT
+; may stay deferred while Mercury drains the last queued TX bytes.  When the
+; host (e.g. BPQ32) ends a BBS forwarding session, Mercury finishes sending
+; any buffered data, then completes a clean air-side DISCONNECT handshake.
+; This cap guarantees the link always tears down within the window even if
+; the session is stuck ping-ponging — preventing the rig from being keyed
+; indefinitely after the host has already disconnected.  On a healthy link
+; the drain finishes in seconds, so this only bites on a stuck session.
+disconnect_drain_timeout_s = 30

--- a/mercury.ini.example
+++ b/mercury.ini.example
@@ -81,12 +81,13 @@ tx_gain_db = 0.0
 
 [arq]
 
-; ARQ link no-progress disconnect budget (seconds, default: 600).
+; ARQ link no-progress disconnect budget (seconds, default: 180).
 ; When data-retry slots exhaust on a frame, Mercury no longer disconnects
-; immediately — it resets the retry counter and keeps banging at the channel.
-; The link only drops when wall-clock since the last ACK that advanced the
-; sequence number exceeds this budget, OR when the keepalive miss limit is
-; reached.  Lower this if you want VARA-HF-style persistence with a tighter
-; ceiling; raise it for ultra-marginal channels where forward progress can
-; take many minutes.
-no_progress_timeout_s = 600
+; immediately — it resets the retry counter and forces a payload-mode
+; downgrade.  The link only drops when wall-clock since the last ACK that
+; advanced the sequence number exceeds this budget, OR when the keepalive
+; miss limit is reached (5 * 20s = 100s by default).  180s sits just above
+; the keepalive timeout as a safety net for the asymmetric case where peer
+; keepalives still arrive but our TX direction has gone one-way.  Raise
+; this for ultra-marginal NVIS work where forward progress can take longer.
+no_progress_timeout_s = 180

--- a/mercury.ini.example
+++ b/mercury.ini.example
@@ -69,6 +69,16 @@ freedv_verbosity = 0
 ; 0=NONE, 1=BUG, 2=ERR, 3=WARN, 4=VERBOSE, 5=TRACE, 6=CACHE
 hamlib_log_level = 0
 
+[audio]
+
+; TX audio gain in dB applied to modulator output samples (default: 0.0).
+; 0.0 dB = no change.  Use this to set Mercury's TX level independently
+; of the host audio mixer, so other modems sharing the radio aren't
+; disturbed when you tune Mercury's drive.  Saturation is applied at the
+; int32 PCM ceiling so any value clips cleanly.
+; Range: -20.0 .. +20.0 (values outside are clamped).
+tx_gain_db = 0.0
+
 [arq]
 
 ; ARQ link no-progress disconnect budget (seconds, default: 600).

--- a/mercury.ini.example
+++ b/mercury.ini.example
@@ -68,3 +68,15 @@ freedv_verbosity = 0
 ; Hamlib radio log level, 0 to 6 (default: 0)
 ; 0=NONE, 1=BUG, 2=ERR, 3=WARN, 4=VERBOSE, 5=TRACE, 6=CACHE
 hamlib_log_level = 0
+
+[arq]
+
+; ARQ link no-progress disconnect budget (seconds, default: 600).
+; When data-retry slots exhaust on a frame, Mercury no longer disconnects
+; immediately — it resets the retry counter and keeps banging at the channel.
+; The link only drops when wall-clock since the last ACK that advanced the
+; sequence number exceeds this budget, OR when the keepalive miss limit is
+; reached.  Lower this if you want VARA-HF-style persistence with a tighter
+; ceiling; raise it for ultra-marginal channels where forward progress can
+; take many minutes.
+no_progress_timeout_s = 600

--- a/modem/modem.c
+++ b/modem/modem.c
@@ -103,13 +103,22 @@ float modem_get_tx_peak_dbfs(void)
 
 /* Convert a 16-bit modulator sample to a 32-bit playback sample with gain
  * and saturation.  At gain == 1.0 this matches the historical behavior of
- * shifting int16 into the upper bits of int32.  Saturates against INT32
- * limits using a >= / <= compare because the literal 2147483647.0f rounds
- * up to 2^31 in float, so a strict > would let the boundary case fall
- * through to an undefined int cast. */
-static inline int32_t tx_sample_with_gain(int16_t sample, float gain)
+ * mapping int16 into the upper bits of int32 — but via a multiply by 65536,
+ * not a left shift: shifting a negative int32 is undefined in C.  Saturates
+ * against INT32 limits using a >= / <= compare because the literal
+ * 2147483647.0f rounds up to 2^31 in float, so a strict > would let the
+ * boundary case fall through to an undefined int cast.  *peak_fs, if
+ * non-NULL, is raised to the pre-saturation magnitude |fs| so the UI meter
+ * reflects the true post-gain level (it can read above full-scale, i.e. the
+ * amount of clipping) rather than the clamped sample. */
+static inline int32_t tx_sample_with_gain(int16_t sample, float gain, float *peak_fs)
 {
-    float fs = (float)((int32_t)sample << 16) * gain;
+    float fs = (float)sample * 65536.0f * gain;
+    if (peak_fs)
+    {
+        float mag = fabsf(fs);
+        if (mag > *peak_fs) *peak_fs = mag;
+    }
     if (fs >=  2147483647.0f) return INT32_MAX;
     if (fs <= -2147483648.0f) return INT32_MIN;
     return (int32_t)fs;
@@ -644,6 +653,7 @@ int send_modulated_data(generic_modem_t *g_modem, uint8_t *bytes_in, int frames_
 
     int total_samples = 0;
     float tx_gain = atomic_load(&g_tx_gain);
+    float peak_fs = 0.0f;  /* pre-saturation peak magnitude across this burst */
 
 
     /* === STEP 1: Generate all modulated audio into temp buffer === */
@@ -656,7 +666,7 @@ int send_modulated_data(generic_modem_t *g_modem, uint8_t *bytes_in, int frames_
     int n_preamble = freedv_rawdatapreambletx(freedv, mod_out_short);
     for (int i = 0; i < n_preamble; i++)
     {
-        tx_buffer[total_samples++] = tx_sample_with_gain(mod_out_short[i], tx_gain);
+        tx_buffer[total_samples++] = tx_sample_with_gain(mod_out_short[i], tx_gain, &peak_fs);
     }
 
     /* Generate data frame(s) */
@@ -671,7 +681,7 @@ int send_modulated_data(generic_modem_t *g_modem, uint8_t *bytes_in, int frames_
         freedv_rawdatatx(freedv, mod_out_short, frame_with_crc);
         for (size_t j = 0; j < n_mod_out; j++)
         {
-            tx_buffer[total_samples++] = tx_sample_with_gain(mod_out_short[j], tx_gain);
+            tx_buffer[total_samples++] = tx_sample_with_gain(mod_out_short[j], tx_gain, &peak_fs);
         }
     }
 
@@ -679,7 +689,7 @@ int send_modulated_data(generic_modem_t *g_modem, uint8_t *bytes_in, int frames_
     int n_postamble = freedv_rawdatapostambletx(freedv, mod_out_short);
     for (int i = 0; i < n_postamble; i++)
     {
-        tx_buffer[total_samples++] = tx_sample_with_gain(mod_out_short[i], tx_gain);
+        tx_buffer[total_samples++] = tx_sample_with_gain(mod_out_short[i], tx_gain, &peak_fs);
     }
 
     /* Add silence at end */
@@ -689,24 +699,17 @@ int send_modulated_data(generic_modem_t *g_modem, uint8_t *bytes_in, int frames_
     }
     pthread_mutex_unlock(&modem_freedv_lock);
 
-    /* Measure post-gain pre-saturation TX peak for the UI meter.  Walk the
-     * buffer once; values were already saturated in tx_sample_with_gain so
-     * INT32_MAX maps to 0 dBFS = the clip ceiling. */
+    /* Publish the post-gain, pre-saturation TX peak for the UI meter.
+     * peak_fs was accumulated as |fs| inside tx_sample_with_gain before any
+     * clamping, so it reflects the true level: at 0 dBFS the signal is right
+     * at the clip ceiling, above 0 dBFS it is clipping by that many dB. */
     {
-        int32_t peak_abs = 0;
-        for (int i = 0; i < total_samples; i++)
-        {
-            int32_t v = tx_buffer[i];
-            int32_t a = (v < 0) ? -v : v;
-            if (a > peak_abs) peak_abs = a;
-        }
         float dbfs = -120.0f;
-        if (peak_abs > 0)
+        if (peak_fs > 0.0f)
         {
-            float lin = (float)peak_abs / 2147483648.0f;  /* INT32 full-scale = 0 dBFS */
+            float lin = peak_fs / 2147483648.0f;  /* INT32 full-scale = 0 dBFS */
             dbfs = 20.0f * log10f(lin);
             if (dbfs < -120.0f) dbfs = -120.0f;
-            if (dbfs >    0.0f) dbfs =    0.0f;
         }
         atomic_store(&g_tx_peak_dbfs, dbfs);
     }

--- a/modem/modem.c
+++ b/modem/modem.c
@@ -81,7 +81,8 @@ static struct MODEM_STATS g_spectrum_stats;
 static bool g_spectrum_stats_inited = false;
 
 /* --- TX audio gain (linear multiplier applied to modulator samples) --- */
-static _Atomic float g_tx_gain = 1.0f;
+static _Atomic float g_tx_gain      = 1.0f;
+static _Atomic float g_tx_peak_dbfs = -120.0f;
 
 void modem_set_tx_gain(float linear)
 {
@@ -93,6 +94,11 @@ void modem_set_tx_gain(float linear)
 float modem_get_tx_gain(void)
 {
     return atomic_load(&g_tx_gain);
+}
+
+float modem_get_tx_peak_dbfs(void)
+{
+    return atomic_load(&g_tx_peak_dbfs);
 }
 
 /* Convert a 16-bit modulator sample to a 32-bit playback sample with gain
@@ -682,6 +688,28 @@ int send_modulated_data(generic_modem_t *g_modem, uint8_t *bytes_in, int frames_
         tx_buffer[total_samples++] = 0;
     }
     pthread_mutex_unlock(&modem_freedv_lock);
+
+    /* Measure post-gain pre-saturation TX peak for the UI meter.  Walk the
+     * buffer once; values were already saturated in tx_sample_with_gain so
+     * INT32_MAX maps to 0 dBFS = the clip ceiling. */
+    {
+        int32_t peak_abs = 0;
+        for (int i = 0; i < total_samples; i++)
+        {
+            int32_t v = tx_buffer[i];
+            int32_t a = (v < 0) ? -v : v;
+            if (a > peak_abs) peak_abs = a;
+        }
+        float dbfs = -120.0f;
+        if (peak_abs > 0)
+        {
+            float lin = (float)peak_abs / 2147483648.0f;  /* INT32 full-scale = 0 dBFS */
+            dbfs = 20.0f * log10f(lin);
+            if (dbfs < -120.0f) dbfs = -120.0f;
+            if (dbfs >    0.0f) dbfs =    0.0f;
+        }
+        atomic_store(&g_tx_peak_dbfs, dbfs);
+    }
 
 
     /* === STEP 2: Key transmitter and send pre-generated audio === */

--- a/modem/modem.c
+++ b/modem/modem.c
@@ -707,7 +707,10 @@ int send_modulated_data(generic_modem_t *g_modem, uint8_t *bytes_in, int frames_
         float dbfs = -120.0f;
         if (peak_fs > 0.0f)
         {
-            float lin = peak_fs / 2147483648.0f;  /* INT32 full-scale = 0 dBFS */
+            /* 0 dBFS reference is the symmetric full scale 2^31 (= |INT32_MIN|),
+             * since peak_fs is a pre-saturation magnitude that ranges over
+             * +/-2^31; the ~4e-9 dB gap to INT32_MAX is irrelevant here. */
+            float lin = peak_fs / 2147483648.0f;
             dbfs = 20.0f * log10f(lin);
             if (dbfs < -120.0f) dbfs = -120.0f;
         }

--- a/modem/modem.c
+++ b/modem/modem.c
@@ -26,6 +26,9 @@
 #include <pthread.h>
 #include <stdint.h>
 #include <time.h>
+#include <stdatomic.h>
+#include <math.h>
+#include <limits.h>
 
 #include "modem.h"
 #include "ring_buffer_posix.h"
@@ -76,6 +79,36 @@ static int g_spectrum_sample_rate = 8000;
 static bool g_spectrum_valid = false;
 static struct MODEM_STATS g_spectrum_stats;
 static bool g_spectrum_stats_inited = false;
+
+/* --- TX audio gain (linear multiplier applied to modulator samples) --- */
+static _Atomic float g_tx_gain = 1.0f;
+
+void modem_set_tx_gain(float linear)
+{
+    if (!isfinite(linear) || linear < 0.0f) linear = 1.0f;
+    if (linear > 100.0f) linear = 100.0f;   /* +40 dB safety cap */
+    atomic_store(&g_tx_gain, linear);
+}
+
+float modem_get_tx_gain(void)
+{
+    return atomic_load(&g_tx_gain);
+}
+
+/* Convert a 16-bit modulator sample to a 32-bit playback sample with gain
+ * and saturation.  At gain == 1.0 this matches the historical behavior of
+ * shifting int16 into the upper bits of int32.  Saturates against INT32
+ * limits using a >= / <= compare because the literal 2147483647.0f rounds
+ * up to 2^31 in float, so a strict > would let the boundary case fall
+ * through to an undefined int cast. */
+static inline int32_t tx_sample_with_gain(int16_t sample, float gain)
+{
+    float fs = (float)((int32_t)sample << 16) * gain;
+    if (fs >=  2147483647.0f) return INT32_MAX;
+    if (fs <= -2147483648.0f) return INT32_MIN;
+    return (int32_t)fs;
+}
+
 #define ARQ_ACTION_WAIT_MS 100
 #define RX_TX_DRAIN_SAMPLES 160
 #define RX_DECODE_CHUNK_SAMPLES 160
@@ -604,6 +637,7 @@ int send_modulated_data(generic_modem_t *g_modem, uint8_t *bytes_in, int frames_
     }
 
     int total_samples = 0;
+    float tx_gain = atomic_load(&g_tx_gain);
 
 
     /* === STEP 1: Generate all modulated audio into temp buffer === */
@@ -616,7 +650,7 @@ int send_modulated_data(generic_modem_t *g_modem, uint8_t *bytes_in, int frames_
     int n_preamble = freedv_rawdatapreambletx(freedv, mod_out_short);
     for (int i = 0; i < n_preamble; i++)
     {
-        tx_buffer[total_samples++] = (int32_t)mod_out_short[i] << 16;
+        tx_buffer[total_samples++] = tx_sample_with_gain(mod_out_short[i], tx_gain);
     }
 
     /* Generate data frame(s) */
@@ -631,7 +665,7 @@ int send_modulated_data(generic_modem_t *g_modem, uint8_t *bytes_in, int frames_
         freedv_rawdatatx(freedv, mod_out_short, frame_with_crc);
         for (size_t j = 0; j < n_mod_out; j++)
         {
-            tx_buffer[total_samples++] = (int32_t)mod_out_short[j] << 16;
+            tx_buffer[total_samples++] = tx_sample_with_gain(mod_out_short[j], tx_gain);
         }
     }
 
@@ -639,7 +673,7 @@ int send_modulated_data(generic_modem_t *g_modem, uint8_t *bytes_in, int frames_
     int n_postamble = freedv_rawdatapostambletx(freedv, mod_out_short);
     for (int i = 0; i < n_postamble; i++)
     {
-        tx_buffer[total_samples++] = (int32_t)mod_out_short[i] << 16;
+        tx_buffer[total_samples++] = tx_sample_with_gain(mod_out_short[i], tx_gain);
     }
 
     /* Add silence at end */

--- a/modem/modem.h
+++ b/modem/modem.h
@@ -69,8 +69,10 @@ void  modem_set_tx_gain(float linear);
 float modem_get_tx_gain(void);
 
 // Most recent TX burst peak amplitude in dBFS (0 dBFS = INT32 full-scale,
-// i.e. clipping).  Measured post-gain, pre-saturation, once per burst.
-// Returns -120.0f when no TX has occurred yet or the last burst was silent.
+// i.e. the clip ceiling).  Measured post-gain but pre-saturation, once per
+// burst, so a return value above 0 dBFS means the burst clipped by that many
+// dB.  Returns -120.0f when no TX has occurred yet or the last burst was
+// silent.
 float modem_get_tx_peak_dbfs(void);
 
 #endif // MODEM_H

--- a/modem/modem.h
+++ b/modem/modem.h
@@ -61,4 +61,11 @@ void *rx_thread(void *g_modem);
 // Returns the sample rate on success, 0 if no spectrum is available yet.
 int modem_get_rx_spectrum(float *out_dB, int max_bins);
 
+// TX audio gain (linear multiplier on modulator output samples).
+// Default 1.0f = no change. Hot-tunable from any thread; the modulator
+// reads it once per burst.  Applied with int32 saturation, so any value
+// is safe — values that would overflow simply clip cleanly.
+void  modem_set_tx_gain(float linear);
+float modem_get_tx_gain(void);
+
 #endif // MODEM_H

--- a/modem/modem.h
+++ b/modem/modem.h
@@ -68,4 +68,9 @@ int modem_get_rx_spectrum(float *out_dB, int max_bins);
 void  modem_set_tx_gain(float linear);
 float modem_get_tx_gain(void);
 
+// Most recent TX burst peak amplitude in dBFS (0 dBFS = INT32 full-scale,
+// i.e. clipping).  Measured post-gain, pre-saturation, once per burst.
+// Returns -120.0f when no TX has occurred yet or the last burst was silent.
+float modem_get_tx_peak_dbfs(void);
+
 #endif // MODEM_H

--- a/tests/datalink_arq/test_arq_fsm.c
+++ b/tests/datalink_arq/test_arq_fsm.c
@@ -348,6 +348,29 @@ void test_retry_exhaustion_persists_then_disconnects(void)
     TEST_ASSERT_EQUAL_INT(ARQ_CONN_DISCONNECTING, sess.conn_state);
 }
 
+/* A CONNECTED baseline at uptime 0 is still valid: the no-progress budget
+ * must expire relative to that baseline rather than treating 0 as "unset". */
+void test_retry_exhaustion_disconnects_from_zero_uptime_baseline(void)
+{
+    mock_set_uptime_ms(0);
+    goto_connected();
+    TEST_ASSERT_EQUAL_UINT64(0, sess.last_tx_progress_ms);
+    goto_wait_ack();
+
+    for (int i = 0; i < 3 * (ARQ_DATA_RETRY_SLOTS + 2); i++)
+    {
+        wait_ack_timeout_cycle();
+        TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
+    }
+
+    mock_set_uptime_ms((uint64_t)ARQ_NO_PROGRESS_TIMEOUT_S * 1000 + 5000);
+    int guard = 0;
+    while (sess.conn_state == ARQ_CONN_CONNECTED && guard++ < ARQ_DATA_RETRY_SLOTS + 4)
+        wait_ack_timeout_cycle();
+
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_DISCONNECTING, sess.conn_state);
+}
+
 /* ---- Timeout tests ---- */
 
 /* CALL timeout transitions to DISCONNECTED */
@@ -408,6 +431,7 @@ int main(void)
     RUN_TEST(test_app_disconnect_defers_with_backlog);
     RUN_TEST(test_disconnect_drain_timeout_forces_teardown);
     RUN_TEST(test_retry_exhaustion_persists_then_disconnects);
+    RUN_TEST(test_retry_exhaustion_disconnects_from_zero_uptime_baseline);
     /* Timeout tests */
     RUN_TEST(test_call_timeout);
     RUN_TEST(test_stop_listen);

--- a/tests/datalink_arq/test_arq_fsm.c
+++ b/tests/datalink_arq/test_arq_fsm.c
@@ -271,6 +271,83 @@ void test_disconnect_drain_timeout_forces_teardown(void)
     TEST_ASSERT_FALSE(sess.pending_disconnect);
 }
 
+/* tx_read fake that always yields one small frame of data. */
+static int tx_read_one_frame(uint8_t *buf, size_t n)
+{
+    size_t k = (n < 16) ? n : 16;
+    memset(buf, 0xA5, k);
+    return (int)k;
+}
+
+/* Drive one ACK-timeout cycle in WAIT_ACK: the timeout resends (DATA_TX) or,
+ * once retries are exhausted, runs the exhaustion branch.  If we land back in
+ * DATA_TX, complete the TX so the next call resumes from WAIT_ACK. */
+static void wait_ack_timeout_cycle(void)
+{
+    arq_event_t ev = make_event(ARQ_EV_TIMER_ACK);
+    arq_fsm_dispatch(&sess, &ev);
+    if (sess.conn_state == ARQ_CONN_CONNECTED &&
+        sess.dflow_state == ARQ_DFLOW_DATA_TX)
+    {
+        ev = make_event(ARQ_EV_TX_COMPLETE);
+        arq_fsm_dispatch(&sess, &ev);
+    }
+}
+
+/* Drive the session into WAIT_ACK with one frame in flight.  The caller side
+ * first has to clear the post-accept connect-confirmation (resolved on
+ * TX_COMPLETE) before data flows, then send a DATA frame (TIMER_ACK triggers
+ * the actual send) and complete it (TX_COMPLETE) to land in WAIT_ACK. */
+static void goto_wait_ack(void)
+{
+    fake_tx_backlog_fake.return_val = 512;
+    fake_tx_read_fake.custom_fake   = tx_read_one_frame;
+
+    arq_event_t ev = make_event(ARQ_EV_APP_DATA_READY);
+    arq_fsm_dispatch(&sess, &ev);
+
+    for (int i = 0; i < 8 && sess.dflow_state != ARQ_DFLOW_WAIT_ACK; i++)
+    {
+        if (sess.dflow_state == ARQ_DFLOW_DATA_TX)
+        {
+            ev = make_event(ARQ_EV_TIMER_ACK);    /* ensure the frame is sent */
+            arq_fsm_dispatch(&sess, &ev);
+            ev = make_event(ARQ_EV_TX_COMPLETE);  /* DATA_TX -> WAIT_ACK */
+            arq_fsm_dispatch(&sess, &ev);
+        }
+        else
+        {
+            ev = make_event(ARQ_EV_TX_COMPLETE);  /* advance connect-confirm */
+            arq_fsm_dispatch(&sess, &ev);
+        }
+    }
+    TEST_ASSERT_EQUAL_INT(ARQ_DFLOW_WAIT_ACK, sess.dflow_state);
+}
+
+/* Retry exhaustion within the no-progress budget persists (stays CONNECTED);
+ * once the budget elapses, the next exhaustion tears the link down. */
+void test_retry_exhaustion_persists_then_disconnects(void)
+{
+    goto_connected();
+    goto_wait_ack();
+
+    /* Within budget: many ACK timeouts (several full exhaustion rounds) must
+     * never disconnect — VARA-style persistence. */
+    for (int i = 0; i < 3 * (ARQ_DATA_RETRY_SLOTS + 2); i++)
+    {
+        wait_ack_timeout_cycle();
+        TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
+    }
+
+    /* Past the no-progress budget: the next exhaustion must disconnect. */
+    mock_set_uptime_ms(1000 + (uint64_t)ARQ_NO_PROGRESS_TIMEOUT_S * 1000 + 5000);
+    int guard = 0;
+    while (sess.conn_state == ARQ_CONN_CONNECTED && guard++ < ARQ_DATA_RETRY_SLOTS + 4)
+        wait_ack_timeout_cycle();
+
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_DISCONNECTING, sess.conn_state);
+}
+
 /* ---- Timeout tests ---- */
 
 /* CALL timeout transitions to DISCONNECTED */
@@ -330,6 +407,7 @@ int main(void)
     RUN_TEST(test_connected_seeds_no_progress_clock);
     RUN_TEST(test_app_disconnect_defers_with_backlog);
     RUN_TEST(test_disconnect_drain_timeout_forces_teardown);
+    RUN_TEST(test_retry_exhaustion_persists_then_disconnects);
     /* Timeout tests */
     RUN_TEST(test_call_timeout);
     RUN_TEST(test_stop_listen);

--- a/tests/datalink_arq/test_arq_fsm.c
+++ b/tests/datalink_arq/test_arq_fsm.c
@@ -210,6 +210,67 @@ void test_rx_disconnect_from_connected(void)
     TEST_ASSERT_EQUAL_INT(ARQ_CONN_DISCONNECTED, sess.conn_state);
 }
 
+/* ---- Helper: drive the session to CONNECTED ---- */
+static void goto_connected(void)
+{
+    arq_event_t ev = make_event(ARQ_EV_APP_LISTEN);
+    arq_fsm_dispatch(&sess, &ev);
+    ev = make_event(ARQ_EV_APP_CONNECT);
+    strncpy(ev.remote_call, "DST1", CALLSIGN_MAX_SIZE);
+    arq_fsm_dispatch(&sess, &ev);
+    ev = make_event(ARQ_EV_RX_ACCEPT);
+    ev.session_id = sess.session_id;
+    strncpy(ev.remote_call, "DST1", CALLSIGN_MAX_SIZE);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
+}
+
+/* ---- Disconnect teardown tests (K7EK field regressions) ---- */
+
+/* Entering CONNECTED seeds the no-progress clock so the wall-clock budget
+ * always has a baseline even before the first advancing ACK. */
+void test_connected_seeds_no_progress_clock(void)
+{
+    goto_connected();
+    TEST_ASSERT_NOT_EQUAL_UINT64(0, sess.last_tx_progress_ms);
+}
+
+/* APP_DISCONNECT with unsent TX backlog is deferred (stays CONNECTED) and
+ * arms the absolute drain deadline rather than tearing down immediately. */
+void test_app_disconnect_defers_with_backlog(void)
+{
+    goto_connected();
+    fake_tx_backlog_fake.return_val = 256;  /* bytes still queued */
+
+    arq_event_t ev = make_event(ARQ_EV_APP_DISCONNECT);
+    arq_fsm_dispatch(&sess, &ev);
+
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
+    TEST_ASSERT_TRUE(sess.pending_disconnect);
+    TEST_ASSERT_NOT_EQUAL_UINT64(0, sess.disconnect_deadline_ms);
+}
+
+/* A deferred APP_DISCONNECT that never drains must still tear down once the
+ * drain deadline elapses — guarantees the rig is not keyed indefinitely
+ * after the host disconnects (the "Mercury kept hanging on" report). */
+void test_disconnect_drain_timeout_forces_teardown(void)
+{
+    goto_connected();
+    fake_tx_backlog_fake.return_val = 256;
+
+    arq_event_t ev = make_event(ARQ_EV_APP_DISCONNECT);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
+
+    /* Advance past the absolute drain budget and feed any CONNECTED event. */
+    mock_set_uptime_ms(1000 + (uint64_t)ARQ_DISCONNECT_DRAIN_TIMEOUT_S * 1000 + 1000);
+    ev = make_event(ARQ_EV_TIMER_KEEPALIVE);
+    arq_fsm_dispatch(&sess, &ev);
+
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_DISCONNECTING, sess.conn_state);
+    TEST_ASSERT_FALSE(sess.pending_disconnect);
+}
+
 /* ---- Timeout tests ---- */
 
 /* CALL timeout transitions to DISCONNECTED */
@@ -266,6 +327,9 @@ int main(void)
     RUN_TEST(test_accept_transitions_to_connected);
     RUN_TEST(test_disconnect_from_connected);
     RUN_TEST(test_rx_disconnect_from_connected);
+    RUN_TEST(test_connected_seeds_no_progress_clock);
+    RUN_TEST(test_app_disconnect_defers_with_backlog);
+    RUN_TEST(test_disconnect_drain_timeout_forces_teardown);
     /* Timeout tests */
     RUN_TEST(test_call_timeout);
     RUN_TEST(test_stop_listen);


### PR DESCRIPTION
Aaddresses field feedback from K7EK: persistent retry instead of disconnect-on-retry-exhaustion, faster gear shifting (lower mode-hold, looser ladder up-step, SNR-driven upgrades), and an end-to-end TX gain control (config + WebSocket + PWA slider + peak meter).