### PR TITLE
build: fix macOS (Apple clang) compilation

### DIFF
--- a/common/ring_buffer_posix.c
+++ b/common/ring_buffer_posix.c
@@ -20,7 +20,22 @@
 #include <string.h>
 
 #include <time.h>
+#if defined(__APPLE__)
+/* macOS has no <malloc.h>, memalign(3), or SHMLBA.  The shared-memory path
+ * below (the -x shm backend) is Linux-only at runtime, but still has to
+ * compile.  posix_memalign(3) from <stdlib.h> is the portable equivalent. */
+#include <unistd.h>
+#ifndef SHMLBA
+#define SHMLBA sysconf(_SC_PAGESIZE)
+#endif
+static inline void *memalign(size_t alignment, size_t size)
+{
+    void *p = NULL;
+    return posix_memalign(&p, alignment, size) == 0 ? p : NULL;
+}
+#else
 #include <malloc.h>
+#endif
 
 #include "os_interop.h"
 

--- a/modem/freedv/defines.h
+++ b/modem/freedv/defines.h
@@ -113,7 +113,7 @@ extern const struct lsp_codebook newamp1_energy_cb[];
 extern const struct lsp_codebook newamp2vq_cb[];
 extern const struct lsp_codebook newamp2_energy_cb[];
 
-#if defined(_GNU_SOURCE) && !defined(_WIN32)
+#if defined(_GNU_SOURCE) && !defined(_WIN32) && !defined(__APPLE__)
 #define POW10F(x) exp10f((x))
 #else
 #define POW10F(x) expf(2.302585092994046f * (x))


### PR DESCRIPTION
Mercury doesn't build on macOS (Apple clang) today. This fixes the three glibc-only spots that stop it: the `exp10f` use in FreeDV's `POW10F` macro, and `<malloc.h>` / `memalign` / `SHMLBA` in `ring_buffer_posix.c`. All changes are behind `__APPLE__`, so Linux and Windows builds are unaffected. Verified building on both macOS and Linux/armhf, with a working binary on each.

Scope note: this fixes the build. It doesn't claim validated CoreAudio runtime on Mac; the control/TNC paths run, but I didn't test audio on Mac hardware.

Diff is 2 files, +16/-1.