### PR TITLE
common: async-signal-safe SIGINT handler, shm_map NULL, ring guard, diagnostics

### DIFF
--- a/common/ring_buffer_posix.c
+++ b/common/ring_buffer_posix.c
@@ -580,6 +580,8 @@ int read_buffer(cbuf_handle_t cbuf, uint8_t *data, size_t len)
 {
     assert(cbuf && data && cbuf->internal && cbuf->buffer);
 
+    if (len == 0) return 0;
+
     int r = -1;
 
  try_again_read:
@@ -617,6 +619,8 @@ int read_buffer(cbuf_handle_t cbuf, uint8_t *data, size_t len)
 int write_buffer(cbuf_handle_t cbuf, uint8_t * data, size_t len)
 {
     assert(cbuf && cbuf->internal && cbuf->buffer);
+
+    if (len == 0) return 0;
 
     int r = -1;
 

--- a/common/shm_posix.c
+++ b/common/shm_posix.c
@@ -101,21 +101,25 @@ int shm_create_and_get_fd(char *name, size_t size)
 		abort();
 	}
 #else
-    if (shm_open(name, O_RDWR, 0644) >= 0)
     {
-        // fprintf(stderr, "POSIX shared memory already created. Re-creating it.\n");
-        shm_unlink(name);
+        int probe_fd = shm_open(name, O_RDWR, 0644);
+        if (probe_fd >= 0)
+        {
+            // fprintf(stderr, "POSIX shared memory already created. Re-creating it.\n");
+            close(probe_fd);
+            shm_unlink(name);
+        }
     }
 
     if((fd = shm_open(name, O_RDWR | O_CREAT, 0644)) == -1)
     {
-        fprintf(stderr, "ERROR: This should never happen! SHM creation error!\n");
+        fprintf(stderr, "ERROR: This should never happen! SHM creation error: %s\n", strerror(errno));
         abort();
     }
 
     if (ftruncate (fd, size) == -1)
     {
-        fprintf(stderr, "ERROR: This should never happen! Error in ftruncate!\n");
+        fprintf(stderr, "ERROR: This should never happen! Error in ftruncate: %s\n", strerror(errno));
         abort();
     }
 #endif
@@ -124,7 +128,7 @@ int shm_create_and_get_fd(char *name, size_t size)
 }
 
 
-// returns the pointer to the region, or (void *) -1 in case of error
+// returns the pointer to the region, or NULL in case of error
 void *shm_map(int fd, size_t size)
 {
 #if defined(_WIN32)
@@ -140,7 +144,8 @@ void *shm_map(int fd, size_t size)
 
     return data;
 #else
-    return mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    void *ptr = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    return (ptr == MAP_FAILED) ? NULL : ptr;
 #endif
 }
 

--- a/main.c
+++ b/main.c
@@ -82,13 +82,21 @@ char *freedv_mode_names[] = { "DATAC1",
 
 volatile bool shutdown_ = false; // global shutdown flag
 
+static volatile sig_atomic_t g_signal_count = 0;
+
 static void handle_termination_signal(int sig)
 {
     (void)sig;
+    if (g_signal_count)
+    {
+        static const char msg[] = "Caught second signal, forcing exit.\n";
+        write(STDERR_FILENO, msg, sizeof(msg) - 1);
+        _exit(1);
+    }
+    g_signal_count = 1;
+    static const char msg[] = "Signal received, shutting down...\n";
+    write(STDERR_FILENO, msg, sizeof(msg) - 1);
     shutdown_ = true;
-    HLOGI("main", "Termination signal received, shutting down...");
-    msleep(1500); // give some time for the main loop to exit and for the modem and interfaces to shutdown gracefully
-    exit(0); // in case the main loop is stuck for some reason, we force exit after a delay
 }
 
 static int parse_rx_channel_layout(const char *value)
@@ -173,6 +181,11 @@ int main(int argc, char *argv[])
     int audio_system = -1; // default audio system
     char *input_dev = (char *) malloc(MAX_PATH);
     char *output_dev = (char *) malloc(MAX_PATH);
+    if (!input_dev || !output_dev)
+    {
+        fprintf(stderr, "out of memory\n");
+        exit(1);
+    }
     uint16_t ui_port = UI_DEFAULT_PORT;
     bool waterfall_enabled = true;
     bool ui_enabled = false;
@@ -550,11 +563,11 @@ int main(int argc, char *argv[])
     case AUDIO_SUBSYSTEM_OSS:
         if (input_dev[0] == 0)
         {
-            sprintf(input_dev, "/dev/dsp");
+            snprintf(input_dev, MAX_PATH, "/dev/dsp");
         }
         if (output_dev[0] == 0)
         {
-            sprintf(output_dev, "/dev/dsp");
+            snprintf(output_dev, MAX_PATH, "/dev/dsp");
         }
         printf("Open Sound System (OSS)\n");
         break;


### PR DESCRIPTION
Six small hardening fixes in main.c, shm_posix.c, and ring_buffer_posix.c. For consideration.

**Async-signal-safe SIGINT handler (main.c)**
The current handler calls `HLOGI`, `msleep(1500)`, and `exit(0)` — none async-signal-safe. If the signal lands inside `malloc` or `printf` the behavior is undefined. Replaced with: `volatile sig_atomic_t` flag + `write(STDERR_FILENO, ...)` on first signal; `_exit(1)` on second. The main loop already polls `shutdown_` so clean shutdown is unchanged.

**`shm_map` return value (shm_posix.c)**
`shm_map` returns `MAP_FAILED` (`(void *)-1`) on failure, but callers `assert(ptr)` — which passes on any non-zero value. A failed mmap silently continues. Return `NULL` instead.

**SHM error diagnostics (shm_posix.c)**
The two error-path `fprintf` calls include no `strerror(errno)`. This would have made issue #72 self-diagnosing. Also: the existence-probe fd opened with `shm_open` is never closed before returning (fd leak on every startup).

**`ring_buffer_posix.c` len==0 guard**
`if (len == 0) return 0;` at the top of `read_buffer`/`write_buffer`. All current callers guard against this, but defensive is free here.

**malloc NULL checks (main.c)**
`input_dev` and `output_dev` are `malloc`'d and immediately dereferenced without a NULL check.

**`sprintf` → `snprintf` for /dev/dsp (main.c)**
Two `sprintf` calls building device strings; changed to `snprintf(buf, sizeof(buf), ...)` for consistency with the rest of the file.