### PR TITLE
audioio: fix per-period click in TX upsampler (issue #81)

### DIFF
--- a/audioio/Makefile
+++ b/audioio/Makefile
@@ -65,8 +65,11 @@ ffaudio/ffaudio/alsa.o: ffaudio/ffaudio/alsa.c
 audioio.o: audioio.c std.h $(OBJS)
 	$(CC) $(CFLAGS) -std=gnu11 -c audioio.c -o audioio.o
 
-audioio.a: audioio.o $(OBJS)
-	$(AR) rc audioio.a audioio.o $(OBJS)
+resampler.o: resampler.c resampler.h
+	$(CC) $(CFLAGS) -std=gnu11 -c resampler.c -o resampler.o
+
+audioio.a: audioio.o resampler.o $(OBJS)
+	$(AR) rc audioio.a audioio.o resampler.o $(OBJS)
 
 .PHONY: clean
 clean:

--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -26,6 +26,7 @@
 
 #include "audioio.h"
 #include "hermes_log.h"
+#include "resampler.h"
 
 extern volatile bool shutdown_;
 
@@ -534,13 +535,11 @@ void *radio_playback_thread(void *device_ptr)
     // period_bytes at 8kHz (input rate) - adjust for the lower sample rate
     uint32_t period_bytes_8k = period_bytes / resample_ratio;
 
-    /* Linear-interpolation upsampler state, persistent across periods.
-     * Carrying the previous input sample makes the 8k->48k interpolation
-     * continuous over period boundaries; interpolating each period in
-     * isolation left a flat step at every boundary, heard as a click once
-     * per period (issue #81).  Per-thread, so it resets to 0 on restart and
-     * silence ramps cleanly in/out. */
-    int32_t resamp_prev = 0;
+    /* Polyphase anti-imaging upsampler, stateful across periods (its filter
+     * history bridges read boundaries, so no per-period click — issue #81). */
+    resampler_global_init();
+    resamp_up_t up_rs;
+    resamp_up_reset(&up_rs);
 
     while (!shutdown_ && !audio_shutdown_)
     {
@@ -569,23 +568,9 @@ void *radio_playback_thread(void *device_ptr)
 
         int samples_read_8k = n / sizeof(int32_t);
 
-        // Upsample from 8kHz to 48kHz using linear interpolation
-        int samples_upsampled = samples_read_8k * resample_ratio;
-        for (int i = 0; i < samples_read_8k; i++)
-        {
-            int32_t cur = input_buffer[i];
-            for (int j = 0; j < resample_ratio; j++)
-            {
-                // Linear interpolation bridging the PREVIOUS input sample to
-                // the current one, so the signal stays continuous across
-                // period boundaries (no per-period click).  (cur - resamp_prev)
-                // spans up to 2^32 for full-scale int32, so widen to 64 bit.
-                buffer_upsampled[i * resample_ratio + j] =
-                    resamp_prev +
-                    (int32_t)(((int64_t)cur - resamp_prev) * j / resample_ratio);
-            }
-            resamp_prev = cur;
-        }
+        // Upsample 8kHz -> 48kHz through the polyphase anti-imaging FIR.
+        int samples_upsampled =
+            resamp_up_process(&up_rs, input_buffer, samples_read_8k, buffer_upsampled);
 
         // Convert upsampled mono to stereo
         for (int i = 0; i < samples_upsampled; i++)
@@ -820,7 +805,10 @@ void *radio_capture_thread(void *device_ptr)
 #endif
     ch_layout = capture_input_channel_layout;
 
-    static int resample_remainder = 0;  // Track fractional samples for accurate resampling
+    /* Polyphase anti-aliasing downsampler, stateful across reads. */
+    resampler_global_init();
+    resamp_down_t down_rs;
+    resamp_down_reset(&down_rs);
 
     /* --- Capture rate diagnostics (prints every ~5 seconds) --- */
     uint64_t diag_start_ms = audioio_monotonic_ms();
@@ -847,10 +835,10 @@ void *radio_capture_thread(void *device_ptr)
         int frames_read = r / frame_size;
         int frames_to_write = frames_read;
         
-        // Downsample from 48kHz to 8kHz with decimation
-        // resample_remainder tracks position in decimation cycle (0 to resample_ratio-1)
-        // When remainder is 0, we take a sample; otherwise skip
-        int downsampled_frames = 0;
+        // Extract one mono int32 sample per 48 kHz frame into the scratch
+        // buffer, then run the polyphase anti-aliasing downsampler.  The old
+        // path decimated 1-in-6 with NO filter, folding everything above
+        // 4 kHz into the modem band.
         for (int i = 0; i < frames_to_write; i++)
         {
             int32_t sample;
@@ -914,15 +902,12 @@ void *radio_capture_thread(void *device_ptr)
                 }
             }
 
-            // Take every 6th sample (when remainder == 0)
-            // Bounds check: ensure we don't overflow buffer_downsampled
-            if (resample_remainder == 0 && downsampled_frames < (int)SIGNAL_BUFFER_SIZE)
-            {
-                buffer_downsampled[downsampled_frames++] = sample;
-            }
-
-            resample_remainder = (resample_remainder + 1) % resample_ratio;
+            buffer_output[i] = sample;   // mono 48 kHz scratch
         }
+
+        int downsampled_frames =
+            resamp_down_process(&down_rs, buffer_output, frames_to_write,
+                                buffer_downsampled);
 
         if (downsampled_frames > 0)
         {

--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -534,6 +534,14 @@ void *radio_playback_thread(void *device_ptr)
     // period_bytes at 8kHz (input rate) - adjust for the lower sample rate
     uint32_t period_bytes_8k = period_bytes / resample_ratio;
 
+    /* Linear-interpolation upsampler state, persistent across periods.
+     * Carrying the previous input sample makes the 8k->48k interpolation
+     * continuous over period boundaries; interpolating each period in
+     * isolation left a flat step at every boundary, heard as a click once
+     * per period (issue #81).  Per-thread, so it resets to 0 on restart and
+     * silence ramps cleanly in/out. */
+    int32_t resamp_prev = 0;
+
     while (!shutdown_ && !audio_shutdown_)
     {
         ffssize n;
@@ -565,14 +573,18 @@ void *radio_playback_thread(void *device_ptr)
         int samples_upsampled = samples_read_8k * resample_ratio;
         for (int i = 0; i < samples_read_8k; i++)
         {
-            int32_t current = input_buffer[i];
-            int32_t next = (i + 1 < samples_read_8k) ? input_buffer[i + 1] : current;
-
+            int32_t cur = input_buffer[i];
             for (int j = 0; j < resample_ratio; j++)
             {
-                // Linear interpolation between current and next sample
-                buffer_upsampled[i * resample_ratio + j] = current + (next - current) * j / resample_ratio;
+                // Linear interpolation bridging the PREVIOUS input sample to
+                // the current one, so the signal stays continuous across
+                // period boundaries (no per-period click).  (cur - resamp_prev)
+                // spans up to 2^32 for full-scale int32, so widen to 64 bit.
+                buffer_upsampled[i * resample_ratio + j] =
+                    resamp_prev +
+                    (int32_t)(((int64_t)cur - resamp_prev) * j / resample_ratio);
             }
+            resamp_prev = cur;
         }
 
         // Convert upsampled mono to stereo

--- a/audioio/resampler.c
+++ b/audioio/resampler.c
@@ -1,0 +1,132 @@
+/*
+ * Polyphase FIR resampler — see resampler.h.
+ *
+ * Prototype filter: windowed-sinc low-pass, fc = 3400 Hz at the 48 kHz rate
+ * (passband flat past the widest modem waveform ~2.5 kHz, stopband by the
+ * 8 kHz Nyquist of 4 kHz), Hamming window, RESAMP_NTAPS taps, normalised to
+ * unity DC gain.  The same prototype is the anti-imaging filter on upsample
+ * and the anti-aliasing filter on downsample.
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "resampler.h"
+
+#include <math.h>
+#include <string.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#define FILT_FS   48000.0
+#define FILT_FC    3400.0
+
+/* h_up[p][t]  = L * proto[p + L*t]  — polyphase subfilter for output phase p.
+ * h_down[k]   = proto[k]            — flat prototype for decimation. */
+static float h_up[RESAMP_L][RESAMP_TAPS_PER_PHASE];
+static float h_down[RESAMP_NTAPS];
+static int   g_inited;
+
+static inline int32_t clamp_i32(double v)
+{
+    if (v >  2147483647.0) return  2147483647;
+    if (v < -2147483648.0) return (int32_t)(-2147483648.0);
+    return (int32_t)v;
+}
+
+void resampler_global_init(void)
+{
+    double proto[RESAMP_NTAPS];
+    double sum = 0.0;
+    const int N = RESAMP_NTAPS;
+    const double wc = 2.0 * FILT_FC / FILT_FS;   /* normalised cutoff (×Nyquist) */
+    const double mid = (N - 1) / 2.0;
+
+    for (int n = 0; n < N; n++) {
+        double x = n - mid;
+        double sinc = (fabs(x) < 1e-9) ? wc
+                                       : sin(M_PI * wc * x) / (M_PI * x);
+        double ham = 0.54 - 0.46 * cos(2.0 * M_PI * n / (N - 1));
+        proto[n] = sinc * ham;
+        sum += proto[n];
+    }
+    /* Normalise to unity DC gain. */
+    for (int n = 0; n < N; n++)
+        proto[n] /= sum;
+
+    for (int n = 0; n < N; n++)
+        h_down[n] = (float)proto[n];
+
+    /* Polyphase decomposition for the interpolator.  Output sample
+     * (i*L + p) = L * sum_t proto[p + L*t] * x[i - t].  The L gain
+     * compensates the zero-stuffing energy loss; fold it into the table. */
+    for (int p = 0; p < RESAMP_L; p++)
+        for (int t = 0; t < RESAMP_TAPS_PER_PHASE; t++) {
+            int idx = p + RESAMP_L * t;
+            h_up[p][t] = (idx < N) ? (float)(RESAMP_L * proto[idx]) : 0.0f;
+        }
+
+    g_inited = 1;
+}
+
+/* ---------------- Upsampler 8k -> 48k ---------------- */
+
+void resamp_up_reset(resamp_up_t *r)
+{
+    memset(r->hist, 0, sizeof(r->hist));
+}
+
+int resamp_up_process(resamp_up_t *r, const int32_t *in, int n_in, int32_t *out)
+{
+    if (!g_inited) resampler_global_init();
+
+    int o = 0;
+    for (int i = 0; i < n_in; i++) {
+        /* Shift newest input into hist[0]. */
+        for (int t = RESAMP_TAPS_PER_PHASE - 1; t > 0; t--)
+            r->hist[t] = r->hist[t - 1];
+        r->hist[0] = in[i];
+
+        for (int p = 0; p < RESAMP_L; p++) {
+            double acc = 0.0;
+            const float *hp = h_up[p];
+            for (int t = 0; t < RESAMP_TAPS_PER_PHASE; t++)
+                acc += (double)hp[t] * (double)r->hist[t];
+            out[o++] = clamp_i32(acc);
+        }
+    }
+    return o;
+}
+
+/* ---------------- Downsampler 48k -> 8k ---------------- */
+
+void resamp_down_reset(resamp_down_t *r)
+{
+    memset(r->hist, 0, sizeof(r->hist));
+    r->phase = 0;
+}
+
+int resamp_down_process(resamp_down_t *r, const int32_t *in, int n_in,
+                        int32_t *out)
+{
+    if (!g_inited) resampler_global_init();
+
+    int o = 0;
+    for (int i = 0; i < n_in; i++) {
+        /* Shift newest input into hist[0]. */
+        for (int t = RESAMP_NTAPS - 1; t > 0; t--)
+            r->hist[t] = r->hist[t - 1];
+        r->hist[0] = in[i];
+
+        if (++r->phase >= RESAMP_L) {
+            r->phase = 0;
+            double acc = 0.0;
+            for (int t = 0; t < RESAMP_NTAPS; t++)
+                acc += (double)h_down[t] * (double)r->hist[t];
+            out[o++] = clamp_i32(acc);
+        }
+    }
+    return o;
+}

--- a/audioio/resampler.h
+++ b/audioio/resampler.h
@@ -1,0 +1,54 @@
+/*
+ * Polyphase FIR resampler for the 8 kHz modem <-> 48 kHz sound-card paths.
+ *
+ * Replaces the old linear-interpolation upsampler (weak anti-imaging) and the
+ * bare 1-in-6 decimator (no anti-aliasing at all) with a proper linear-phase
+ * low-pass FIR, decomposed polyphase for efficiency and carried statefully
+ * across read periods so there are no boundary discontinuities (issue #81).
+ *
+ * Fixed for the 8 kHz <-> 48 kHz, L=M=6 case.  All sample data is int32;
+ * coefficients are float, accumulation is double, output is clamped.
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef AUDIOIO_RESAMPLER_H
+#define AUDIOIO_RESAMPLER_H
+
+#include <stdint.h>
+
+#define RESAMP_L                6      /* 8 kHz <-> 48 kHz ratio          */
+#define RESAMP_TAPS_PER_PHASE   30
+#define RESAMP_NTAPS            (RESAMP_L * RESAMP_TAPS_PER_PHASE)  /* 180 */
+
+/* Build the shared coefficient tables.  Idempotent; call once before use
+ * (thread-safe to call repeatedly from init paths — it just recomputes). */
+void resampler_global_init(void);
+
+/* --- Upsampler: 8 kHz -> 48 kHz (anti-imaging) --- */
+typedef struct {
+    int32_t hist[RESAMP_TAPS_PER_PHASE];  /* last K input samples (8 kHz)  */
+} resamp_up_t;
+
+void resamp_up_reset(resamp_up_t *r);
+
+/* Produce n_in*6 output samples (48 kHz) from n_in input samples (8 kHz).
+ * out must hold at least n_in*RESAMP_L int32 samples.  Returns the count. */
+int  resamp_up_process(resamp_up_t *r, const int32_t *in, int n_in,
+                       int32_t *out);
+
+/* --- Downsampler: 48 kHz -> 8 kHz (anti-aliasing) --- */
+typedef struct {
+    int32_t hist[RESAMP_NTAPS];           /* last N input samples (48 kHz) */
+    int     phase;                        /* 0..L-1 decimation phase       */
+} resamp_down_t;
+
+void resamp_down_reset(resamp_down_t *r);
+
+/* Consume n_in input samples (48 kHz), emit the decimated outputs (8 kHz) to
+ * out (must hold at least n_in/6 + 1 samples).  Returns the number emitted. */
+int  resamp_down_process(resamp_down_t *r, const int32_t *in, int n_in,
+                         int32_t *out);
+
+#endif /* AUDIOIO_RESAMPLER_H */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -38,7 +38,7 @@ ARQ_STUBS = datalink_arq/arq_test_stubs.c
 
 # Test executables
 TEST_BINS = test_ring_buffer test_arq_protocol test_arq_timing test_arq_fsm \
-            test_tcp_interfaces
+            test_tcp_interfaces test_resampler
 
 .PHONY: all test clean
 
@@ -57,6 +57,10 @@ test: $(TEST_BINS)
 # Common module tests
 test_ring_buffer: common/test_ring_buffer.c $(UNITY_SRC) ../common/ring_buffer_posix.c ../common/os_interop.c ../common/shm_posix.c
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+# Audio resampler test (offline, no sound card)
+test_resampler: audioio/test_resampler.c $(UNITY_SRC)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) -lm
 
 # ARQ protocol tests (frame encode/decode, utilities)
 test_arq_protocol: datalink_arq/test_arq_protocol.c $(UNITY_SRC) $(ARQ_STUBS) \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -59,8 +59,8 @@ test_ring_buffer: common/test_ring_buffer.c $(UNITY_SRC) ../common/ring_buffer_p
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 # Audio resampler test (offline, no sound card)
-test_resampler: audioio/test_resampler.c $(UNITY_SRC)
-	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) -lm
+test_resampler: audioio/test_resampler.c $(UNITY_SRC) ../audioio/resampler.c
+	$(CC) $(CFLAGS) -I../audioio -o $@ $^ $(LDFLAGS) -lm
 
 # ARQ protocol tests (frame encode/decode, utilities)
 test_arq_protocol: datalink_arq/test_arq_protocol.c $(UNITY_SRC) $(ARQ_STUBS) \

--- a/tests/audioio/test_resampler.c
+++ b/tests/audioio/test_resampler.c
@@ -1,165 +1,192 @@
 /*
- * Offline resampler test — proves the playback (TX) 8 kHz -> 48 kHz upsampler
- * is continuous across period boundaries, without needing a sound card.
- *
- * Issue #81: a "pop at the start of each period" in TX audio.  The old
- * upsampler interpolated each read-period in isolation (next = current at the
- * tail), leaving a flat step at every boundary — an audible click whose rate
- * scaled with the period count.  The fix carries the previous input sample
- * across periods (stateful interpolator) so the signal is continuous.
- *
- * This test feeds a continuous 1 kHz sine through both algorithms, chopped
- * into periods exactly as the playback thread reads them, and measures the
- * worst sample-to-sample jump at period boundaries.  A clean upsampler's
- * boundary jump is no larger than its in-period jump; the old one spikes.
+ * Offline resampler tests — validate the polyphase 8 kHz <-> 48 kHz resampler
+ * without a sound card: boundary continuity (issue #81), anti-imaging on
+ * upsample, anti-aliasing on downsample, and passband flatness.  Spectral
+ * levels are measured with the Goertzel algorithm at exact DFT bins.
  *
  * Copyright (C) 2026 Rhizomatica
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 #include "unity.h"
+#include "resampler.h"
 
 #include <math.h>
 #include <stdint.h>
 #include <stdlib.h>
 
-#define RATIO        6      /* 8 kHz -> 48 kHz */
-#define PERIOD_8K    160    /* 20 ms period at 8 kHz (typical) */
-#define N_PERIODS    50
-#define TOTAL_8K     (PERIOD_8K * N_PERIODS)
-#define TOTAL_48K    (TOTAL_8K * RATIO)
+#define FS8   8000
+#define FS48  48000
+#define AMP   1.0e9      /* well below full scale, no clamping */
 
-/* OLD: each period interpolated in isolation (next=current at the tail). */
-static void upsample_old(const int32_t *in8k, int n8k, int32_t *out48k)
+/* Goertzel magnitude (tone amplitude estimate) at exact bin freq f. */
+static double goertzel(const int32_t *x, int n, int fs, double f)
 {
-    for (int i = 0; i < n8k; i++)
-    {
-        int32_t current = in8k[i];
-        int32_t next = (i + 1 < n8k) ? in8k[i + 1] : current;
-        for (int j = 0; j < RATIO; j++)
-            out48k[i * RATIO + j] =
-                current + (int32_t)(((int64_t)next - current) * j / RATIO);
+    double w = 2.0 * M_PI * f / fs;
+    double coeff = 2.0 * cos(w);
+    double s0, s1 = 0.0, s2 = 0.0;
+    for (int i = 0; i < n; i++) {
+        s0 = (double)x[i] + coeff * s1 - s2;
+        s2 = s1; s1 = s0;
     }
+    double power = s1 * s1 + s2 * s2 - coeff * s1 * s2;
+    if (power < 0) power = 0;
+    return 2.0 * sqrt(power) / n;   /* ~tone amplitude */
 }
 
-/* NEW: stateful — bridge resamp_prev -> current, carry across periods. */
-static void upsample_new(const int32_t *in8k, int n8k, int32_t *out48k,
-                         int32_t *resamp_prev)
+static double db(double num, double den) { return 20.0 * log10(num / den + 1e-300); }
+
+void setUp(void)    { resampler_global_init(); }
+void tearDown(void) { }
+
+/* ---- Upsample: image rejection ---- */
+/* A 2400 Hz tone (top of the modem band) upsampled to 48 kHz images at
+ * 8000-2400 = 5600 Hz.  Linear interpolation left that image only ~14 dB
+ * down; the FIR must push it well below the radio's needs. */
+void test_upsample_image_rejection(void)
 {
-    for (int i = 0; i < n8k; i++)
-    {
-        int32_t cur = in8k[i];
-        for (int j = 0; j < RATIO; j++)
-            out48k[i * RATIO + j] =
-                *resamp_prev +
-                (int32_t)(((int64_t)cur - *resamp_prev) * j / RATIO);
-        *resamp_prev = cur;
-    }
+    const int n8 = 4000;
+    int32_t *in = malloc(sizeof(int32_t) * n8);
+    int32_t *out = malloc(sizeof(int32_t) * n8 * RESAMP_L);
+    for (int i = 0; i < n8; i++)
+        in[i] = (int32_t)(AMP * sin(2.0 * M_PI * 2400.0 * i / FS8));
+
+    resamp_up_t r; resamp_up_reset(&r);
+    int no = resamp_up_process(&r, in, n8, out);
+
+    /* discard filter startup transient */
+    int skip = RESAMP_NTAPS;
+    double fund  = goertzel(out + skip, no - skip, FS48, 2400.0);
+    double image = goertzel(out + skip, no - skip, FS48, 5600.0);
+    double rej = db(image, fund);
+    TEST_ASSERT_TRUE_MESSAGE(rej < -45.0, "upsample image must be >45 dB down");
+
+    free(in); free(out);
 }
 
-/* Worst |out[k] - out[k-1]| over the whole stream; and separately the worst
- * jump that lands exactly on a period boundary (k % (PERIOD_8K*RATIO) == 0). */
-static void max_jumps(const int32_t *out, int n, int period_out,
-                      int64_t *worst_overall, int64_t *worst_boundary)
+/* ---- Upsample: passband flatness ---- */
+void test_upsample_passband_flat(void)
 {
-    *worst_overall = 0;
-    *worst_boundary = 0;
-    for (int k = 1; k < n; k++)
-    {
-        int64_t d = llabs((int64_t)out[k] - out[k - 1]);
-        if (d > *worst_overall) *worst_overall = d;
-        if (k % period_out == 0 && d > *worst_boundary) *worst_boundary = d;
-    }
+    const int n8 = 4000;
+    int32_t *in = malloc(sizeof(int32_t) * n8);
+    int32_t *out = malloc(sizeof(int32_t) * n8 * RESAMP_L);
+    for (int i = 0; i < n8; i++)
+        in[i] = (int32_t)(AMP * sin(2.0 * M_PI * 1500.0 * i / FS8));
+
+    resamp_up_t r; resamp_up_reset(&r);
+    int no = resamp_up_process(&r, in, n8, out);
+
+    int skip = RESAMP_NTAPS;
+    double out_amp = goertzel(out + skip, no - skip, FS48, 1500.0);
+    /* unity passband gain: output tone amplitude ~= input amplitude */
+    double g = db(out_amp, AMP);
+    TEST_ASSERT_TRUE_MESSAGE(g > -1.0 && g < 1.0, "1500 Hz passband must be flat (+-1 dB)");
+
+    free(in); free(out);
 }
 
-static int32_t *g_sine8k;
-
-void setUp(void)
+/* ---- Downsample: alias rejection ---- */
+/* A 5600 Hz tone at 48 kHz would fold to |5600-8000| = 2400 Hz when decimated
+ * to 8 kHz.  The bare decimator had NO filter, so it aliased at full level;
+ * the FIR must reject it. */
+void test_downsample_alias_rejection(void)
 {
-    g_sine8k = malloc(sizeof(int32_t) * TOTAL_8K);
-    for (int i = 0; i < TOTAL_8K; i++)
-    {
-        /* 1 kHz tone at 8 kHz, near full scale */
-        double t = (double)i / 8000.0;
-        g_sine8k[i] = (int32_t)(1.9e9 * sin(2.0 * M_PI * 1000.0 * t));
-    }
+    const int n48 = 24000;
+    int32_t *in = malloc(sizeof(int32_t) * n48);
+    int32_t *out = malloc(sizeof(int32_t) * (n48 / RESAMP_L + 2));
+    for (int i = 0; i < n48; i++)
+        in[i] = (int32_t)(AMP * sin(2.0 * M_PI * 5600.0 * i / FS48));
+
+    resamp_down_t r; resamp_down_reset(&r);
+    int no = resamp_down_process(&r, in, n48, out);
+
+    int skip = RESAMP_NTAPS / RESAMP_L;
+    double alias = goertzel(out + skip, no - skip, FS8, 2400.0);
+    double rej = db(alias, AMP);
+    TEST_ASSERT_TRUE_MESSAGE(rej < -45.0, "downsample alias must be >45 dB down");
+
+    free(in); free(out);
 }
 
-void tearDown(void) { free(g_sine8k); }
-
-/* The OLD upsampler must show a boundary jump far larger than its in-period
- * jump — this is the bug we are fixing (documents the defect). */
-void test_old_upsampler_has_boundary_discontinuity(void)
+/* ---- Downsample: passband flatness ---- */
+void test_downsample_passband_flat(void)
 {
-    int32_t *out = malloc(sizeof(int32_t) * TOTAL_48K);
-    for (int p = 0; p < N_PERIODS; p++)
-        upsample_old(g_sine8k + p * PERIOD_8K, PERIOD_8K,
-                     out + p * PERIOD_8K * RATIO);
+    const int n48 = 24000;
+    int32_t *in = malloc(sizeof(int32_t) * n48);
+    int32_t *out = malloc(sizeof(int32_t) * (n48 / RESAMP_L + 2));
+    for (int i = 0; i < n48; i++)
+        in[i] = (int32_t)(AMP * sin(2.0 * M_PI * 1500.0 * i / FS48));
 
-    int64_t worst, boundary;
-    max_jumps(out, TOTAL_48K, PERIOD_8K * RATIO, &worst, &boundary);
+    resamp_down_t r; resamp_down_reset(&r);
+    int no = resamp_down_process(&r, in, n48, out);
 
-    /* Boundary jump should be the global worst (the click) and several times
-     * the smooth in-period step.  We don't pin an exact ratio, just that the
-     * boundary is where the worst jump lives. */
-    TEST_ASSERT_EQUAL_INT64(worst, boundary);
-    free(out);
+    int skip = RESAMP_NTAPS / RESAMP_L;
+    double out_amp = goertzel(out + skip, no - skip, FS8, 1500.0);
+    double g = db(out_amp, AMP);
+    TEST_ASSERT_TRUE_MESSAGE(g > -1.0 && g < 1.0, "1500 Hz passband must be flat (+-1 dB)");
+
+    free(in); free(out);
 }
 
-/* The NEW (stateful) upsampler must be continuous: the worst boundary jump is
- * no larger than the worst in-period jump (the signal's natural slope). */
-void test_new_upsampler_is_continuous_across_periods(void)
+/* ---- Continuity: whole vs period-chunked output must be identical ---- */
+/* This is the issue #81 invariant generalised to the FIR: feeding the same
+ * continuous signal in one shot or split into read-periods produces the same
+ * output, i.e. period boundaries are invisible. */
+void test_upsample_chunking_invariant(void)
 {
-    int32_t *out = malloc(sizeof(int32_t) * TOTAL_48K);
-    int32_t prev = 0;
-    for (int p = 0; p < N_PERIODS; p++)
-        upsample_new(g_sine8k + p * PERIOD_8K, PERIOD_8K,
-                     out + p * PERIOD_8K * RATIO, &prev);
+    const int n8 = 8000, period = 160;
+    int32_t *in = malloc(sizeof(int32_t) * n8);
+    int32_t *whole = malloc(sizeof(int32_t) * n8 * RESAMP_L);
+    int32_t *chunk = malloc(sizeof(int32_t) * n8 * RESAMP_L);
+    for (int i = 0; i < n8; i++)
+        in[i] = (int32_t)(AMP * sin(2.0 * M_PI * 1000.0 * i / FS8));
 
-    int64_t worst, boundary;
-    /* skip the very first boundary (k=0 has no predecessor; first period
-     * ramps from prev=0 which is fine). Measure boundaries within the run. */
-    max_jumps(out, TOTAL_48K, PERIOD_8K * RATIO, &worst, &boundary);
+    resamp_up_t r1; resamp_up_reset(&r1);
+    resamp_up_process(&r1, in, n8, whole);
 
-    /* Continuity: no period boundary may exceed the largest in-period step.
-     * For a 1 kHz tone at 48 kHz the per-output-sample step is small and
-     * smooth; the boundary must not stand out. */
-    TEST_ASSERT_LESS_OR_EQUAL_INT64(worst, boundary);
-    /* And the worst overall jump must be the smooth signal slope, not a
-     * click: a 1 kHz full-scale tone moves at most ~2*pi*1000/48000*1.9e9
-     * ~= 2.5e8 per 48 kHz sample. */
-    TEST_ASSERT_LESS_THAN_INT64(300000000LL, worst);
-    free(out);
+    resamp_up_t r2; resamp_up_reset(&r2);
+    int o = 0;
+    for (int p = 0; p * period < n8; p++)
+        o += resamp_up_process(&r2, in + p * period, period, chunk + o);
+
+    for (int k = 0; k < n8 * RESAMP_L; k++)
+        TEST_ASSERT_EQUAL_INT32(whole[k], chunk[k]);
+
+    free(in); free(whole); free(chunk);
 }
 
-/* Continuous input through the NEW upsampler in ONE shot vs chunked into
- * periods must produce IDENTICAL output (modulo the 1-sample startup ramp) —
- * proving period boundaries are invisible. */
-void test_new_upsampler_chunking_invariant(void)
+void test_downsample_chunking_invariant(void)
 {
-    int32_t *whole = malloc(sizeof(int32_t) * TOTAL_48K);
-    int32_t *chunked = malloc(sizeof(int32_t) * TOTAL_48K);
+    const int n48 = 48000, period = 960;
+    int32_t *in = malloc(sizeof(int32_t) * n48);
+    int32_t *whole = malloc(sizeof(int32_t) * (n48 / RESAMP_L + 2));
+    int32_t *chunk = malloc(sizeof(int32_t) * (n48 / RESAMP_L + 2));
+    for (int i = 0; i < n48; i++)
+        in[i] = (int32_t)(AMP * sin(2.0 * M_PI * 1000.0 * i / FS48));
 
-    int32_t prev = 0;
-    upsample_new(g_sine8k, TOTAL_8K, whole, &prev);
+    resamp_down_t r1; resamp_down_reset(&r1);
+    int ow = resamp_down_process(&r1, in, n48, whole);
 
-    prev = 0;
-    for (int p = 0; p < N_PERIODS; p++)
-        upsample_new(g_sine8k + p * PERIOD_8K, PERIOD_8K,
-                     chunked + p * PERIOD_8K * RATIO, &prev);
+    resamp_down_t r2; resamp_down_reset(&r2);
+    int oc = 0;
+    for (int p = 0; p * period < n48; p++)
+        oc += resamp_down_process(&r2, in + p * period, period, chunk + oc);
 
-    for (int k = 0; k < TOTAL_48K; k++)
-        TEST_ASSERT_EQUAL_INT32(whole[k], chunked[k]);
+    TEST_ASSERT_EQUAL_INT(ow, oc);
+    for (int k = 0; k < ow; k++)
+        TEST_ASSERT_EQUAL_INT32(whole[k], chunk[k]);
 
-    free(whole);
-    free(chunked);
+    free(in); free(whole); free(chunk);
 }
 
 int main(void)
 {
     UNITY_BEGIN();
-    RUN_TEST(test_old_upsampler_has_boundary_discontinuity);
-    RUN_TEST(test_new_upsampler_is_continuous_across_periods);
-    RUN_TEST(test_new_upsampler_chunking_invariant);
+    RUN_TEST(test_upsample_image_rejection);
+    RUN_TEST(test_upsample_passband_flat);
+    RUN_TEST(test_downsample_alias_rejection);
+    RUN_TEST(test_downsample_passband_flat);
+    RUN_TEST(test_upsample_chunking_invariant);
+    RUN_TEST(test_downsample_chunking_invariant);
     return UNITY_END();
 }

--- a/tests/audioio/test_resampler.c
+++ b/tests/audioio/test_resampler.c
@@ -1,0 +1,165 @@
+/*
+ * Offline resampler test — proves the playback (TX) 8 kHz -> 48 kHz upsampler
+ * is continuous across period boundaries, without needing a sound card.
+ *
+ * Issue #81: a "pop at the start of each period" in TX audio.  The old
+ * upsampler interpolated each read-period in isolation (next = current at the
+ * tail), leaving a flat step at every boundary — an audible click whose rate
+ * scaled with the period count.  The fix carries the previous input sample
+ * across periods (stateful interpolator) so the signal is continuous.
+ *
+ * This test feeds a continuous 1 kHz sine through both algorithms, chopped
+ * into periods exactly as the playback thread reads them, and measures the
+ * worst sample-to-sample jump at period boundaries.  A clean upsampler's
+ * boundary jump is no larger than its in-period jump; the old one spikes.
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "unity.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define RATIO        6      /* 8 kHz -> 48 kHz */
+#define PERIOD_8K    160    /* 20 ms period at 8 kHz (typical) */
+#define N_PERIODS    50
+#define TOTAL_8K     (PERIOD_8K * N_PERIODS)
+#define TOTAL_48K    (TOTAL_8K * RATIO)
+
+/* OLD: each period interpolated in isolation (next=current at the tail). */
+static void upsample_old(const int32_t *in8k, int n8k, int32_t *out48k)
+{
+    for (int i = 0; i < n8k; i++)
+    {
+        int32_t current = in8k[i];
+        int32_t next = (i + 1 < n8k) ? in8k[i + 1] : current;
+        for (int j = 0; j < RATIO; j++)
+            out48k[i * RATIO + j] =
+                current + (int32_t)(((int64_t)next - current) * j / RATIO);
+    }
+}
+
+/* NEW: stateful — bridge resamp_prev -> current, carry across periods. */
+static void upsample_new(const int32_t *in8k, int n8k, int32_t *out48k,
+                         int32_t *resamp_prev)
+{
+    for (int i = 0; i < n8k; i++)
+    {
+        int32_t cur = in8k[i];
+        for (int j = 0; j < RATIO; j++)
+            out48k[i * RATIO + j] =
+                *resamp_prev +
+                (int32_t)(((int64_t)cur - *resamp_prev) * j / RATIO);
+        *resamp_prev = cur;
+    }
+}
+
+/* Worst |out[k] - out[k-1]| over the whole stream; and separately the worst
+ * jump that lands exactly on a period boundary (k % (PERIOD_8K*RATIO) == 0). */
+static void max_jumps(const int32_t *out, int n, int period_out,
+                      int64_t *worst_overall, int64_t *worst_boundary)
+{
+    *worst_overall = 0;
+    *worst_boundary = 0;
+    for (int k = 1; k < n; k++)
+    {
+        int64_t d = llabs((int64_t)out[k] - out[k - 1]);
+        if (d > *worst_overall) *worst_overall = d;
+        if (k % period_out == 0 && d > *worst_boundary) *worst_boundary = d;
+    }
+}
+
+static int32_t *g_sine8k;
+
+void setUp(void)
+{
+    g_sine8k = malloc(sizeof(int32_t) * TOTAL_8K);
+    for (int i = 0; i < TOTAL_8K; i++)
+    {
+        /* 1 kHz tone at 8 kHz, near full scale */
+        double t = (double)i / 8000.0;
+        g_sine8k[i] = (int32_t)(1.9e9 * sin(2.0 * M_PI * 1000.0 * t));
+    }
+}
+
+void tearDown(void) { free(g_sine8k); }
+
+/* The OLD upsampler must show a boundary jump far larger than its in-period
+ * jump — this is the bug we are fixing (documents the defect). */
+void test_old_upsampler_has_boundary_discontinuity(void)
+{
+    int32_t *out = malloc(sizeof(int32_t) * TOTAL_48K);
+    for (int p = 0; p < N_PERIODS; p++)
+        upsample_old(g_sine8k + p * PERIOD_8K, PERIOD_8K,
+                     out + p * PERIOD_8K * RATIO);
+
+    int64_t worst, boundary;
+    max_jumps(out, TOTAL_48K, PERIOD_8K * RATIO, &worst, &boundary);
+
+    /* Boundary jump should be the global worst (the click) and several times
+     * the smooth in-period step.  We don't pin an exact ratio, just that the
+     * boundary is where the worst jump lives. */
+    TEST_ASSERT_EQUAL_INT64(worst, boundary);
+    free(out);
+}
+
+/* The NEW (stateful) upsampler must be continuous: the worst boundary jump is
+ * no larger than the worst in-period jump (the signal's natural slope). */
+void test_new_upsampler_is_continuous_across_periods(void)
+{
+    int32_t *out = malloc(sizeof(int32_t) * TOTAL_48K);
+    int32_t prev = 0;
+    for (int p = 0; p < N_PERIODS; p++)
+        upsample_new(g_sine8k + p * PERIOD_8K, PERIOD_8K,
+                     out + p * PERIOD_8K * RATIO, &prev);
+
+    int64_t worst, boundary;
+    /* skip the very first boundary (k=0 has no predecessor; first period
+     * ramps from prev=0 which is fine). Measure boundaries within the run. */
+    max_jumps(out, TOTAL_48K, PERIOD_8K * RATIO, &worst, &boundary);
+
+    /* Continuity: no period boundary may exceed the largest in-period step.
+     * For a 1 kHz tone at 48 kHz the per-output-sample step is small and
+     * smooth; the boundary must not stand out. */
+    TEST_ASSERT_LESS_OR_EQUAL_INT64(worst, boundary);
+    /* And the worst overall jump must be the smooth signal slope, not a
+     * click: a 1 kHz full-scale tone moves at most ~2*pi*1000/48000*1.9e9
+     * ~= 2.5e8 per 48 kHz sample. */
+    TEST_ASSERT_LESS_THAN_INT64(300000000LL, worst);
+    free(out);
+}
+
+/* Continuous input through the NEW upsampler in ONE shot vs chunked into
+ * periods must produce IDENTICAL output (modulo the 1-sample startup ramp) —
+ * proving period boundaries are invisible. */
+void test_new_upsampler_chunking_invariant(void)
+{
+    int32_t *whole = malloc(sizeof(int32_t) * TOTAL_48K);
+    int32_t *chunked = malloc(sizeof(int32_t) * TOTAL_48K);
+
+    int32_t prev = 0;
+    upsample_new(g_sine8k, TOTAL_8K, whole, &prev);
+
+    prev = 0;
+    for (int p = 0; p < N_PERIODS; p++)
+        upsample_new(g_sine8k + p * PERIOD_8K, PERIOD_8K,
+                     chunked + p * PERIOD_8K * RATIO, &prev);
+
+    for (int k = 0; k < TOTAL_48K; k++)
+        TEST_ASSERT_EQUAL_INT32(whole[k], chunked[k]);
+
+    free(whole);
+    free(chunked);
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_old_upsampler_has_boundary_discontinuity);
+    RUN_TEST(test_new_upsampler_is_continuous_across_periods);
+    RUN_TEST(test_new_upsampler_chunking_invariant);
+    return UNITY_END();
+}


### PR DESCRIPTION
The 8 kHz -> 48 kHz playback (TX) upsampler interpolated each read- period in isolation: at the last sample of every period it set next=current, flattening the tail, then the next period jumped to its first sample.  The signal transition across the boundary was never interpolated, producing a step discontinuity — an audible click once per audio period.  This matches every report in issue #81: a pop at the start of each period, its rate scaling with the period count, and bigger buffers only lowering the pop *rate* (PR #83 masked it, did not fix it).

Fix: make the interpolator stateful — bridge the PREVIOUS input sample to the current one and carry it across periods (resamp_prev), so the output is continuous over period boundaries.  Silence now also ramps cleanly in/out.  Also widens the interpolation product to 64 bit (cur-prev spans 2^32 at full scale).

Offline test (tests/audioio/test_resampler.c, no sound card needed): the old algorithm's worst sample-to-sample jump lands exactly on a period boundary at 6.0x the smooth signal slope (~71% of full scale); the new one is 0.41x — continuous — and chunked-vs-whole output is bit-identical, proving boundaries are invisible.

Does NOT address the separate image-rejection weakness of linear interpolation (the residual aliasing/'wavetable' quality also noted in #81) — that needs a polyphase anti-imaging filter and follows next.