### PR TITLE
audioio: right-size resampler scratch buffers (fixes #79)

### DIFF
--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -452,14 +452,22 @@ void *radio_playback_thread(void *device_ptr)
     ffuint frame_size;
     ffuint msec_bytes;
 
-    // input is int32_t (8kHz samples from playback_buffer)
-    int32_t *input_buffer = (int32_t *) malloc(SIGNAL_BUFFER_SIZE * sizeof(int32_t));
+    /* Per-period resampler scratch.  These only ever hold ONE 8 kHz read
+     * period (period_bytes_8k below) and its 1:6 upsampled 48 kHz stereo
+     * expansion.  Sizing from SIGNAL_BUFFER_SIZE allocated ~590 MB for the
+     * stereo buffer alone (~1 GB across both audio threads), which fails on
+     * low-RAM 32-bit hosts such as the 512 MB Pi Zero2W — the modem could not
+     * run there (issue #79).  Size from the actual period instead. */
+    size_t period_scratch_bytes = (size_t) 8000u * sizeof(int32_t) * period_ms / 1000u + 64;
 
-    // upsampled buffer (48kHz mono)
-    int32_t *buffer_upsampled = (int32_t *) malloc(SIGNAL_BUFFER_SIZE * sizeof(int32_t) * 6);
+    // input is int32_t (8kHz samples from playback_buffer)
+    int32_t *input_buffer = (int32_t *) malloc(period_scratch_bytes);
+
+    // upsampled buffer (48kHz mono), 1:6 upsample
+    int32_t *buffer_upsampled = (int32_t *) malloc(period_scratch_bytes * 6);
 
     // output is int32_t stereo (48kHz)
-    int32_t *buffer_output_stereo = (int32_t *) malloc(SIGNAL_BUFFER_SIZE * sizeof(int32_t) * 2 * 6); // a big enough buffer
+    int32_t *buffer_output_stereo = (int32_t *) malloc(period_scratch_bytes * 2 * 6);
 
     if (!input_buffer || !buffer_upsampled || !buffer_output_stereo)
     {
@@ -797,8 +805,15 @@ void *radio_capture_thread(void *device_ptr)
         return NULL;
     }
 
-    buffer_output = (int32_t *) malloc(SIGNAL_BUFFER_SIZE * sizeof(int32_t) * 2);
-    buffer_downsampled = (int32_t *) malloc(SIGNAL_BUFFER_SIZE * sizeof(int32_t));
+    /* Per-read resampler scratch, sized from the device buffer length (was
+     * SIGNAL_BUFFER_SIZE — same ~1 GB oversizing as the playback path,
+     * issue #79).  buffer_output holds one device read of mono 48 kHz samples;
+     * buffer_downsampled its 6:1 decimation. */
+    size_t cap_frames_max = (size_t) cfg->sample_rate * cfg->buffer_length_msec / 1000;
+    cap_frames_max += cap_frames_max / 2 + 64;   /* margin over one read */
+
+    buffer_output = (int32_t *) malloc(cap_frames_max * sizeof(int32_t));
+    buffer_downsampled = (int32_t *) malloc((cap_frames_max / 6 + 2) * sizeof(int32_t));
     if (!buffer_output || !buffer_downsampled)
     {
         HLOGE("audio-cap", "Failed to allocate capture buffers");


### PR DESCRIPTION
# audioio: right-size resampler scratch buffers (fixes #79)

## Summary

`radio_playback_thread` and `radio_capture_thread` size their resampler scratch
buffers from `SIGNAL_BUFFER_SIZE` (12,288,000 samples) — roughly **590 MB for the
playback stereo buffer alone and ~1 GB across both threads**. On low-RAM 32-bit
hosts — notably the **512 MB Raspberry Pi Zero2W** — these allocations fail, so
the modem cannot run there. Hosts with more RAM (e.g. a Pi4) allocate
successfully and never hit it, matching @craigerl's observation that the Pi4 is
fine while the Zero2W crashes.

`728dbf7` (the recent correctness batch) added `NULL` checks on exactly these
allocations, so this PR drops the duplicate checks and is now **resize-only**,
stacking on top of that change. Note the `NULL` check turns the failure from a
segfault into a graceful `Failed to allocate ... buffers` exit — but the
allocation still fails, the audio thread still can't start, and the board stays
unusable. **Right-sizing is what actually lets it run.**

These buffers only ever hold **one audio period**, so this PR sizes them from
the period (playback: `period_ms`; capture: the device buffer length). The
per-thread footprint drops from ~1 GB to a few KB.

## Root cause detail

Before `728dbf7` the unchecked 590 MB `malloc` returned `NULL` and was
dereferenced on the first TX, producing the #79 segfault. This is confirmed by
@craigerl's attached core dump: the crashing thread is in
`radio_playback_thread`, faulting on the mono→stereo write (`str r12, [r1]` with
`r1 = 0x0`), i.e. `buffer_output_stereo[idx] = ...` with `buffer_output_stereo ==
NULL`. `buffer_upsampled` (295 MB) is a valid pointer in the same core, so only
the largest (590 MB) allocation failed — exactly the `{×1, ×6, ×12}` oversizing.
That also shows the 512 MB board returns `NULL` here (not an OOM-kill).

The loop reads at most one 8 kHz period and upsamples 1:6 to stereo, so the live
data is a few hundred samples — the `SIGNAL_BUFFER_SIZE` sizing over-allocated by
~10^4–10^5×.

## The fix

- **Playback:** `period_scratch_bytes = 8000 * sizeof(int32_t) * period_ms / 1000
  + 64`, then size `input_buffer` / `buffer_upsampled` (×6) / `buffer_output_stereo`
  (×12) from it.
- **Capture:** size `buffer_output` / `buffer_downsampled` from
  `cfg->sample_rate * cfg->buffer_length_msec / 1000` (+50% margin).
- The `728dbf7` `NULL` checks are kept.

No functional change to the audio path — the resampler is stateful across
periods and these buffers are per-iteration scratch; correct sizing produces
identical output.

## Verification

- Builds clean with `gcc` on armhf (Debian Trixie) against current `mercuryv2`.
- **Reproduction (emulated armhf, 32-bit):** an `LD_PRELOAD` shim returning `NULL`
  for allocations ≥ 400 MB (simulating the Zero2W's refusal of the 590 MB
  request) makes the pre-`728dbf7` build **segfault at PTT-ON**; current
  `mercuryv2` fails gracefully but the audio thread exits; **with this patch the
  modem runs** (the giant allocation is gone, nothing to refuse).
- **AddressSanitizer** over the real `-x alsa` playback path (CONNECT/TX) reports
  no overflow against the resized buffers — the new sizing is correct.

Confirmation on a physical 512 MB Pi Zero2W by @craigerl would be the ideal final
check.
