### PR TITLE
fix: cfg_write [tnc] section, mg_ws_send length, device-list OOB, port strtol

### DIFF
--- a/common/cfg_utils.c
+++ b/common/cfg_utils.c
@@ -270,6 +270,10 @@ bool cfg_write(const mercury_config *cfg, const char *ini_path)
     fprintf(f, "\n[audio]\n");
     fprintf(f, "tx_gain_db = %.2f\n", cfg->tx_gain_db);
 
+    fprintf(f, "\n[tnc]\n");
+    fprintf(f, "keepalive_s = %d\n", cfg->tnc_keepalive_s);
+    fprintf(f, "buffer_report_ms = %d\n", cfg->tnc_buffer_report_ms);
+
     fclose(f);
     return true;
 }

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -310,7 +310,7 @@ void *ui_publisher_thread(void *arg)
                 pos += snprintf(buf + pos, sizeof(buf) - pos,
                     "{\"type\":\"capture_dev_list\",\"selected\":\"%s\",\"list\":[",
                     ctx->selected_capture_dev);
-                for (int i = 0; i < cap_count && pos < (int)sizeof(buf) - 128; i++) {
+                for (int i = 0; i < cap_count && pos < (int)sizeof(buf) - 160; i++) {
                     if (i > 0) buf[pos++] = ',';
                     pos += snprintf(buf + pos, sizeof(buf) - pos,
                         "{\"name\":\"%s\",\"id\":\"%s\"}", cap_names[i], cap_ids[i]);
@@ -329,7 +329,7 @@ void *ui_publisher_thread(void *arg)
                 pos += snprintf(buf + pos, sizeof(buf) - pos,
                     "{\"type\":\"playback_dev_list\",\"selected\":\"%s\",\"list\":[",
                     ctx->selected_playback_dev);
-                for (int i = 0; i < pb_count && pos < (int)sizeof(buf) - 128; i++) {
+                for (int i = 0; i < pb_count && pos < (int)sizeof(buf) - 160; i++) {
                     if (i > 0) buf[pos++] = ',';
                     pos += snprintf(buf + pos, sizeof(buf) - pos,
                         "{\"name\":\"%s\",\"id\":\"%s\"}", pb_names[i], pb_ids[i]);

--- a/gui_interface/websocket/mercury_websocket.c
+++ b/gui_interface/websocket/mercury_websocket.c
@@ -271,7 +271,8 @@ static void ws_handle_message(struct mg_connection *c, struct mg_ws_message *wm)
     if (!s_ws_ctx || !s_ws_ctx->cmd_callback)
     {
         // No callback registered - acknowledge but ignore
-        mg_ws_send(c, "{\"error\":\"no handler\"}", 21, WEBSOCKET_OP_TEXT);
+        const char *err = "{\"error\":\"no handler\"}";
+        mg_ws_send(c, err, strlen(err), WEBSOCKET_OP_TEXT);
         return;
     }
 

--- a/main.c
+++ b/main.c
@@ -250,7 +250,16 @@ int main(int argc, char *argv[])
         {
         case 'U':
             if (optarg)
-                ui_port = atoi(optarg);
+            {
+                char *endptr = NULL;
+                long value = strtol(optarg, &endptr, 10);
+                if (endptr == optarg || *endptr != '\0' || value <= 0 || value > 65535)
+                {
+                    fprintf(stderr, "Invalid UI port '%s'. Valid range is 1..65535.\n", optarg);
+                    return EXIT_FAILURE;
+                }
+                ui_port = (uint16_t)value;
+            }
             break;
         case 'W':
             waterfall_enabled = false;
@@ -319,11 +328,29 @@ int main(int argc, char *argv[])
             break;
         case 'p':
             if (optarg)
-                base_tcp_port = atoi(optarg);
+            {
+                char *endptr = NULL;
+                long value = strtol(optarg, &endptr, 10);
+                if (endptr == optarg || *endptr != '\0' || value <= 0 || value > 65535)
+                {
+                    fprintf(stderr, "Invalid ARQ TCP base port '%s'. Valid range is 1..65535.\n", optarg);
+                    return EXIT_FAILURE;
+                }
+                base_tcp_port = (int)value;
+            }
             break;
         case 'b':
             if (optarg)
-                broadcast_port = atoi(optarg);
+            {
+                char *endptr = NULL;
+                long value = strtol(optarg, &endptr, 10);
+                if (endptr == optarg || *endptr != '\0' || value <= 0 || value > 65535)
+                {
+                    fprintf(stderr, "Invalid broadcast TCP port '%s'. Valid range is 1..65535.\n", optarg);
+                    return EXIT_FAILURE;
+                }
+                broadcast_port = (int)value;
+            }
             break;
         case 'x':
             if (!strcmp(optarg, "alsa"))


### PR DESCRIPTION
Four correctness fixes. For consideration.

**`cfg_write` drops the [tnc] section (cfg_utils.c)**
`cfg_write()` emits [main], [arq], [audio] but no [tnc] section. Any load+save round-trip silently drops `keepalive_s` and `buffer_report_ms`. Added the missing section; key names verified against `cfg_utils.h`.

**`mg_ws_send` length off-by-one (mercury_websocket.c)**
The error response `{"error":"no handler"}` is 22 bytes; the call passes `21`. Clients receive invalid JSON missing the closing `}`. Changed to `strlen`.

**Device-list JSON buffer OOB (ui_communication.c)**
Two snprintf loops guard with `pos < sizeof(buf) - 128`, but a full entry (`{"name":"<64>","id":"<64>"}`) can be 149 bytes. Bumped margin to 160.

**Port arguments `atoi` → `strtol` (main.c)**
`-U`, `-p`, `-b` use `atoi` (returns 0 on invalid input, no range check). Converted to `strtol` with `1..65535` validation, matching the existing `-f`/`-H` pattern.