### PR TITLE
audioio: break on write error instead of corrupting the playback offset

### DIFF
--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -647,6 +647,7 @@ void *radio_playback_thread(void *device_ptr)
             if (r < 0)
             {
                 HLOGE("audio-play", "ffaudio.write: %s", audio->error(b));
+                break;
             }
 #if 0 // print time measurement
             else


### PR DESCRIPTION
## The bug

`radio_playback_thread` has an inner loop that calls `audio->write()` until a
full period of samples is drained to the device. Underrun (`-FFAUDIO_ESYNC`) is
handled with a `continue`. Any other negative return — `FFAUDIO_ERROR` (-1) or
`FFAUDIO_EDEV_OFFLINE` (-4) — falls through to the update arithmetic:

```c
total_written += r;   // ffuint (unsigned int) + negative int wraps to ~4 GB
n -= r;               // ssize_t -= negative grows n; loop continues
```

On the next iteration, `audio->write()` is called as:

```c
audio->write(b, ((uint8_t *)buffer_output_stereo) + total_written, n)
```

with `total_written` now ~4 GB, reading and writing arbitrary memory past the
end of the heap-allocated output buffer. The result is a segfault or silent
corruption of whatever lives at that address.

The typical trigger: a USB soundcard unplugged or going offline mid-transmit,
which returns `FFAUDIO_EDEV_OFFLINE`. This is a realistic field event on Pi
rigs running off battery with a USB audio adapter.

## The fix

One line: `break` on any `r < 0` that is not `FFAUDIO_ESYNC`. This matches how
the capture thread already handles its equivalent read errors, and leaves
`total_written` / `n` in their pre-error state so no pointer arithmetic is
corrupted.

The outer `while (!shutdown_ && !audio_shutdown_)` loop then retries the next
period; on a persistent device-offline it will keep logging and retrying until
shutdown is signaled, which is the existing behaviour for other audio errors.

## Diff

1 file, +1/-0.