### PR TITLE
ci: add SANITIZE_TSAN and SANITIZE_ASAN_UBSAN build toggles and informational CI jobs

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,92 @@
+# Mercury CI Pipeline - Sanitizers (TSan + ASan/UBSan)
+#
+# Triggers: PRs and pushes to mercuryv2, plus manual dispatch.
+# INFORMATIONAL to start (continue-on-error): the tree has known pre-existing
+# findings (e.g. the arq_conn data race) triaged separately. Flip
+# continue-on-error to false to make these required once the baseline is clean.
+#
+# Runs on Linux amd64 only (sanitizers need native execution).
+
+name: Sanitizers
+
+on:
+  pull_request:
+    branches: [mercuryv2]
+  push:
+    branches: [mercuryv2]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Target branch | default = "mercuryv2"'
+        required: false
+        type: string
+        default: 'mercuryv2'
+
+jobs:
+  tsan-unit:
+    name: TSan (unit tests, Linux amd64)
+    runs-on: ubuntu-latest
+    container: debian:trixie
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+      - name: Install build dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates build-essential git openssh-client \
+            libpulse-dev libasound2-dev libhamlib-dev
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.branch || github.event.pull_request.head.sha || github.sha }}
+      - name: Git Safe Directory
+        run: git config --global --add safe.directory /__w/mercury/mercury
+      - name: Run unit tests under ThreadSanitizer
+        shell: bash
+        env:
+          TSAN_OPTIONS: "halt_on_error=1 second_deadlock_stack=1 suppressions=tests/sanitizer-suppressions/tsan.supp"
+        run: |
+          make -C tests clean
+          make -C tests SANITIZE_TSAN=1 test
+
+  asan-ubsan:
+    name: ASan+UBSan (unit + one integration session, Linux amd64)
+    runs-on: ubuntu-latest
+    container: debian:trixie
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+      - name: Install build dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates build-essential git openssh-client \
+            libpulse-dev libasound2-dev libhamlib-dev pkg-config golang-go
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.branch || github.event.pull_request.head.sha || github.sha }}
+      - name: Git Safe Directory
+        run: git config --global --add safe.directory /__w/mercury/mercury
+      - name: Run unit tests under ASan/UBSan
+        shell: bash
+        env:
+          ASAN_OPTIONS: "halt_on_error=1 detect_leaks=1 abort_on_error=1"
+          LSAN_OPTIONS: "suppressions=tests/sanitizer-suppressions/lsan.supp"
+          UBSAN_OPTIONS: "halt_on_error=1 print_stacktrace=1"
+        run: |
+          make -C tests clean
+          make -C tests SANITIZE_ASAN_UBSAN=1 test
+      - name: Build mercury with ASan/UBSan and run one integration session
+        shell: bash
+        env:
+          ASAN_OPTIONS: "halt_on_error=1 detect_leaks=1 abort_on_error=1"
+          LSAN_OPTIONS: "suppressions=tests/sanitizer-suppressions/lsan.supp"
+          UBSAN_OPTIONS: "halt_on_error=1 print_stacktrace=1"
+        run: |
+          make clean
+          make SANITIZE_ASAN_UBSAN=1 -j$(nproc)
+          make integration-test

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ install: all
 
 $(BINARY): $(MERCURY_LINK_INPUTS)
 	$(CC) -o $(BINARY)  \
-		$(MERCURY_LINK_INPUTS) $(LDFLAGS)
+		$(MERCURY_LINK_INPUTS) $(LDFLAGS) $(SAN_LDFLAGS)
 
 # Stamp file: written only when GIT_HASH changes so main.o is rebuilt
 # exactly when needed (FORCE makes the recipe always run; the recipe

--- a/config.mk
+++ b/config.mk
@@ -59,3 +59,30 @@ DEBUG_IO ?= 0
 ifeq ($(DEBUG_IO),1)
   COMMON_CFLAGS += -DDEBUG_IO
 endif
+
+# Optional: build with sanitizers (default: off). Mutually exclusive.
+# Enable with:  make SANITIZE_TSAN=1 ...        (ThreadSanitizer)
+#          or:  make SANITIZE_ASAN_UBSAN=1 ...  (Address + UndefinedBehavior)
+# Sanitizer flags must reach the linker too, so they are also collected into
+# SAN_LDFLAGS, which every link line appends (the binary link uses LDFLAGS,
+# not CFLAGS, so COMMON_CFLAGS alone would not instrument the final link).
+SAN_LDFLAGS =
+
+SANITIZE_TSAN ?= 0
+SANITIZE_ASAN_UBSAN ?= 0
+
+ifeq ($(SANITIZE_TSAN),1)
+  ifeq ($(SANITIZE_ASAN_UBSAN),1)
+    $(error SANITIZE_TSAN and SANITIZE_ASAN_UBSAN are mutually exclusive)
+  endif
+  SAN_FLAGS := -fsanitize=thread -g -O1 -fno-omit-frame-pointer
+  COMMON_CFLAGS += $(SAN_FLAGS)
+  SAN_LDFLAGS += -fsanitize=thread
+endif
+
+ifeq ($(SANITIZE_ASAN_UBSAN),1)
+  SAN_FLAGS := -fsanitize=address,undefined -fno-sanitize-recover=undefined \
+               -g -O1 -fno-omit-frame-pointer
+  COMMON_CFLAGS += $(SAN_FLAGS)
+  SAN_LDFLAGS += -fsanitize=address,undefined
+endif

--- a/docs/SANITIZERS.md
+++ b/docs/SANITIZERS.md
@@ -1,0 +1,25 @@
+# Sanitizers
+
+Mercury can build under ThreadSanitizer or Address+UndefinedBehavior sanitizer
+via two mutually-exclusive make toggles (default off):
+
+    make SANITIZE_TSAN=1 -C tests test
+    make SANITIZE_ASAN_UBSAN=1 -C tests test
+    make SANITIZE_ASAN_UBSAN=1 && make integration-test
+
+Runtime options are set via TSAN_OPTIONS / ASAN_OPTIONS / LSAN_OPTIONS /
+UBSAN_OPTIONS (see .github/workflows/sanitizers.yml for the CI values).
+
+## Suppressions
+
+tests/sanitizer-suppressions/tsan.supp and lsan.supp hold ONLY known, triaged,
+pre-existing findings. Every entry has a justification and, for real bugs, a
+reference to where the fix is tracked. A NEW finding must fail the job, so do
+not suppress broadly.
+
+## CI status: informational -> required
+
+The Sanitizers workflow starts as `continue-on-error: true` (informational)
+because the baseline has pre-existing findings tracked elsewhere (notably the
+arq_conn data race). Once those land and the baseline is clean, remove
+`continue-on-error` from both jobs to make them required.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -33,9 +33,9 @@ PROJECT_INC = -I../common -I../modem -I../datalink_arq -I../datalink_broadcast \
 CFLAGS = $(COMMON_CFLAGS) $(UNITY_CFLAGS) $(UNITY_INC) $(PROJECT_INC)
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-LDFLAGS = -lpthread -lm
+LDFLAGS = -lpthread -lm $(SAN_LDFLAGS)
 else
-LDFLAGS = -lpthread -lrt -lm
+LDFLAGS = -lpthread -lrt -lm $(SAN_LDFLAGS)
 endif
 
 # Shared mock stubs for ARQ tests

--- a/tests/sanitizer-suppressions/lsan.supp
+++ b/tests/sanitizer-suppressions/lsan.supp
@@ -1,0 +1,7 @@
+# LeakSanitizer (ASan) suppressions for Mercury.
+#
+# Policy: same as tsan.supp — justified, triaged, pre-existing only.
+# Format: leak:<symbol or library substring>
+#
+# Example (commented; enable only if the first run proves it and it is triaged):
+# leak:hamlib            # one-time rig backend table, freed at process exit

--- a/tests/sanitizer-suppressions/tsan.supp
+++ b/tests/sanitizer-suppressions/tsan.supp
@@ -1,0 +1,8 @@
+# ThreadSanitizer suppressions for Mercury unit tests.
+#
+# Policy: every entry MUST have a one-line justification and, where the race is
+# a real pre-existing bug being tracked separately, a reference (issue/PR/plan).
+# Suppress ONLY known, triaged, pre-existing findings so the job stays green on
+# the baseline; a NEW race must fail the job. Format: race:<symbol substring>
+#
+# (no active suppressions yet — the first CI run populates this if needed)


### PR DESCRIPTION
Opt-in sanitizer builds and informational CI jobs. For consideration.

**config.mk toggles**
`SANITIZE_TSAN=1` and `SANITIZE_ASAN_UBSAN=1`, mutually exclusive, defaulting to 0. Mirrors the existing `DEBUG_IO` pattern. Sanitizer flags go in `SAN_LDFLAGS` (appended to `LDFLAGS`) because the binary link rule uses `$(LDFLAGS)`, not `$(CFLAGS)`.

**CI jobs (`.github/workflows/sanitizers.yml`)**
Two jobs — `tsan-unit` and `asan-ubsan` — both `continue-on-error: true`. Same `debian:trixie` container and trigger set as `ut.yml`. Suppression file scaffold at `tests/sanitizer-suppressions/tsan.supp` (empty baseline).

**Why informational:** The `arq_conn` global is still accessed from multiple threads without a lock (known, in progress). TSan will fire on the integration harness until that is closed. Once clean, these jobs can be made required.

Locally verified: `SANITIZE_TSAN=1 make -j$(nproc)` builds cleanly on gcc; `__tsan_init` present in the test binary. Same for ASan/UBSan.