### PR TITLE
audioio: increase Linux ALSA/Pulse buffer from 30ms to 80ms

### DIFF
--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -413,7 +413,7 @@ void *radio_playback_thread(void *device_ptr)
     if (audio_subsystem == AUDIO_SUBSYSTEM_DSOUND)
         audio = (ffaudio_interface *) &ffdsound;
 #elif defined(__linux__)
-    conf.buf.buffer_length_msec = 30;
+    conf.buf.buffer_length_msec = 80;
     period_ms = conf.buf.buffer_length_msec / 3;
     if (audio_subsystem == AUDIO_SUBSYSTEM_ALSA)
         audio = (ffaudio_interface *) &ffalsa;
@@ -689,7 +689,7 @@ void *radio_capture_thread(void *device_ptr)
         audio = (ffaudio_interface *) &ffdsound;
     }
 #elif defined(__linux__)
-    conf.buf.buffer_length_msec = 30;
+    conf.buf.buffer_length_msec = 80;
     if (audio_subsystem == AUDIO_SUBSYSTEM_ALSA)
         audio = (ffaudio_interface *) &ffalsa;
     if (audio_subsystem == AUDIO_SUBSYSTEM_PULSE)


### PR DESCRIPTION
Raspberry Pi USB audio suffers from isochronous transfer jitter that causes buffer underruns with small 10ms periods. The resulting gaps in TX audio manifest as crackling noise that prevents reliable decoding by remote stations (e.g. VARA HF at ~5% decode rate).

Both ALSA and PulseAudio backends share this buffer length config. Increasing to 80ms (3 periods of ~27ms) gives the Pi's dwc_otg USB driver sufficient headroom to avoid underruns.

Closes #81