### PR TITLE
broadcast: preserve payload length so VARA/KISS clients decode broadcasts

### DIFF
--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -848,12 +848,28 @@ void *control_worker_thread_rx(void *conn)
 /********** BROADCAST TCP port INTERFACE **********/
 
 /*
+ * Length-prefixed broadcast framing.
+ *
+ * The broadcast datalink uses fixed-size modem frames, so a short VARA/AX.25
+ * frame is zero-padded up to frame_size for TX. Without recording the original
+ * length, the receiver can only hand the client the whole padded frame, and a
+ * VARA client (e.g. VarAC) then rejects it because the trailing zeros corrupt
+ * its payload. To fix this we store the real payload length in a 2-byte
+ * big-endian prefix right after the Mercury header and flag it with a header
+ * extension bit, so the receiver delivers the exact original frame. Receivers
+ * fall back to the legacy header-strip when the flag is absent.
+ */
+#define BCAST_LEN_SIZE       2     /* big-endian payload length after the header */
+#define BCAST_EXT_LEN_PREFIX 0x01  /* header extension bit: length prefix present */
+
+/*
  * Normalises a decoded KISS broadcast frame and queues it to
  * data_tx_buffer_broadcast.
  *
- * VARA clients (CMD_AX25 / CMD_AX25CALLSIGN): inject a 1-byte Mercury
- * PACKET_TYPE_BROADCAST_DATA header, truncate if the payload would overflow,
- * then zero-pad to frame_size.
+ * VARA clients (CMD_AX25 / CMD_AX25CALLSIGN): inject the 1-byte Mercury
+ * PACKET_TYPE_BROADCAST_DATA header plus a 2-byte length prefix (flagged with
+ * BCAST_EXT_LEN_PREFIX), truncate if the payload would overflow, then zero-pad
+ * to frame_size.
  *
  * hermes-broadcast (CMD_DATA): the frame already carries the Mercury header;
  * zero-pad if short, discard if oversized.
@@ -873,19 +889,23 @@ static bool bcast_process_decoded_frame(uint8_t *decoded_frame, int frame_len,
 
     if (kiss_cmd == CMD_AX25 || kiss_cmd == CMD_AX25CALLSIGN)
     {
-        /* Inject 1-byte Mercury header before the AX.25 payload */
-        size_t max_payload = frame_size - HEADER_SIZE;
+        /* Inject Mercury header + 2-byte payload-length prefix before the AX.25
+         * payload, so the receiver can recover the exact frame length (the modem
+         * zero-pads to frame_size). The length prefix is flagged in the header. */
+        size_t max_payload = frame_size - HEADER_SIZE - BCAST_LEN_SIZE;
         if ((size_t)frame_len > max_payload)
         {
-            HLOGW("tcp-bcast", "Truncating VARA frame from %d to %zu to fit header",
+            HLOGW("tcp-bcast", "Truncating VARA frame from %d to %zu to fit header+len",
                   frame_len, max_payload);
             frame_len = (int)max_payload;
         }
-        memmove(decoded_frame + HEADER_SIZE, decoded_frame, (size_t)frame_len);
-        write_frame_header(decoded_frame, PACKET_TYPE_BROADCAST_DATA, 0);
-        frame_len += HEADER_SIZE;
-        HLOGD("tcp-bcast", "Added Mercury broadcast header (cmd=0x%02X), frame now %d bytes",
+        memmove(decoded_frame + HEADER_SIZE + BCAST_LEN_SIZE, decoded_frame, (size_t)frame_len);
+        write_frame_header(decoded_frame, PACKET_TYPE_BROADCAST_DATA, BCAST_EXT_LEN_PREFIX);
+        decoded_frame[HEADER_SIZE]     = (uint8_t)(((unsigned)frame_len >> 8) & 0xFF);
+        decoded_frame[HEADER_SIZE + 1] = (uint8_t)((unsigned)frame_len & 0xFF);
+        HLOGD("tcp-bcast", "Added Mercury broadcast header+len (cmd=0x%02X, payload=%d bytes)",
               kiss_cmd, frame_len);
+        frame_len += HEADER_SIZE + BCAST_LEN_SIZE;
     }
 
     if ((size_t)frame_len > frame_size)
@@ -910,19 +930,43 @@ static bool bcast_process_decoded_frame(uint8_t *decoded_frame, int frame_len,
 
 /*
  * Computes the payload slice and KISS command byte to send back to a broadcast
- * client, reading the latched bcast_reply_cmd.
+ * client.
  *
- * CMD_DATA (hermes-broadcast): forward the full frame including the Mercury
- * header — hermes-broadcast's receiver parses frame[0] as the packet type.
+ * Length-prefixed frame (BCAST_EXT_LEN_PREFIX set in a BROADCAST_DATA header):
+ * return exactly the original AX.25 payload (header + 2-byte length stripped,
+ * padding dropped) and reply with CMD_AX25CALLSIGN. This is detected from the
+ * received frame itself, so it works on a receive-only station regardless of
+ * the latched bcast_reply_cmd.
  *
- * CMD_AX25CALLSIGN (VarAC/VARA): strip the Mercury header byte so the client
- * receives a raw AX.25 payload.
+ * Otherwise mirror the latched bcast_reply_cmd:
+ *   CMD_DATA (hermes-broadcast): forward the full frame including the header.
+ *   else (VarAC/VARA legacy): strip the 1-byte Mercury header only.
  *
  * Sets *payload_out and *payload_len_out; returns the reply command byte.
  */
 static uint8_t bcast_get_tx_payload(uint8_t *frame_buffer, size_t frame_size,
                                      uint8_t **payload_out, int *payload_len_out)
 {
+    /* A length-prefixed broadcast frame is self-describing: detect it from the
+     * received frame's own header, independent of what the local client last
+     * transmitted (bcast_reply_cmd defaults to CMD_DATA and is reset on every
+     * client connect, so a receive-only station would otherwise forward the raw
+     * padded frame). Deliver exactly the original AX.25 payload and reply with
+     * the AX.25/CALLSIGN KISS command so a VARA client (VarAC) accepts it. */
+    if (frame_size >= HEADER_SIZE + BCAST_LEN_SIZE &&
+        frame_header_packet_type(frame_buffer[0]) == PACKET_TYPE_BROADCAST_DATA &&
+        (frame_header_extension(frame_buffer[0]) & BCAST_EXT_LEN_PREFIX))
+    {
+        int len = ((int)frame_buffer[HEADER_SIZE] << 8) | (int)frame_buffer[HEADER_SIZE + 1];
+        int max_len = (int)frame_size - HEADER_SIZE - BCAST_LEN_SIZE;
+        if (len < 0) len = 0;
+        if (len > max_len) len = max_len;
+        *payload_out     = frame_buffer + HEADER_SIZE + BCAST_LEN_SIZE;
+        *payload_len_out = len;
+        return CMD_AX25CALLSIGN;
+    }
+
+    /* Legacy / hermes-broadcast frames: mirror the latched client framing. */
     uint8_t reply_cmd = atomic_load_explicit(&bcast_reply_cmd, memory_order_relaxed);
     if (reply_cmd == CMD_DATA)
     {

--- a/tests/data_interfaces/test_tcp_interfaces.c
+++ b/tests/data_interfaces/test_tcp_interfaces.c
@@ -575,6 +575,13 @@ void test_cmd_callint_negative(void)
  *   (0x04 << 5) | 0 = 0x80 */
 #define BCAST_HDR_BYTE 0x80
 
+/* Length-prefixed broadcast framing (mirrors tcp_interfaces.c). VARA frames now
+ * carry a 2-byte length after the header, flagged with ext bit 0x01, so the
+ * header byte becomes 0x80 | 0x01 = 0x81. */
+#define BCAST_LEN_SIZE       2
+#define BCAST_EXT_LEN_PREFIX 0x01
+#define BCAST_HDR_BYTE_LEN   (BCAST_HDR_BYTE | BCAST_EXT_LEN_PREFIX)
+
 /* CMD_DATA, exact frame_size: queued unchanged, bcast_reply_cmd = CMD_DATA */
 void test_bcast_rx_cmd_data_exact_size(void)
 {
@@ -636,7 +643,8 @@ void test_bcast_rx_cmd_data_oversized_discarded(void)
         atomic_load_explicit(&bcast_reply_cmd, memory_order_relaxed));
 }
 
-/* CMD_AX25CALLSIGN, payload fits: header injected, payload shifted, zero-padded */
+/* CMD_AX25CALLSIGN, payload fits: header + length prefix injected, payload
+ * shifted, zero-padded */
 void test_bcast_rx_vara_header_injected(void)
 {
     const size_t fsz = 10;
@@ -652,13 +660,17 @@ void test_bcast_rx_vara_header_injected(void)
     TEST_ASSERT_TRUE(ok);
     TEST_ASSERT_EQUAL(1, write_buffer_call_count);
     TEST_ASSERT_EQUAL_size_t(fsz, last_write_buffer_len);
-    /* frame[0] must be the broadcast header byte */
-    TEST_ASSERT_EQUAL_HEX8(BCAST_HDR_BYTE, last_write_buffer_data[0]);
-    /* Original payload shifted to [1..5] */
+    /* frame[0] is the broadcast header byte with the length-prefix flag set */
+    TEST_ASSERT_EQUAL_HEX8(BCAST_HDR_BYTE_LEN, last_write_buffer_data[0]);
+    /* 2-byte big-endian length prefix = 5 */
+    TEST_ASSERT_EQUAL_HEX8(0x00, last_write_buffer_data[1]);
+    TEST_ASSERT_EQUAL_HEX8(0x05, last_write_buffer_data[2]);
+    /* Original payload shifted to [3..7] */
     for (int i = 0; i < 5; i++)
-        TEST_ASSERT_EQUAL_HEX8((uint8_t)(i + 1), last_write_buffer_data[1 + i]);
-    /* Tail bytes [6..9] must be zero */
-    for (size_t i = 6; i < fsz; i++)
+        TEST_ASSERT_EQUAL_HEX8((uint8_t)(i + 1),
+            last_write_buffer_data[HEADER_SIZE + BCAST_LEN_SIZE + i]);
+    /* Tail bytes [8..9] must be zero */
+    for (size_t i = 8; i < fsz; i++)
         TEST_ASSERT_EQUAL_HEX8(0x00, last_write_buffer_data[i]);
     /* Reply cmd normalised to CMD_AX25CALLSIGN regardless of CMD_AX25 vs _CALLSIGN */
     TEST_ASSERT_EQUAL_HEX8(CMD_AX25CALLSIGN,
@@ -681,13 +693,14 @@ void test_bcast_rx_cmd_ax25_reply_cmd(void)
         atomic_load_explicit(&bcast_reply_cmd, memory_order_relaxed));
 }
 
-/* CMD_AX25CALLSIGN, payload longer than frame_size-1: truncated then header added */
+/* CMD_AX25CALLSIGN, payload longer than frame_size-(header+len): truncated */
 void test_bcast_rx_vara_long_payload_truncated(void)
 {
     const size_t fsz = 10;
     broadcast_frame_size_cfg = fsz;
-    /* max_payload = fsz - HEADER_SIZE = 9; send 12 bytes */
+    /* max_payload = fsz - HEADER_SIZE - BCAST_LEN_SIZE = 7; send 12 bytes */
     const int raw_len = 12;
+    const int max_payload = (int)fsz - HEADER_SIZE - BCAST_LEN_SIZE; /* 7 */
 
     uint8_t frame[MAX_PAYLOAD];
     for (int i = 0; i < raw_len; i++) frame[i] = (uint8_t)(0x10 + i);
@@ -697,10 +710,14 @@ void test_bcast_rx_vara_long_payload_truncated(void)
     TEST_ASSERT_TRUE(ok);
     TEST_ASSERT_EQUAL(1, write_buffer_call_count);
     TEST_ASSERT_EQUAL_size_t(fsz, last_write_buffer_len);
-    TEST_ASSERT_EQUAL_HEX8(BCAST_HDR_BYTE, last_write_buffer_data[0]);
-    /* Only the first 9 bytes of the original payload must survive */
-    for (int i = 0; i < 9; i++)
-        TEST_ASSERT_EQUAL_HEX8((uint8_t)(0x10 + i), last_write_buffer_data[1 + i]);
+    TEST_ASSERT_EQUAL_HEX8(BCAST_HDR_BYTE_LEN, last_write_buffer_data[0]);
+    /* Length prefix reflects the truncated length (7) */
+    TEST_ASSERT_EQUAL_HEX8(0x00, last_write_buffer_data[1]);
+    TEST_ASSERT_EQUAL_HEX8((uint8_t)max_payload, last_write_buffer_data[2]);
+    /* Only the first 7 bytes of the original payload must survive */
+    for (int i = 0; i < max_payload; i++)
+        TEST_ASSERT_EQUAL_HEX8((uint8_t)(0x10 + i),
+            last_write_buffer_data[HEADER_SIZE + BCAST_LEN_SIZE + i]);
 }
 
 /* bcast_get_tx_payload: CMD_DATA → full frame, payload_len == frame_size */
@@ -739,6 +756,70 @@ void test_bcast_tx_vara_strips_header(void)
     TEST_ASSERT_EQUAL_HEX8(CMD_AX25CALLSIGN, cmd);
     TEST_ASSERT_EQUAL_PTR(frame + HEADER_SIZE, payload); /* skips the Mercury header */
     TEST_ASSERT_EQUAL_INT((int)fsz - HEADER_SIZE, plen); /* one byte shorter */
+}
+
+/* Round-trip: a VARA frame run through TX framing then RX extraction must yield
+ * exactly the original payload (length + bytes), with the modem zero padding
+ * stripped. This is the core of the length-prefix fix. */
+void test_bcast_vara_length_roundtrip(void)
+{
+    const size_t fsz = 32;
+    broadcast_frame_size_cfg = fsz;
+
+    const int orig_len = 11;
+    uint8_t orig[32];
+    for (int i = 0; i < orig_len; i++) orig[i] = (uint8_t)(0xA0 + i);
+
+    /* TX: build the on-air frame (captured by the mock write_buffer). */
+    uint8_t txframe[MAX_PAYLOAD];
+    memset(txframe, 0, sizeof(txframe));
+    memcpy(txframe, orig, orig_len);
+    bool ok = bcast_process_decoded_frame(txframe, orig_len, CMD_AX25CALLSIGN, fsz);
+    TEST_ASSERT_TRUE(ok);
+    TEST_ASSERT_EQUAL_size_t(fsz, last_write_buffer_len);
+
+    /* RX: extract from the framed buffer; reply_cmd was latched by the TX call. */
+    uint8_t rxframe[MAX_PAYLOAD];
+    memcpy(rxframe, last_write_buffer_data, fsz);
+    uint8_t *payload = NULL;
+    int plen = 0;
+    uint8_t cmd = bcast_get_tx_payload(rxframe, fsz, &payload, &plen);
+
+    TEST_ASSERT_EQUAL_HEX8(CMD_AX25CALLSIGN, cmd);
+    TEST_ASSERT_EQUAL_INT(orig_len, plen);              /* exact original length */
+    TEST_ASSERT_EQUAL_PTR(rxframe + HEADER_SIZE + BCAST_LEN_SIZE, payload);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(orig, payload, orig_len); /* exact original bytes */
+}
+
+/* Receive-only station: a length-prefixed frame must be delivered as the exact
+ * AX.25 payload with CMD_AX25CALLSIGN even when bcast_reply_cmd is still the
+ * default CMD_DATA (local client has not transmitted). Regression for the bug
+ * where receive-only stations forwarded the raw padded frame as CMD_DATA. */
+void test_bcast_tx_lenprefix_ignores_reply_cmd_default(void)
+{
+    const size_t fsz = 32;
+    const int len = 9;
+
+    uint8_t frame[32];
+    memset(frame, 0, sizeof(frame));
+    frame[0] = BCAST_HDR_BYTE_LEN;                 /* BROADCAST_DATA + len flag */
+    frame[1] = (uint8_t)((len >> 8) & 0xFF);
+    frame[2] = (uint8_t)(len & 0xFF);
+    for (int i = 0; i < len; i++)
+        frame[HEADER_SIZE + BCAST_LEN_SIZE + i] = (uint8_t)(0x40 + i);
+
+    /* Default / receive-only state */
+    atomic_store_explicit(&bcast_reply_cmd, CMD_DATA, memory_order_relaxed);
+
+    uint8_t *payload = NULL;
+    int plen = 0;
+    uint8_t cmd = bcast_get_tx_payload(frame, fsz, &payload, &plen);
+
+    TEST_ASSERT_EQUAL_HEX8(CMD_AX25CALLSIGN, cmd);     /* NOT CMD_DATA */
+    TEST_ASSERT_EQUAL_INT(len, plen);                  /* exact length, not fsz */
+    TEST_ASSERT_EQUAL_PTR(frame + HEADER_SIZE + BCAST_LEN_SIZE, payload);
+    for (int i = 0; i < len; i++)
+        TEST_ASSERT_EQUAL_HEX8((uint8_t)(0x40 + i), payload[i]);
 }
 
 int main(void)
@@ -791,5 +872,7 @@ int main(void)
     RUN_TEST(test_bcast_rx_vara_long_payload_truncated);
     RUN_TEST(test_bcast_tx_cmd_data_full_frame);
     RUN_TEST(test_bcast_tx_vara_strips_header);
+    RUN_TEST(test_bcast_vara_length_roundtrip);
+    RUN_TEST(test_bcast_tx_lenprefix_ignores_reply_cmd_default);
     return UNITY_END();
 }


### PR DESCRIPTION
Fixes #75.

## Problem
When a VARA/KISS client (e.g. VarAC) uses the broadcast port (8100) as a TNC, **received broadcasts never decode**. The broadcast datalink is fixed-size, so a short AX.25 frame is zero-padded to `frame_size` on TX, and on receive Mercury forwards the whole padded frame (`frame_size - HEADER_SIZE` bytes) to the client, which rejects the trailing zeros. Transmit works; receive does not. (Full analysis in #75.)

Observed: VarAC sends a 40-byte broadcast (`KISS frame decoded: cmd=0x01 len=40`), the receiver's Mercury always delivers `Sending KISS frame to client: ... payload=125`, and the client drops it.

## Fix
Carry the real payload length in a 2-byte big-endian prefix after the 1-byte Mercury header, flagged with a header extension bit (`BCAST_EXT_LEN_PREFIX`):

- **TX** (`bcast_process_decoded_frame`): header + length prefix + payload, then zero-pad.
- **RX** (`bcast_get_tx_payload`): if the received frame's header carries the flag, return exactly the original payload with `CMD_AX25CALLSIGN`. This is detected from the **frame's own header**, not the latched `bcast_reply_cmd` (which defaults to `CMD_DATA` and resets on every client connect, so a receive-only station otherwise forwards the raw padded frame). Frames without the flag fall back to the existing header-strip.

`CMD_DATA` (hermes-broadcast) framing is unchanged.

## Tests
Updates the affected broadcast unit tests and adds a TX→RX round-trip test plus a receive-only regression test in `tests/data_interfaces/test_tcp_interfaces.c`. Full suite passes locally (`make test`).

## ⚠️ Compatibility note (needs a maintainer decision)
This **changes the on-air broadcast frame format**, so a patched station and a stock station will **not broadcast-interoperate** (ARQ is unaffected; a receiver still falls back to legacy for unflagged frames). A broadcast-format version bump or capability flag may be warranted — happy to adjust the approach (e.g. gate behind a version, or drive the AX.25-vs-CMD_DATA decision entirely off the frame header).

Verified end-to-end on two FT-857D/DigiRig stations: with both patched, broadcasts now decode into VarAC (`Async message received`).