### PR TITLE
arq: fix S1 fade-cliff stall

### DIFF
--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -617,9 +617,10 @@ static bool maybe_upgrade_mode(arq_session_t *sess)
      * peer's rx_expected, which resolves the window safely before the switch
      * (delivered frames are ACK-progressed, undelivered bytes are restaged and
      * re-framed at the new mode). */
-    if (sess->tx_window_count > 0 && !sess->mode_probe)
-        return false;
+    bool probe = sess->mode_probe;
     sess->mode_probe = false;   /* one-shot */
+    if (sess->tx_window_count > 0 && !probe)
+        return false;
 
     /* Normally we need at least one valid peer SNR reading before deciding.
      * Exception: a retry-forced downgrade is driven purely by delivery
@@ -643,6 +644,17 @@ static bool maybe_upgrade_mode(arq_session_t *sess)
         sess->mode_upgrade_count = 0;
         return false;
     }
+
+    /* A probe is fired from retry trouble (ACK timeouts / exhaustion) to
+     * ESCAPE a mode the channel can no longer deliver — it must only ever
+     * move DOWN the ladder.  Without this, an SNR reading that still looks
+     * adequate (fading: the surviving frames measure fine) lets the probe
+     * UPGRADE mid-trouble — measured on the Watterson bench as a climb into
+     * the fade followed by a ~2 min go-back-N stall, slower than just
+     * holding the floor.  Upgrades keep the original discipline: only at
+     * burst boundaries with a drained window. */
+    if (probe && mode_rank(desired_mode) >= mode_rank(sess->payload_mode))
+        return false;
 
     /* After a retry-forced downgrade, don't allow re-upgrade until the
      * hold timer expires.  This prevents oscillation when stale SNR

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -264,7 +264,8 @@ static void send_mode_negotiation(arq_session_t *sess, arq_subtype_t subtype, in
                                         sess->session_id, snr_raw, mode);
     else
         n = arq_protocol_build_mode_ack(frame, sizeof(frame),
-                                        sess->session_id, snr_raw, mode);
+                                        sess->session_id, snr_raw, mode,
+                                        sess->rx_expected);
     if (n > 0)
         send_frame(PACKET_TYPE_ARQ_CONTROL, sess->control_mode, (size_t)n, frame, 0);
 }
@@ -343,13 +344,22 @@ static void record_tx_outcome(arq_session_t *sess, bool clean)
      * would needlessly under-run a healthy forward link).  Genuine forward /
      * propagation degradation drops peer_snr and falls through to the normal
      * step-down below. */
-    if (!clean && peer_snr_supports_mode(sess, sess->payload_mode))
+    if (!clean && peer_snr_supports_mode(sess, sess->payload_mode) &&
+        sess->reverse_hold_streak < ARQ_REVERSE_HOLD_MAX)
     {
+        /* Bounded (S1 fade-cliff fix): an UNBOUNDED hold froze OLLA and
+         * consecutive_retries whenever the SNR of the (few) surviving frames
+         * still looked healthy, making every downgrade path — including the
+         * hard-loss floor — unreachable while the transfer stalled above the
+         * fade cliff.  After ARQ_REVERSE_HOLD_MAX consecutive holds with no
+         * clean delivery in between, the retry falls through to the normal
+         * delivery feedback below. */
+        sess->reverse_hold_streak++;
         HLOGD(LOG_COMP,
               "Retry but peer_snr=%.1f dB supports mode %d — likely reverse-path "
-              "ACK loss; holding forward level %d (no step-down)",
+              "ACK loss; holding forward level %d (no step-down, hold %d/%d)",
               (float)sess->peer_snr_x10 / 10.0f, sess->payload_mode,
-              sess->speed_level);
+              sess->speed_level, sess->reverse_hold_streak, ARQ_REVERSE_HOLD_MAX);
         return;
     }
 
@@ -373,6 +383,7 @@ static void record_tx_outcome(arq_session_t *sess, bool clean)
     else
     {
         sess->consecutive_retries = 0;
+        sess->reverse_hold_streak = 0;  /* clean delivery re-arms the gate */
         sess->tx_success_count++;
         if (sess->tx_success_count >= ARQ_LADDER_UP_SUCCESSES &&
             sess->speed_level < ARQ_LADDER_LEVELS - 1)
@@ -383,6 +394,99 @@ static void record_tx_outcome(arq_session_t *sess, bool clean)
                   sess->speed_level, ARQ_LADDER_UP_SUCCESSES);
         }
     }
+}
+
+/* ---- Restage plumbing (S1 fade-cliff fix) ----
+ * The app TX ring has no un-read; once bytes enter the go-back-N window they
+ * can only leave via an ACK.  To change mode with unACKed frames stuck in a
+ * fade, their bytes are pulled back into sess->restage_buf and re-framed at
+ * the (new) mode by send_data_burst().  These wrappers make the restage bytes
+ * part of the TX stream, ahead of the ring. */
+
+static int session_tx_backlog(const arq_session_t *sess)
+{
+    int n = (int)(sess->restage_len - sess->restage_off);
+    if (g_cbs.tx_backlog)
+        n += g_cbs.tx_backlog();
+    return n;
+}
+
+static int session_tx_read(arq_session_t *sess, uint8_t *buf, size_t len)
+{
+    size_t n = 0;
+    while (n < len && sess->restage_off < sess->restage_len)
+        buf[n++] = sess->restage_buf[sess->restage_off++];
+    if (sess->restage_off >= sess->restage_len)
+        sess->restage_off = sess->restage_len = 0;
+    if (n < len && g_cbs.tx_read)
+    {
+        int m = g_cbs.tx_read(buf + n, len - n);
+        if (m > 0)
+            n += (size_t)m;
+    }
+    return (int)n;
+}
+
+/** Pull the unACKed window's user bytes back into the restage buffer and
+ *  rewind tx_seq to the window base.  ONLY safe once the peer's rx_expected
+ *  is known to equal the window base (the MODE_ACK probe proves the frames
+ *  were never delivered) — otherwise re-sending these bytes under the old
+ *  base seq would double-deliver on the peer. */
+static void restage_tx_window(arq_session_t *sess)
+{
+    if (sess->tx_window_count == 0)
+        return;
+
+    /* Rebuild the whole unsent prefix in strict stream order:
+     *   [ window frame payloads, seq order ] ++ [ unread restage residue ]
+     * The window frames are the EARLIEST unacknowledged bytes, so they must
+     * precede any residue already staged (bytes further along the stream).
+     * Appending them after the residue (the previous bug) reordered the
+     * stream and corrupted delivery when a second mode change hit with a
+     * partially-read restage buffer.  Ring bytes are always later still and
+     * are appended by session_tx_read after the restage buffer drains. */
+    uint8_t tmp[sizeof(sess->restage_buf)];
+    size_t  n = 0;
+
+    for (int i = 0; i < sess->tx_window_count; i++)
+    {
+        int plen = sess->tx_window[i].payload_len;
+        if (plen <= 0)
+            continue;
+        if (n + (size_t)plen > sizeof(tmp))
+        {
+            HLOGE(LOG_COMP, "restage overflow (%zu + %d) — keeping window",
+                  n, plen);
+            return;
+        }
+        memcpy(tmp + n, sess->tx_window[i].buf + ARQ_FRAME_HDR_SIZE, (size_t)plen);
+        n += (size_t)plen;
+    }
+
+    size_t residue = sess->restage_len - sess->restage_off;
+    if (n + residue > sizeof(tmp))
+    {
+        HLOGE(LOG_COMP, "restage+residue overflow (%zu + %zu) — keeping window",
+              n, residue);
+        return;
+    }
+    memcpy(tmp + n, sess->restage_buf + sess->restage_off, residue);
+    n += residue;
+
+    memcpy(sess->restage_buf, tmp, n);
+    sess->restage_len = n;
+    sess->restage_off = 0;
+
+    HLOGI(LOG_COMP,
+          "Restaged %d unACKed frame(s) (+%zu residue = %zu bytes) — "
+          "tx_seq rewound %d -> %d",
+          sess->tx_window_count, residue, n,
+          (int)sess->tx_seq, (int)sess->tx_window[0].seq);
+
+    sess->tx_seq            = sess->tx_window[0].seq;
+    sess->tx_window_count   = 0;
+    sess->tx_window_retx    = false;
+    sess->tx_inflight_bytes = 0;
 }
 
 /** Compute desired payload mode based on peer_snr_x10 and TX backlog.
@@ -480,7 +584,7 @@ static bool maybe_upgrade_mode(arq_session_t *sess)
         if (now_ms - s_olla_log_ms >= 4000)
         {
             s_olla_log_ms = now_ms;
-            int bk = g_cbs.tx_backlog ? g_cbs.tx_backlog() : 0;
+            int bk = session_tx_backlog(sess);
             HLOGI(LOG_COMP,
                   "OLLA-state: payload_mode=%d peer_snr=%.1f local_snr=%.1f olla=%+.1f retries=%d backlog=%d startup_rem=%lldms",
                   sess->payload_mode,
@@ -503,9 +607,19 @@ static bool maybe_upgrade_mode(arq_session_t *sess)
      * wrong byte count (a FULL DATAC15 frame read at DATAC3's larger slot
      * over-delivers: the 118-vs-112 bidirectional regression).  Defer the change
      * until the window drains; it reaches 0 after every fully-ACKed burst, so
-     * mode adaptation still happens at burst boundaries. */
-    if (sess->tx_window_count > 0)
+     * mode adaptation still happens at burst boundaries.
+     *
+     * Exception (S1 fade-cliff fix): the retry-exhaustion path sets mode_probe
+     * to break out of a channel that can no longer deliver the current mode —
+     * there the window may NEVER drain, which made this guard a permanent
+     * mode-change lockout (the transfer starved above the fade cliff).  The
+     * MODE_REQ itself doesn't touch the window; the MODE_ACK reply carries the
+     * peer's rx_expected, which resolves the window safely before the switch
+     * (delivered frames are ACK-progressed, undelivered bytes are restaged and
+     * re-framed at the new mode). */
+    if (sess->tx_window_count > 0 && !sess->mode_probe)
         return false;
+    sess->mode_probe = false;   /* one-shot */
 
     /* Normally we need at least one valid peer SNR reading before deciding.
      * Exception: a retry-forced downgrade is driven purely by delivery
@@ -521,7 +635,7 @@ static bool maybe_upgrade_mode(arq_session_t *sess)
         sess->consecutive_retries < ARQ_HARD_LOSS_THRESHOLD)
         return false;
 
-    int backlog = g_cbs.tx_backlog ? g_cbs.tx_backlog() : 0;
+    int backlog = session_tx_backlog(sess);
     int desired_mode = select_best_mode(sess, backlog);
 
     if (desired_mode == sess->payload_mode)
@@ -664,7 +778,7 @@ static void send_ack(arq_session_t *sess, uint8_t ack_delay_raw)
     uint8_t flags   = 0;
     uint8_t snr_raw = 0;
 
-    if (g_cbs.tx_backlog && g_cbs.tx_backlog() > 0)
+    if (session_tx_backlog(sess) > 0)
         flags |= ARQ_FLAG_HAS_DATA;
     if (sess->local_snr_x10 != 0)
         snr_raw = arq_protocol_encode_snr((float)sess->local_snr_x10 / 10.0f);
@@ -706,7 +820,7 @@ static void send_data_burst(arq_session_t *sess)
         int slot_idx = sess->tx_window_count;
 
         memset(payload, 0, user_bytes);
-        int payload_len = g_cbs.tx_read(payload, user_bytes);
+        int payload_len = session_tx_read(sess, payload, user_bytes);
         if (payload_len <= 0)
             break;  /* backlog drained */
 
@@ -767,7 +881,7 @@ static void send_data_burst(arq_session_t *sess)
         if (g_timing)
             arq_timing_record_tx_queue(g_timing, (int)sess->tx_window[i].seq,
                                        sess->payload_mode,
-                                       g_cbs.tx_backlog(),
+                                       session_tx_backlog(sess),
                                        sess->tx_window[i].payload_len);
     }
 }
@@ -782,7 +896,7 @@ static void enter_idle_iss(arq_session_t *sess, bool gained_turn)
 {
     (void)gained_turn;  /* per-direction mode: my TX mode evolves independently */
     sess->tx_retries_left = ARQ_DATA_RETRY_SLOTS;  /* fresh counter on ISS role entry */
-    if (g_cbs.tx_backlog && g_cbs.tx_backlog() > 0)
+    if (session_tx_backlog(sess) > 0)
     {
         dflow_enter(sess, ARQ_DFLOW_DATA_TX, UINT64_MAX, ARQ_EV_TIMER_RETRY);
         send_data_burst(sess);
@@ -814,7 +928,7 @@ static void enter_idle_iss_guarded(arq_session_t *sess, bool gained_turn)
 {
     (void)gained_turn;  /* per-direction mode: my TX mode evolves independently */
     sess->tx_retries_left = ARQ_DATA_RETRY_SLOTS;  /* fresh counter on ISS role entry */
-    if (g_cbs.tx_backlog && g_cbs.tx_backlog() > 0)
+    if (session_tx_backlog(sess) > 0)
     {
         /* Attempt mode negotiation when startup window has passed and we
          * have a valid peer SNR estimate.  If maybe_upgrade_mode() fires
@@ -1007,7 +1121,7 @@ static void fsm_calling(arq_session_t *sess, const arq_event_t *ev)
     case ARQ_EV_RX_ACCEPT:
         if (ev->session_id == sess->session_id)
         {
-            bool has_tx_backlog = g_cbs.tx_backlog && g_cbs.tx_backlog() > 0;
+            bool has_tx_backlog = session_tx_backlog(sess) > 0;
             sess->role        = ARQ_ROLE_CALLER;
             sess->tx_seq      = 0;
             sess->rx_expected = 0;
@@ -1249,13 +1363,13 @@ static void fsm_connected(arq_session_t *sess, const arq_event_t *ev)
          * drained buffer fires the deferred disconnect at the next idle-ISS
          * entry (an ACKed last frame with empty backlog disconnects there
          * without extra delay). */
-        if ((g_cbs.tx_backlog && g_cbs.tx_backlog() > 0) ||
+        if ((session_tx_backlog(sess) > 0) ||
             sess->dflow_state == ARQ_DFLOW_DATA_TX ||
             sess->dflow_state == ARQ_DFLOW_WAIT_ACK)
         {
             HLOGD(LOG_COMP,
                   "APP_DISCONNECT deferred — backlog=%d dflow=%s",
-                  g_cbs.tx_backlog ? g_cbs.tx_backlog() : 0,
+                  session_tx_backlog(sess),
                   arq_dflow_state_name(sess->dflow_state));
             sess->pending_disconnect = true;
             sess->disconnect_deadline_ms =
@@ -1362,8 +1476,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
     switch (sess->dflow_state)
     {
     case ARQ_DFLOW_IDLE_ISS:
-        if (ev->id == ARQ_EV_APP_DATA_READY && g_cbs.tx_backlog &&
-            g_cbs.tx_backlog() > 0)
+        if (ev->id == ARQ_EV_APP_DATA_READY && session_tx_backlog(sess) > 0)
         {
             if (sess->need_initial_guard)
             {
@@ -1425,7 +1538,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
             if (g_timing)
                 arq_timing_record_tx_start(g_timing, (int)sess->tx_seq,
                                            sess->payload_mode,
-                                           g_cbs.tx_backlog ? g_cbs.tx_backlog() : 0);
+                                           session_tx_backlog(sess));
         }
         else if (ev->id == ARQ_EV_TX_COMPLETE)
         {
@@ -1508,7 +1621,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
             sess->last_tx_progress_ms = hermes_uptime_ms();  /* forward progress */
             sess->peer_has_data = (ev->rx_flags & ARQ_FLAG_HAS_DATA) != 0;
             if (g_cbs.send_buffer_status)
-                g_cbs.send_buffer_status(g_cbs.tx_backlog ? g_cbs.tx_backlog() : 0);
+                g_cbs.send_buffer_status(session_tx_backlog(sess));
 
             if (sess->tx_window_count > 0)
             {
@@ -1576,7 +1689,25 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                 /* Ladder step-down happens once per frame in the RX_ACK /
                  * implicit-ACK handler via record_tx_outcome(), NOT here.
                  * Calling it on every retry would cause double/triple penalty
-                 * when the ACK handler also calls it. */
+                 * when the ACK handler also calls it.
+                 *
+                 * consecutive_retries, however, IS advanced per timeout (S1
+                 * fade-cliff fix): each ACK timeout is a definitive non-
+                 * delivery, and it is the only evidence a fade ever produces
+                 * (no ACK arrives, so record_tx_outcome never runs).  This
+                 * feeds the hard-loss floor drop and the mode probe below
+                 * WITHOUT touching OLLA's tuned first-try-FER accounting.
+                 * Any ACK progress resets the counter. */
+                sess->consecutive_retries++;
+                if (sess->consecutive_retries >= ARQ_RETRY_DOWNGRADE_THRESHOLD)
+                {
+                    /* Probe for a mode change mid-window (see the exhaustion
+                     * path and maybe_upgrade_mode for the full S1 story). */
+                    sess->mode_probe = true;
+                    if (maybe_upgrade_mode(sess))
+                        return;
+                    sess->mode_probe = false;
+                }
                 if (g_timing)
                     arq_timing_record_retry(g_timing,
                                             sess->tx_window_count > 0
@@ -1638,18 +1769,34 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                     sess->tx_retries_left = ARQ_DATA_RETRY_SLOTS;
 
                     /* Channel couldn't deliver a frame in ARQ_DATA_RETRY_SLOTS
-                     * attempts — force the delivery-feedback safety net to
-                     * threshold so select_best_mode pulls payload_mode one
-                     * step lower.  maybe_upgrade_mode handles the MODE_REQ /
-                     * MODE_ACK negotiation; on success the FSM is now in
-                     * MODE_REQ_TX state and will resume DATA_TX at the lower
-                     * mode after MODE_ACK.  On failure (no peer SNR yet,
-                     * MODE_REQ retries exhaust, already at slowest mode)
-                     * fall through and retransmit at the current mode. */
+                     * attempts.  Account that as what it is — one definitive
+                     * failed outcome per consumed retry slot — so OLLA and the
+                     * hard-loss counter actually move (S1 fix, part 1: no ACK
+                     * ever arrives on a channel this broken, so the RX_ACK /
+                     * implicit-ACK paths that normally call record_tx_outcome
+                     * never run; without this the delivery feedback stayed
+                     * frozen at "all fine" while everything died, and
+                     * select_best_mode — fed by stale pre-fade SNR — never
+                     * chose a lower mode).  No double-count: these attempts
+                     * produced no ACK, so no other path has recorded them.
+                     *
+                     * mode_probe then lets maybe_upgrade_mode fire the
+                     * MODE_REQ despite the unACKed window (S1 fix, part 2:
+                     * the window cannot drain here, and the old unconditional
+                     * window guard silently vetoed every downgrade attempt —
+                     * the "dead code" fade-cliff stall).  On MODE_ACK the
+                     * peer's rx_expected resolves the window; on failure (no
+                     * peer SNR yet, MODE_REQ retries exhaust, already at the
+                     * slowest mode) fall through and retransmit at the
+                     * current mode. */
+                    for (int i = 0; i < ARQ_DATA_RETRY_SLOTS; i++)
+                        record_tx_outcome(sess, false);
                     if (sess->consecutive_retries < ARQ_RETRY_DOWNGRADE_THRESHOLD)
                         sess->consecutive_retries = ARQ_RETRY_DOWNGRADE_THRESHOLD;
+                    sess->mode_probe = true;
                     if (maybe_upgrade_mode(sess))
                         return;
+                    sess->mode_probe = false;
 
                     dflow_enter(sess, ARQ_DFLOW_DATA_TX, UINT64_MAX, ARQ_EV_TIMER_RETRY);
                     send_data_burst(sess);
@@ -1680,7 +1827,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                 sess->last_tx_progress_ms = hermes_uptime_ms();
                 sess->peer_has_data = (ev->rx_flags & ARQ_FLAG_HAS_DATA) != 0;
                 if (g_cbs.send_buffer_status)
-                    g_cbs.send_buffer_status(g_cbs.tx_backlog ? g_cbs.tx_backlog() : 0);
+                    g_cbs.send_buffer_status(session_tx_backlog(sess));
                 if (deliver_rx_checked(sess, ev) && g_timing)
                     arq_timing_record_data_rx(g_timing, (int)ev->seq,
                                               (int)ev->data_bytes,
@@ -1726,7 +1873,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                 sess->tx_inflight_bytes = 0;
                 sess->tx_retries_left   = ARQ_DATA_RETRY_SLOTS;
                 if (g_cbs.send_buffer_status)
-                    g_cbs.send_buffer_status(g_cbs.tx_backlog ? g_cbs.tx_backlog() : 0);
+                    g_cbs.send_buffer_status(session_tx_backlog(sess));
                 sess->peer_tx_mode = ev->mode;  /* update RX decoder; our TX mode unchanged */
                 /* Guard: allow ARQ_CHANNEL_GUARD_MS for the ISS to drop PTT
                  * before our MODE_ACK preamble arrives (same guard used by
@@ -1789,7 +1936,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                             deadline_from_s(tm ? tm->retry_interval_s : 7.0f),
                             ARQ_EV_TIMER_RETRY);
             }
-            else if (g_cbs.tx_backlog && g_cbs.tx_backlog() > 0)
+            else if (session_tx_backlog(sess) > 0)
             {
                 send_ctrl_frame(sess, ARQ_SUBTYPE_TURN_REQ);
                 sess->tx_retries_left = ARQ_TURN_REQ_RETRIES;
@@ -1847,7 +1994,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
              * Capture HAS_DATA state before sending so ACK_TX → TX_COMPLETE
              * knows whether a piggyback turn is valid. */
             uint32_t delay_ms = (uint32_t)(hermes_uptime_ms() - sess->last_rx_ms);
-            sess->acktx_had_has_data = g_cbs.tx_backlog && g_cbs.tx_backlog() > 0;
+            sess->acktx_had_has_data = session_tx_backlog(sess) > 0;
             send_ack(sess, arq_protocol_encode_ack_delay(delay_ms));
             if (g_timing)
                 arq_timing_record_ack_tx(g_timing, (int)sess->rx_expected - 1);
@@ -1891,7 +2038,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
             if (sess->pending_connect_confirm)
             {
                 sess->pending_connect_confirm = false;
-                if (g_cbs.tx_backlog && g_cbs.tx_backlog() > 0)
+                if (session_tx_backlog(sess) > 0)
                     enter_idle_iss_guarded(sess, false);
                 else
                     enter_idle_iss(sess, false);
@@ -1905,7 +2052,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                 if (g_timing) arq_timing_record_turn(g_timing, true, "piggyback");
                 enter_idle_iss_guarded(sess, true);  /* IRS gaining turn — use peer's observed mode */
             }
-            else if (g_cbs.tx_backlog && g_cbs.tx_backlog() > 0)
+            else if (session_tx_backlog(sess) > 0)
             {
                 /* Data arrived during ACK TX (APP_DATA_READY ignored, HAS_DATA
                  * not set).  The ISS may start a new DATA_TX within ~150ms of
@@ -2084,7 +2231,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                  * pending_disconnect whose drain condition was met here. */
                 sess->tx_retries_left = ARQ_DATA_RETRY_SLOTS;
                 uint64_t guard_ms = tm ? (uint64_t)(tm->ack_timeout_s * 1000.0f) : 6000ULL;
-                if (g_cbs.tx_backlog && g_cbs.tx_backlog() > 0)
+                if (session_tx_backlog(sess) > 0)
                     dflow_enter(sess, ARQ_DFLOW_DATA_TX,
                                 hermes_uptime_ms() + guard_ms,
                                 ARQ_EV_TIMER_ACK);
@@ -2104,7 +2251,55 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
         /* ISS: waiting for MODE_ACK from IRS. */
         if (ev->id == ARQ_EV_RX_MODE_ACK)
         {
-            if (arq_protocol_mode_timing(ev->mode) != NULL &&
+            /* S1 fade-cliff fix: a mode probe can arrive here with unACKed
+             * frames still in the window.  The MODE_ACK's rx_expected
+             * (flagged ARQ_FLAG_CTRL_ACKSEQ) resolves them definitively
+             * BEFORE the mode changes: frames the peer already delivered
+             * are ACK-progressed here; bytes it never got are restaged and
+             * re-framed at the new mode by the next send_data_burst(). */
+            bool window_resolved = true;
+            if (sess->tx_window_count > 0)
+            {
+                if (!(ev->rx_flags & ARQ_FLAG_CTRL_ACKSEQ))
+                {
+                    /* No rx_expected in the MODE_ACK — cannot prove the
+                     * window's fate; changing framing now could double-
+                     * deliver.  Keep the old mode and the intact window. */
+                    HLOGW(LOG_COMP,
+                          "MODE_ACK without ACKSEQ while %d frame(s) unACKed — "
+                          "keeping mode %d",
+                          sess->tx_window_count, sess->payload_mode);
+                    window_resolved = false;
+                }
+                else
+                {
+                    int n_acked = 0;
+                    uint8_t base = sess->tx_window[0].seq;
+                    uint8_t dist = (uint8_t)(ev->ack_seq - base);
+                    if (dist >= 1 && dist <= (uint8_t)sess->tx_window_count)
+                        n_acked = (int)dist;
+
+                    if (n_acked > 0)
+                    {
+                        /* Same bookkeeping as the WAIT_ACK progress path. */
+                        for (int i = 0; i < n_acked; i++)
+                            sess->tx_inflight_bytes -= sess->tx_window[i].payload_len;
+                        if (sess->tx_inflight_bytes < 0)
+                            sess->tx_inflight_bytes = 0;
+                        for (int i = n_acked; i < sess->tx_window_count; i++)
+                            sess->tx_window[i - n_acked] = sess->tx_window[i];
+                        sess->tx_window_count   -= n_acked;
+                        sess->last_tx_progress_ms = hermes_uptime_ms();
+                        record_tx_outcome(sess, false);  /* delivered, not clean */
+                    }
+                    if (sess->tx_window_count > 0)
+                        restage_tx_window(sess);
+                    sess->tx_retries_left = ARQ_DATA_RETRY_SLOTS;
+                }
+            }
+
+            if (window_resolved &&
+                arq_protocol_mode_timing(ev->mode) != NULL &&
                 ev->mode != ARQ_CONTROL_MODE)
             {
                 /* If this MODE_ACK confirms a downgrade, start the hold

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -1714,11 +1714,27 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                 if (sess->consecutive_retries >= ARQ_RETRY_DOWNGRADE_THRESHOLD)
                 {
                     /* Probe for a mode change mid-window (see the exhaustion
-                     * path and maybe_upgrade_mode for the full S1 story). */
-                    sess->mode_probe = true;
-                    if (maybe_upgrade_mode(sess))
-                        return;
-                    sess->mode_probe = false;
+                     * path and maybe_upgrade_mode for the full S1 story) —
+                     * but NEVER once the no-progress budget is spent.  A
+                     * probe's purpose is finding a mode that restores
+                     * progress; past the budget the session's job is to
+                     * disconnect.  Without this gate a dead peer produced an
+                     * infinite persist loop (Pedro's estacao6/10 OTA, S1
+                     * build): hard-loss probe -> MODE_REQ retries exhaust ->
+                     * revert -> retry budget and consecutive_retries reset ->
+                     * repeat every ~200 s, preempting the retry-exhaustion
+                     * branch that owns the no-progress disconnect. */
+                    uint64_t np_now = hermes_uptime_ms();
+                    bool budget_spent =
+                        (np_now - sess->last_tx_progress_ms) >=
+                        (uint64_t)ARQ_NO_PROGRESS_TIMEOUT_S * 1000ULL;
+                    if (!budget_spent)
+                    {
+                        sess->mode_probe = true;
+                        if (maybe_upgrade_mode(sess))
+                            return;
+                        sess->mode_probe = false;
+                    }
                 }
                 if (g_timing)
                     arq_timing_record_retry(g_timing,

--- a/datalink_arq/arq_fsm.h
+++ b/datalink_arq/arq_fsm.h
@@ -234,6 +234,12 @@ typedef struct
 
     /* --- Delivery-feedback safety net --- */
     int      consecutive_retries;      /* consecutive non-clean TX outcomes     */
+    int      reverse_hold_streak;      /* consecutive retries attributed to
+                                        * reverse-path ACK loss (mode held);
+                                        * capped at ARQ_REVERSE_HOLD_MAX so a
+                                        * fade cluster with healthy-looking SNR
+                                        * cannot freeze the downgrade paths
+                                        * (S1 fade-cliff fix); reset on clean  */
     uint64_t mode_hold_until_ms;       /* after forced downgrade: don't upgrade
                                         * until this uptime (prevents oscillation
                                         * when stale SNR says "upgrade" but the
@@ -253,6 +259,20 @@ typedef struct
     int      tx_window_count;          /* unACKed frames in the window      */
     bool     tx_window_retx;           /* window needed >=1 retransmission  */
     int      tx_inflight_bytes;       /* payload bytes across the window    */
+
+    /* --- Restage buffer (S1 fade-cliff fix) ---
+     * When a mode change is needed but the window holds unACKed frames, the
+     * MODE_ACK probe resolves their fate; bytes confirmed UNdelivered are
+     * pulled back here (tx_seq rewound to the window base) and re-framed by
+     * send_data_burst() at the new mode.  Sized for a full window of the
+     * largest frames. */
+    uint8_t  restage_buf[ARQ_BURST_MAX * 1280];
+    size_t   restage_len;              /* valid bytes in restage_buf        */
+    size_t   restage_off;              /* next unread offset                */
+    bool     mode_probe;               /* one-shot: allow MODE_REQ with a
+                                        * non-empty window (set by the retry-
+                                        * exhaustion path; consumed by
+                                        * maybe_upgrade_mode)               */
 
     /* --- Keepalive tracking --- */
     int      keepalive_miss_count;

--- a/datalink_arq/arq_protocol.c
+++ b/datalink_arq/arq_protocol.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdatomic.h>
+#include <math.h>
 
 /* Runtime-configurable retry counts, initialised from compile-time defaults */
 _Atomic int arq_call_retry_slots       = ARQ_CALL_RETRY_SLOTS_DEFAULT;
@@ -192,7 +193,10 @@ int arq_protocol_bw_hz_from_token(uint8_t bw_token)
 
 uint8_t arq_protocol_encode_snr(float snr_db)
 {
-    int v = (int)(snr_db + 0.5f) + 128;
+    /* floorf: plain (int) truncates toward zero, so negative SNRs rounded
+     * asymmetrically (-1.0 dB encoded as 0 dB) — a +1 dB flattery right at
+     * the fade cliff where mode decisions are most sensitive. */
+    int v = (int)floorf(snr_db + 0.5f) + 128;
     if (v < 1)   v = 1;
     if (v > 255) v = 255;
     return (uint8_t)v;
@@ -339,12 +343,12 @@ int arq_protocol_build_mode_req(uint8_t *buf, size_t buf_len,
 
 int arq_protocol_build_mode_ack(uint8_t *buf, size_t buf_len,
                                  uint8_t session_id, uint8_t snr_raw,
-                                 int freedv_mode)
+                                 int freedv_mode, uint8_t rx_ack_seq)
 {
     uint8_t payload[1] = { (uint8_t)freedv_mode };
     return build_ctrl(buf, buf_len,
                       ARQ_SUBTYPE_MODE_ACK, session_id,
-                      0, 0, 0, snr_raw, 0,
+                      0, rx_ack_seq, ARQ_FLAG_CTRL_ACKSEQ, snr_raw, 0,
                       payload, 1);
 }
 

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -102,6 +102,14 @@
                                   * with LEN_HI/LEN_B9 allows counts up to     *
                                   * 2047 (DATAC17 carries 1172 user bytes,     *
                                   * QAM16C2 1205).                             */
+#define ARQ_FLAG_CTRL_ACKSEQ 0x02 /* bit 1: CONTROL frames — rx_ack_seq field
+                                   * carries the sender's valid rx_expected.
+                                   * Set on MODE_ACK so the ISS can resolve an
+                                   * unACKed TX window during a mode-change
+                                   * probe (S1 fade-cliff fix): rx_ack_seq
+                                   * tells it definitively whether the stuck
+                                   * frame was delivered (late/lost ACK) or
+                                   * never arrived. */
 #define ARQ_FLAG_BURST_END 0x04  /* bit 2: DATA frames only — last frame of a  *
                                   * multi-frame burst; the IRS sends one       *
                                   * cumulative ACK when it sees this (or when  *
@@ -289,6 +297,18 @@ extern _Atomic float arq_callint_override_s;
  * test_olla_low_snr_no_collapse).  Only a long unbroken fail run drops straight
  * to the robust floor and lets OLLA climb back. */
 #define ARQ_HARD_LOSS_THRESHOLD       8     /* consecutive retries => drop to floor */
+/* Reverse-loss attribution bound (S1 fade-cliff fix).  The asymmetric-link
+ * gate holds the forward mode on a retry when peer_snr says the forward link
+ * comfortably supports it (retry = probably a lost ACK, not a decode fail).
+ * But SNR can look healthy while frames die (fade clusters, interference,
+ * sync loss), and an UNBOUNDED hold freezes OLLA and consecutive_retries,
+ * making every downgrade path — including the hard-loss floor — unreachable:
+ * the transfer stalls above the fade cliff.  Bound the run: after this many
+ * CONSECUTIVE holds with no clean delivery in between, stop attributing
+ * retries to reverse loss and let normal delivery feedback act.  3 matches
+ * the adaptive-ACK escalation cap: an isolated reverse-path ACK-loss run of
+ * <=3 stays protected (the bench-validated case). */
+#define ARQ_REVERSE_HOLD_MAX          3     /* consecutive reverse-loss holds */
 
 /* ---- Outer-loop link adaptation (OLLA) ----
  * A per-link SNR offset (dB) driven by delivery outcomes corrects the gap
@@ -494,10 +514,12 @@ int arq_protocol_build_mode_req(uint8_t *buf, size_t buf_len,
                                  uint8_t session_id, uint8_t snr_raw,
                                  int freedv_mode);
 
-/** MODE_ACK frame — accept peer's mode request. */
+/** MODE_ACK frame — accept peer's mode request.  Carries the responder's
+ *  rx_expected (flagged ARQ_FLAG_CTRL_ACKSEQ) so a probing ISS can resolve
+ *  its unACKed TX window before switching modes. */
 int arq_protocol_build_mode_ack(uint8_t *buf, size_t buf_len,
                                  uint8_t session_id, uint8_t snr_raw,
-                                 int freedv_mode);
+                                 int freedv_mode, uint8_t rx_ack_seq);
 
 /* --- Data frame (PACKET_TYPE_ARQ_DATA) --- */
 

--- a/docs/ARQ.md
+++ b/docs/ARQ.md
@@ -94,13 +94,22 @@ Packet type values:
 ```
 Byte 0: framer byte  (packet_type | extension_field)
 Byte 1: subtype      (arq_subtype_t)
-Byte 2: flags        bit7=TURN_REQ  bit6=HAS_DATA
+Byte 2: flags        bit7=TURN_REQ  bit6=HAS_DATA  bit2=BURST_END (DATA)
+                     bit1=CTRL_ACKSEQ (CONTROL)  bits5/4/3=LEN_HI/B9/B10 (DATA)
 Byte 3: session_id   random byte chosen by caller at connect time
 Byte 4: tx_seq       sender's frame sequence number
 Byte 5: rx_ack_seq   last sequence number received from peer (implicit ACK)
 Byte 6: snr_raw      local RX SNR as uint8 = round(snr_dB) + 128; 0=unknown
 Byte 7: ack_delay    IRS→ISS delay from data_rx to ack_tx, in 10ms units; 0=unknown
 ```
+
+**`ARQ_FLAG_CTRL_ACKSEQ` (bit 1, CONTROL frames)** — set on `MODE_ACK` to mark
+`rx_ack_seq` (byte 5) as carrying the responder's valid `rx_expected`.  This
+lets a mode-probing ISS resolve an unACKed TX window during a mid-transfer
+mode change (see *Mode Upgrade / Downgrade* below): the value tells it
+definitively which queued frames the peer already delivered.  Absent on frames
+from older builds, in which case the ISS keeps its current mode and window
+(no interop break).
 
 For **DATA frames** (`ARQ_DATA`), payload bytes follow immediately after byte 7.
 The payload size is determined by the FreeDV mode in use.
@@ -393,12 +402,46 @@ Mode selection follows a `speed_level` ladder:
 **Downgrade** triggers:
 - A retry event (frame not ACKed in time): step one level down (floor: DATAC15).
 - Peer SNR feedback below threshold.
+- Sustained delivery failure — the S1 fade-cliff net below.
 
 Mode change procedure: ISS sends `MODE_REQ`; IRS responds with `MODE_ACK` or
 ignores (ISS falls back after `ARQ_MODE_REQ_RETRIES = 2`).
 
 During the **startup window** (`ARQ_STARTUP_MAX_S = 10 s`), only DATAC16 is used
 for bidirectional control framing to ensure the link is stable before upgrading.
+
+### Delivery-driven downgrade (S1 fade-cliff)
+
+The primary rate controller is OLLA, a per-link SNR offset. But SNR alone
+mispredicts on a fading or ISI-limited channel (e.g. NVIS), where a mode can
+lose most of its frames while the *surviving* frames still measure a healthy
+SNR. Three mechanisms keep the link from starving above such a cliff:
+
+- **Bounded reverse-loss hold.** A retry with healthy peer SNR is normally
+  attributed to reverse-path ACK loss (asymmetric HF) and the forward mode is
+  held. This hold is capped at `ARQ_REVERSE_HOLD_MAX` (3) consecutive holds;
+  a clean delivery re-arms it. Without the cap it froze OLLA and the retry
+  counters, making every downgrade path unreachable.
+- **Per-timeout failure accounting.** On a dead-enough channel no ACK ever
+  arrives, so the normal outcome accounting never runs. Each ACK timeout now
+  advances `consecutive_retries`, which feeds the hard-loss drop to the floor
+  (`ARQ_HARD_LOSS_THRESHOLD`) without disturbing OLLA's tuned first-try-FER
+  accounting.
+- **Mid-window mode probe (downgrade-only).** When retries can't drain the
+  go-back-N window (the window never empties if the mode can't deliver), a
+  *probe* issues a `MODE_REQ` despite the unACKed window. The `MODE_ACK`
+  carries the peer's `rx_expected` (flagged `ARQ_FLAG_CTRL_ACKSEQ`), which
+  resolves the window: frames the peer already got are ACK-progressed;
+  undelivered bytes are **restaged** (pulled back into `restage_buf`, `tx_seq`
+  rewound) and re-framed at the new mode. A probe only ever moves *down* the
+  ladder, and never fires once the no-progress budget is spent (past that the
+  session's job is to disconnect, not to keep probing a dead peer).
+
+Rationale note: capping selection *toward* robust modes on NVIS was tried and
+measured to reduce throughput (goodput rises with mode speed there despite
+high erasure — the large frames win). The mechanisms above therefore restore
+delivery without holding the link at the floor. See
+`docs/S1-FADECLIFF-DECISION.md` for the full simulation + OTA evidence.
 
 ---
 
@@ -536,6 +579,8 @@ All in `arq_protocol.h`:
 #define ARQ_STARTUP_MAX_S             10    /* control-mode-only startup window */
 #define ARQ_PEER_PAYLOAD_HOLD_S       15    /* hold payload mode after activity */
 #define ARQ_SNR_HYST_DB               1.0f
+#define ARQ_HARD_LOSS_THRESHOLD       8     /* consecutive retries => drop to floor */
+#define ARQ_REVERSE_HOLD_MAX          3     /* bounded reverse-loss holds (S1)   */
 ```
 
 ---

--- a/docs/S1-FADECLIFF-DECISION.md
+++ b/docs/S1-FADECLIFF-DECISION.md
@@ -1,0 +1,149 @@
+# S1 fade-cliff fix (`fix-s1-fadecliff`) — merge-decision simulation report
+
+**Date:** 2026-07-04/05 · **Branch under decision:** `fix-s1-fadecliff` @ `a014b3c`
+(vs trunk `mercuryv2` @ `e7a2d84`) · **Question:** does the branch have real
+advantages over trunk, and does it regress anything?
+
+## What the branch changes
+
+Under a fade below the active payload mode's cliff, trunk transfers stall
+instead of downgrading to the DATAC15 floor (S1 — proven by an in-tree
+executable test that was shipped `TEST_IGNORE`d).  The branch:
+
+1. bounds the asymmetric-link reverse-loss hold (`ARQ_REVERSE_HOLD_MAX` = 3
+   consecutive holds; a clean delivery re-arms it);
+2. advances `consecutive_retries` per ACK timeout (the only failure evidence
+   a fade produces — no ACK ever arrives to run the normal accounting);
+3. allows a **downgrade-only** mode probe with an unACKed window: the
+   MODE_ACK now carries the peer's `rx_expected` (`ARQ_FLAG_CTRL_ACKSEQ`),
+   which resolves the window — confirmed-undelivered bytes are restaged and
+   re-framed at the new mode;
+4. `encode_snr` rounds negative SNRs correctly (`floorf`);
+5. never fires a probe after the no-progress budget is spent, so a dead peer
+   leads to a bounded disconnect (fix for Pedro's OTA finding, see below).
+
+Wire note: MODE_ACK gains a flag + a previously-zero header field.  Old
+receivers ignore both; a new sender ↔ old receiver falls back to the old
+"keep mode, keep window" behaviour (no interop break, but both ends need the
+branch to benefit).
+
+## Instruments (and their own validation)
+
+- **Two-FSM deterministic sim** (`tests/sim`): real `arq_fsm.c`/protocol under
+  a virtual clock and seeded channels.  Extended on this branch with a
+  mode-aware SNR-cliff model and an empirical per-mode-PER model.
+- **Watterson FIFO harness** (`MERCURY_CH_ENGINE=watterson`): calibration
+  independently cross-checked against AE4JY PathSim (`Rhizomatica/pathsim`)
+  — measured SNR within ±0.2 dB of target, matching delivery cliffs.
+  (That cross-check also found and fixed two real pathsim bugs upstream.)
+- **loopsim**: two real Mercury instances over kernel `snd-aloop`, AWGN.
+- **pathsim offline** (`--midlat-dist-nvis`): per-mode delivery measured with
+  the freedv raw tools, then driven through the deterministic sim.
+- **OTA**: Pedro's estacao6↔estacao10 session of 2026-07-04 ran the branch
+  build (`21266a6`) on real sky.
+
+## Results
+
+### 1. Deterministic fade-cliff test (the S1 proof)
+
+`test_sim_fade_cliff_downgrades` (previously `TEST_IGNORE`d as documentation
+of the bug): connect clean → fade below every non-floor mode's cliff → the
+branch descends to DATAC15 and delivers all 16 KB; trunk starves above the
+cliff.  Fuzz PER ceiling raised 0.25 → 0.40, 50 seeds green.
+
+### 2. Watterson HF fading A/B (1054 B, two rounds)
+
+| Condition (measured SNR) | trunk r1 | trunk r2 | branch r2 (final) |
+|---|---|---|---|
+| Moderate (~1–3 dB) | 1054 ✅ 298 s | 458 ❌ | **1054 ✅ 298 s** |
+| Poor, No −17 | 1054 ✅ 217 s | 1054 ✅ 216 s | **1054 ✅ 217 s** |
+| Poor, No −13 (below cliff) | 344 ❌ | 596 ❌ | **684** (3× runs: 684/684/684 vs trunk 344/596/596) |
+
+Notes: the harness Watterson is unseeded — trunk itself flips PASS/FAIL at
+"Moderate", so only cross-round patterns count.  Round 1 caught a real branch
+regression (the probe could *upgrade* into a fade; ~2 min go-back-N stall) —
+fixed by making probes downgrade-only (`21266a6`) before round 2.
+
+### 3. loopsim AWGN, 3-way with v1.9.9 (2048 B)
+
+| Channel | v1.9.9 | trunk | branch |
+|---|---|---|---|
+| Clean | 57.3 s ✅ | 62.0 s ✅ | 54.8 s ✅ |
+| Noise 1.0 (≈ −4 dB) | **0 bytes** ❌ | 592 s ✅ | 601 s ✅ |
+
+Parity everywhere; both post-1.9.9 builds rescue the −4 dB channel where
+v1.9.9 moves nothing.
+
+### 4. NVIS-disturbed (the deployment channel) — empirical-PER sim bench
+
+pathsim `--midlat-dist-nvis` (7 ms delay spread, 1 Hz Doppler) measured with
+freedv raw tools at SNR 10 is **ISI-limited, not SNR-limited** (delivery is
+flat from SNR 16 down to 4): DATAC15 ≈ 80 % delivery, DATAC3 ≈ 33 %,
+DATAC1 ≈ 11 %.  This is the exact S1 trap: SNR reads healthy while fast modes
+die.  Those measured per-mode PERs drive the deterministic sim (8 KB, 30
+virtual minutes, frames stamped 10 dB):
+
+| seed | trunk delivered | branch delivered |
+|---|---|---|
+| 1 | 22 B | 3188 B |
+| 2 | 22 B | 4572 B |
+| 3 | 22 B | 4214 B |
+| 4 | 22 B | 524 B |
+| 5 | 22 B | 4952 B |
+
+Trunk delivers exactly one floor frame (sent before the ladder climbs), then
+stalls at DATAC1 forever — the healthy SNR feeds the unbounded reverse-loss
+hold and the window guard, and no downgrade path can fire.  The branch keeps
+moving (integrity OK on every seed).  Branch behaviour is not perfect — the
+SNR trap re-arms after each hold expiry, and two seeds ended in a no-progress
+disconnect before finishing — but the difference is categorical: **~24–225×
+more data delivered on the channel these stations actually operate on.**
+
+### 5. OTA (Pedro, estacao6 ↔ estacao10, 2026-07-04, branch build)
+
+- S1 mechanics observed working on real sky: bounded holds engaging
+  (`hold 1/3`, re-armed by clean deliveries), OLLA climbing +0→+3 dB, ladder
+  ascending DATAC15→DATAC4→DATAC3→DATAC1 at burst boundaries on a −5 dB
+  forward path, restage firing correctly on a mid-window downgrade.
+- **Real bug found** ("IRS desconectou e a ISS continuou transmitindo"): with
+  a dead peer, the probe→failed-MODE_REQ→revert loop reset the retry budget
+  every ~200 s, preempting the no-progress disconnect indefinitely.  Fixed
+  (`a014b3c`): probes never fire once the no-progress budget is spent;
+  guarded by `test_sim_peer_loss_disconnects` (verified to fail on the bug).
+- Pre-existing gap noted (trunk too, NOT addressed here): an ISS idling with
+  an **empty** backlog never keepalive-times-out — only the IRS monitors
+  inactivity.  Belongs to the keepalive-persistence work.
+
+## Verdict
+
+- **No regression found anywhere workable**: clean AWGN, harsh AWGN, and
+  workable fading are at parity with trunk (after the round-1 probe fix).
+- **Real, repeatable advantage exactly where the fix aims**: below the fade
+  cliff (3× consistent on Watterson) and on ISI-limited NVIS-disturbed
+  (trunk effectively cannot transfer at all; the branch moves data on every
+  seed).
+- **OTA exposure already happened** and the one defect it surfaced is fixed
+  and regression-guarded.
+
+**Recommendation: merge `fix-s1-fadecliff` @ `a014b3c` into `mercuryv2`**,
+with one more Pedro OTA session on the `a014b3c` build as confirmation.
+Known follow-ups (not blockers): idle-ISS keepalive gap (pre-existing); the
+NVIS SNR-trap re-arming suggests a future "ISI channel" heuristic (delivery
+persistently contradicting SNR should cap the ladder); pathsim streaming
+mode still needs work for live bursty bridges (offline/continuous use is
+validated — the NVIS numbers above come from the validated offline path).
+
+## Reproducing
+
+```
+# deterministic suite (includes the cliff + peer-loss guards)
+make -C tests test_arq_sim && ./tests/test_arq_sim
+
+# Watterson A/B (per build: set MERCURY_BIN)
+MERCURY_CH_ENGINE=watterson MERCURY_CH_FADING=poor MERCURY_CH_NO=-13 \
+MERCURY_TEST_PAYLOAD_KB=1 go test -C tests/integration -run TestMercuryARQTransfer$
+
+# NVIS per-mode PER measurement (offline pathsim + freedv raw tools), then
+# the empirical-PER bench: see tests/sim sim_channel_set_mode_per(); the
+# bench driver used for §4 lives in the session scratchpad (nvis_bench.c).
+```

--- a/docs/S1-FADECLIFF-DECISION.md
+++ b/docs/S1-FADECLIFF-DECISION.md
@@ -114,6 +114,54 @@ more data delivered on the channel these stations actually operate on.**
   an **empty** backlog never keepalive-times-out — only the IRS monitors
   inactivity.  Belongs to the keepalive-persistence work.
 
+## Update (2026-07-05): broadened regression sweep + the NVIS mode question
+
+**A mode-selection "NVIS fix" was tried and REJECTED by the data.**  The
+hypothesis: since OLLA is a single SNR-offset scalar, on ISI-limited NVIS it
+re-climbs into fast modes that fail — so add a delivery-driven *mode ceiling*
+that caps selection below any rank that just failed to deliver.  Implemented,
+then measured on the NVIS bench: it made throughput **worse** (8-seed total
+23,100 B vs 29,900 B without it, −23 %).  The goodput arithmetic on the
+pathsim-measured NVIS profile explains why — throughput rises monotonically
+with mode speed *despite* high erasure, because the big frames carry so much
+more per delivered frame:
+
+| mode | frame | deliver | goodput (incl. go-back-N ACK cost) |
+|---|---|---|---|
+| DATAC15 | 22 B | 80 % | 1.9 B/s |
+| DATAC3 | 118 B | 33 % | 4.8 B/s |
+| DATAC1 | 502 B | 11 % | 6.0 B/s |
+| DATAC17 | 1172 B | 7 % | 7.0 B/s |
+
+So on NVIS the *correct* strategy is to favour the fast modes — which S1's
+existing re-climb behaviour already does.  The ceiling was reverted; **S1 as it
+stands is the NVIS win, not something needing a mode-selection fix.**  (A
+goodput-aware mode *lock* that holds the best-measured-goodput mode instead of
+oscillating is real future work, but it is an optimisation on top of an already
+large win, and this attempt shows how easily such a change regresses — it must
+be driven by the bench, not intuition.)
+
+**Broadened A/B regression grid (trunk `e7a2d84` vs branch, `tests/sim/ab_bench.c`,
+8 KB / 30 virtual min, 9 channels × 6 seeds = 108 runs; the two flagged channels
+re-run to 16 seeds):**
+
+| channel | branch ÷ trunk (aggregate) | note |
+|---|---|---|
+| clean, awgn 0.10, awgn 0.25 | 100 % | identical |
+| cliff +6, cliff +2 | 100 % | identical |
+| cliff −2 | 99 % | noise |
+| **cliff −5 (below cliff)** | **1728 %** | S1 target — trunk starves |
+| **nvis** (16 seeds) | **558 %**, branch wins 15/16 | primary channel |
+| awgn 0.40 (16 seeds) | 96 %, 13/16 ties | see below |
+
+- **Integrity: 0 corruptions across all 108 + 32 runs.**
+- The lone soft spot is **awgn 0.40** (96 % aggregate): a 40 %-flat-erasure
+  channel with *healthy* SNR — artificial (real high-erasure comes with low
+  SNR), and flat across modes so, unlike NVIS, downgrading cannot help.  S1's
+  slightly more eager downgrade response costs ~4 % there.  It is the flip side
+  of the exact mechanism that yields 5–17× on the realistic hard channels, has
+  13/16 ties and no integrity loss, and is not considered a blocker.
+
 ## Verdict
 
 - **No regression found anywhere workable**: clean AWGN, harsh AWGN, and

--- a/tests/datalink_arq/arq_test_stubs.c
+++ b/tests/datalink_arq/arq_test_stubs.c
@@ -12,6 +12,9 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <stdio.h>
+#ifdef SIM_TRACE_LOGS
+#include <stdarg.h>
+#endif
 
 #include "hermes_log.h"
 #include "framer.h"
@@ -34,7 +37,21 @@ void mock_set_uptime_ms(uint64_t ms)
 void hermes_logf(hermes_log_level_t level, const char *component,
                  const char *fmt, ...)
 {
+#ifdef SIM_TRACE_LOGS
+    /* Opt-in FSM log visibility for sim debugging:
+     *   make ... CFLAGS+=-DSIM_TRACE_LOGS
+     * Prefixes the virtual uptime so traces line up with sim time. */
+    va_list ap;
+    fprintf(stderr, "[%8llu ms] [%s] ",
+            (unsigned long long)hermes_uptime_ms(), component);
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    fputc('\n', stderr);
+    (void)level;
+#else
     (void)level; (void)component; (void)fmt;
+#endif
 }
 
 /* ---- framer stubs ---- */

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -62,6 +62,38 @@ If neither a root Mercury binary nor `make` is available, the test is skipped
 with a prerequisite message. `MERCURY_BIN=/path/to/mercury` can be used to point
 the harness at an already-built binary.
 
+## Channel simulation for `TestMercuryARQTransfer`
+
+`TestMercuryARQTransfer` bridges two Mercury instances through a channel
+simulator over the FIFO backend. Environment variables select the engine and
+conditions (all optional; default is codec2 `ch` on an effectively clean link):
+
+| Env var | Meaning |
+|---|---|
+| `MERCURY_CH_ENGINE` | `ch` (default, codec2 AWGN/MPP), `watterson` (in-tree ITU-R fading), or `pathsim` (AE4JY reference — requires `MERCURY_PATHSIM_BIN`) |
+| `MERCURY_PATHSIM_BIN` | path to a streaming-mode `pathsim` binary (`MERCURY_CH_ENGINE=pathsim`) |
+| `MERCURY_CH_NO` | AWGN noise density dBHz (`ch`/`watterson`; SNR3k ≈ −No − 14.82). For `pathsim`, carries its native `--snr` dB instead |
+| `MERCURY_CH_FADING` | fading profile — `ch`: `mpg`/`mpp`/`mpd`; `watterson`: `good`/`moderate`/`poor`/`flutter`; `pathsim`: a preset name, e.g. `ccir-poor`, `midlat-dist-nvis` |
+| `MERCURY_CH_GAIN` | linear channel gain (default 1.0) |
+| `MERCURY_CH_NO_FWD` / `_REV` | per-direction noise override (asymmetric link: A→B forward data vs B→A reverse ACKs) |
+| `MERCURY_CH_FADING_FWD` / `_REV` | per-direction fading profile (`none` disables one direction) |
+| `MERCURY_TEST_PAYLOAD_KB` | transfer size in KB (default ~102 bytes = 3 DATAC15 frames) |
+| `MERCURY_TEST_LOGDIR` | directory to keep per-instance logs (default: temp, deleted) |
+
+Example — one 1 KB transfer over an NVIS-disturbed pathsim channel:
+```
+MERCURY_BIN=./mercury MERCURY_CH_ENGINE=pathsim \
+MERCURY_PATHSIM_BIN=/path/to/pathsim MERCURY_CH_FADING=midlat-dist-nvis \
+MERCURY_CH_NO=10 MERCURY_TEST_PAYLOAD_KB=1 \
+go test -run 'TestMercuryARQTransfer$' -v
+```
+
+The Watterson engine (`utils/watterson_test`) is calibrated to `ch`
+(SNR3k = −No − 14.82) and cross-validated against `pathsim`. **`pathsim`
+streaming is validated for offline/continuous input; live bursty bridging is
+still WIP** — see the S1 decision doc. For the fully deterministic (no wall
+clock, no audio) FSM sweep, use the two-FSM sim in `../sim` instead.
+
 ## Future two-process harness
 
 Start with a Go harness here that can:

--- a/tests/integration/channel_bridge_test.go
+++ b/tests/integration/channel_bridge_test.go
@@ -27,6 +27,17 @@ func DefaultChannelParams() ChannelParams {
 }
 
 func (p ChannelParams) args() []string {
+	if p.Engine == "pathsim" {
+		// pathsim (AE4JY PathSim port) speaks --snr, not --No, and its SNR is
+		// referenced to the MEASURED signal RMS (own convention, roughly 2-3 dB
+		// harsher than SNR3k at matched numbers — do not mix scales).  For this
+		// engine No_dBHz carries the pathsim-native SNR in dB directly.
+		a := []string{"--snr", fmt.Sprintf("%.2f", p.No_dBHz)}
+		if p.Fading != "" {
+			a = append(a, "--"+p.Fading)
+		}
+		return a
+	}
 	a := []string{
 		"--No", fmt.Sprintf("%.2f", p.No_dBHz),
 		"--freq", fmt.Sprintf("%.2f", p.FreqOffsetHz),

--- a/tests/integration/mercury_arq_transfer_test.go
+++ b/tests/integration/mercury_arq_transfer_test.go
@@ -29,15 +29,26 @@ func TestMercuryARQTransfer(t *testing.T) {
 
 	params := DefaultChannelParams()
 
-	// Channel engine: codec2 ch.c (default) or the Watterson HF model.  The
-	// Watterson model gives controllable slow/deep fades (ITU-R good/moderate/
-	// poor) that reach the gear-shift oscillation regime ch --mpp cannot.
+	// Channel engine: codec2 ch.c (default), the Watterson HF model, or the
+	// AE4JY pathsim reference (MERCURY_CH_ENGINE=pathsim, streaming-mode
+	// binary pointed at by MERCURY_PATHSIM_BIN; MERCURY_CH_NO then carries the
+	// pathsim-native --snr dB, and MERCURY_CH_FADING one of its presets, e.g.
+	// ccir-poor or midlat-dist-nvis).  The Watterson model gives controllable
+	// slow/deep fades (ITU-R good/moderate/poor) that reach the gear-shift
+	// oscillation regime ch --mpp cannot.
 	var chBin string
 	var err error
-	if os.Getenv("MERCURY_CH_ENGINE") == "watterson" {
+	switch os.Getenv("MERCURY_CH_ENGINE") {
+	case "watterson":
 		params.Engine = "watterson"
 		chBin, err = buildWatterson(repoRoot)
-	} else {
+	case "pathsim":
+		params.Engine = "pathsim"
+		chBin = os.Getenv("MERCURY_PATHSIM_BIN")
+		if chBin == "" {
+			t.Skip("MERCURY_CH_ENGINE=pathsim requires MERCURY_PATHSIM_BIN")
+		}
+	default:
 		chBin, err = buildCh(repoRoot)
 	}
 	if err != nil {

--- a/tests/sim/README.md
+++ b/tests/sim/README.md
@@ -82,17 +82,29 @@ This is enough for the FSM to record `local_snr_x10` and enable mode
 upgrading, but does not exercise SNR-driven adaptation paths.  A richer SNR
 model (sampled from a distribution or derived from PER) is a future task.
 
-## The S1 fade-cliff regression
+## The S1 fade-cliff regression (fixed)
 
-`test_sim_fade_cliff_downgrades` is registered with `TEST_IGNORE_MESSAGE`.
-It documents that, on the current HEAD, when a channel is too lossy for the
-active payload mode, the FSM does not downgrade to the DATAC15 floor.  The
-dead-code path that should trigger the downgrade is the S1 issue.
+`test_sim_fade_cliff_downgrades` connects on a good band, then drops the
+channel SNR below the cliff of every mode except the DATAC15 floor
+(`sim_set_snr` enables the mode-aware cliff erasure model).  It asserts the
+FSM descends to DATAC15 and still delivers every byte.
 
-Once the S1 fix lands:
-1. Remove the `TEST_IGNORE_MESSAGE` wrapper.
-2. Raise the PER ceiling in `test_sim_fuzz` from 0.25 to 0.40.
-3. Verify that `test_sim_fade_cliff_downgrades` now PASS.
+The S1 bug was an UNBOUNDED reverse-loss hold in `record_tx_outcome()`: when
+the SNR of surviving frames still looked adequate, every retry was charged to
+reverse-path ACK loss, freezing OLLA and `consecutive_retries` so no downgrade
+path (not even the hard-loss floor) could fire — the transfer starved above
+the cliff.  The fix bounds the hold (`ARQ_REVERSE_HOLD_MAX`), advances
+`consecutive_retries` per ACK timeout, and lets a mode probe change mode with
+an unACKed window (the MODE_ACK carries the peer's `rx_expected`, which
+resolves the window; undelivered bytes are restaged and re-framed at the new
+mode).  The fuzz loop PER ceiling was raised 0.25 → 0.40 accordingly.
+
+### Debugging the FSM under the sim
+
+Build the sim binary with `-DSIM_TRACE_LOGS` to route the FSM's `HLOG*`
+output (normally swallowed by the test stub) to stderr, each line prefixed
+with the virtual uptime — invaluable for following mode negotiation, restage,
+and retry decisions.
 
 ## Future work
 

--- a/tests/sim/README.md
+++ b/tests/sim/README.md
@@ -82,6 +82,38 @@ This is enough for the FSM to record `local_snr_x10` and enable mode
 upgrading, but does not exercise SNR-driven adaptation paths.  A richer SNR
 model (sampled from a distribution or derived from PER) is a future task.
 
+## Fault-injection API (channel controls)
+
+The channel starts at each `sim_channel_cfg_t`'s base per-frame erasure `per`.
+These calls change conditions mid-run (call them *after* `make_connected` so
+the handshake completes on a clean channel, then the fault hits the transfer):
+
+| Call (`sim_core.h`) | Effect |
+|---|---|
+| `sim_set_per(s, per)` | flat per-frame erasure probability [0,1] |
+| `sim_set_rx_snr(s, db)` | SNR stamped on delivered frames (drives OLLA feedback) |
+| `sim_set_snr(s, db)` | **coherent fade**: mode-aware SNR *cliff* erasure model + stamps the same SNR on survivors. A frame in a mode whose cliff (approx. `docs/MODES.md`) is above the channel SNR is erased ~90%; robust modes pass. This makes "downgrade" the winning move, as on real HF. |
+| `sim_set_mode_per(s, tbl, n, db)` | **empirical per-mode erasure**: a `{freedv_mode, per}` table (e.g. measured on pathsim `--midlat-dist-nvis`) plus the delivered-frame SNR. Models ISI-limited channels where SNR reads healthy while fast modes fail. Overrides the cliff model. |
+
+`test_sim_fuzz` sweeps flat AWGN erasure; `test_sim_fuzz_fading` sweeps the
+cliff and per-mode-PER models (60 seeds), asserting the two invariants that
+must hold on any channel — **no corruption** (delivered is a byte-exact prefix
+of sent) and **clean termination** (completed or disconnected, never stuck
+CONNECTED). `test_sim_peer_loss_disconnects` blacks out a peer mid-transfer and
+requires a bounded disconnect.
+
+## A/B throughput bench (`ab_bench.c`)
+
+`ab_bench <seed> <channel>` (channel = `clean | awgn:<per> | cliff:<snr> | nvis`)
+runs an 8 KB transfer and prints delivered/total, integrity, final mode and
+conn-state. It links against whatever tree's `arq_fsm.c` it is compiled in, so
+comparing two builds means compiling it twice (against tree A's and tree B's
+sources) and diffing the output across a seed × channel grid. Trust the
+**aggregate** over many seeds and always the integrity flag, not per-seed
+deltas — the channel PRNG is a single shared stream, so once two builds make
+different decisions they consume it differently and see different erasure
+realizations. Used for the S1 merge decision (`docs/S1-FADECLIFF-DECISION.md`).
+
 ## The S1 fade-cliff regression (fixed)
 
 `test_sim_fade_cliff_downgrades` connects on a good band, then drops the

--- a/tests/sim/ab_bench.c
+++ b/tests/sim/ab_bench.c
@@ -1,0 +1,92 @@
+/* Deterministic ARQ throughput/integrity bench over a channel matrix.
+ *
+ *   ab_bench <seed> <channel>
+ *   channel := clean | awgn:<per> | cliff:<snr_db> | nvis
+ *
+ * Connects two real arq_fsm sessions over the two-FSM sim, applies the named
+ * channel to an 8 KB transfer, and prints delivered/total, integrity,
+ * final mode and conn_state after 30 virtual minutes.  It links against the
+ * arq_fsm.c of whatever tree it is compiled in, so an A/B comparison is:
+ *
+ *   gcc ... -I<treeA/...> ab_bench.c <sim srcs> <treeA arq_*.c> -o benchA
+ *   gcc ... -I<treeB/...> ab_bench.c <sim srcs> <treeB arq_*.c> -o benchB
+ *   for ch in clean awgn:0.25 cliff:-5 nvis; do for s in $(seq 1 16); do
+ *     benchA $s $ch; benchB $s $ch; done; done   # compare delivered/integrity
+ *
+ * NB: the sim channel PRNG is a single shared stream, so once the two builds
+ * make different mode/timing decisions they consume it differently and see
+ * different erasure realizations.  Per-seed A/B is therefore only loosely
+ * controlled; trust the AGGREGATE over many seeds, and always the integrity
+ * flag (which must be OK on every run).  Used for the S1 fade-cliff merge
+ * decision — see docs/S1-FADECLIFF-DECISION.md.
+ */
+#include "sim_clock.h"
+#include "sim_channel.h"
+#include "sim_endpoint.h"
+#include "sim_core.h"
+#include "arq_fsm.h"
+#include "arq_protocol.h"
+#include "freedv_api.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+/* Measured NVIS (pathsim --midlat-dist-nvis --snr 10, freedv raw tools). */
+static const sim_mode_per_t NVIS[] = {
+    { FREEDV_MODE_DATAC15, 0.20 }, { FREEDV_MODE_DATAC16, 0.20 },
+    { FREEDV_MODE_DATAC13, 0.30 }, { FREEDV_MODE_DATAC14, 0.30 },
+    { FREEDV_MODE_DATAC4,  0.45 }, { FREEDV_MODE_DATAC3,  0.67 },
+    { FREEDV_MODE_DATAC1,  0.89 }, { FREEDV_MODE_DATAC17, 0.93 },
+    { FREEDV_MODE_QAM16C2, 0.95 },
+};
+
+int main(int argc, char **argv)
+{
+    if (argc < 3) { fprintf(stderr, "usage: %s <seed> <channel>\n", argv[0]); return 1; }
+    uint64_t seed = (uint64_t)atoll(argv[1]);
+    const char *chan_spec = argv[2];
+
+    sim_channel_cfg_t chan = { .seed = seed, .per = 0.02, .guard_ms = 150 };
+    sim_t *s = sim_create(&chan, "A0AAA", "B0BBB");
+    if (!s) { fprintf(stderr, "sim_create failed\n"); return 1; }
+
+    arq_event_t listen = { .id = ARQ_EV_APP_LISTEN };
+    sim_inject(s, sim_b(s), &listen);
+    arq_event_t conn = { .id = ARQ_EV_APP_CONNECT };
+    snprintf(conn.remote_call, CALLSIGN_MAX_SIZE, "%s", "B0BBB");
+    sim_inject(s, sim_a(s), &conn);
+    sim_run_until_idle(s, 30000);
+    if (sim_endpoint_session(sim_a(s))->conn_state != ARQ_CONN_CONNECTED) {
+        printf("seed=%llu chan=%s delivered=0/8192 integrity=OK final_mode=-1 conn=NOCONNECT\n",
+               (unsigned long long)seed, chan_spec);
+        sim_destroy(s); return 0;
+    }
+
+    /* Apply channel after connect (connect always on the clean 2% floor). */
+    if (strncmp(chan_spec, "awgn:", 5) == 0)
+        sim_set_per(s, atof(chan_spec + 5));
+    else if (strncmp(chan_spec, "cliff:", 6) == 0)
+        sim_set_snr(s, atof(chan_spec + 6));
+    else if (strcmp(chan_spec, "nvis") == 0)
+        sim_set_mode_per(s, NVIS, (int)(sizeof(NVIS)/sizeof(NVIS[0])), 10.0f);
+    /* "clean" leaves the 2% floor. */
+
+    static uint8_t blob[8192];
+    for (int i = 0; i < (int)sizeof(blob); i++) blob[i] = (uint8_t)((i * 13 + 7) & 0xFF);
+    sim_endpoint_queue_tx(sim_a(s), blob, sizeof(blob));
+    arq_event_t dready = { .id = ARQ_EV_APP_DATA_READY };
+    sim_inject(s, sim_a(s), &dready);
+
+    sim_run_until_idle(s, 30 * 60 * 1000);
+
+    static uint8_t got[65536];
+    size_t n = sim_endpoint_delivered(sim_b(s), got, sizeof(got));
+    int ok = (n <= sizeof(blob)) && memcmp(got, blob, n) == 0;
+    arq_session_t *sa = sim_endpoint_session(sim_a(s));
+    printf("seed=%llu chan=%s delivered=%zu/%zu integrity=%s final_mode=%d conn=%d\n",
+           (unsigned long long)seed, chan_spec, n, sizeof(blob),
+           ok ? "OK" : "CORRUPT", sa->payload_mode, (int)sa->conn_state);
+    sim_destroy(s);
+    return ok ? 0 : 2;
+}

--- a/tests/sim/sim_channel.c
+++ b/tests/sim/sim_channel.c
@@ -12,6 +12,8 @@ struct sim_channel {
     uint32_t guard_ms;
     bool     cliff_enabled;   /* mode-aware erasure (see sim_channel_set_snr) */
     double   snr_db;          /* current channel SNR when cliff_enabled */
+    sim_mode_per_t mode_per[SIM_MODE_PER_MAX]; /* empirical per-mode erasure */
+    int      mode_per_count;
 };
 
 /* Per-mode SNR cliff (dB): below this the mode effectively stops decoding.
@@ -63,6 +65,16 @@ void sim_channel_set_snr(sim_channel_t *ch, double snr_db)
     }
 }
 
+void sim_channel_set_mode_per(sim_channel_t *ch,
+                              const sim_mode_per_t *table, int count)
+{
+    if (!ch) return;
+    if (count > SIM_MODE_PER_MAX) count = SIM_MODE_PER_MAX;
+    for (int i = 0; i < count; i++)
+        ch->mode_per[i] = table[i];
+    ch->mode_per_count = count;
+}
+
 /* SplitMix64: deterministic, seedable, no global state. */
 double sim_channel_next_rand(sim_channel_t *ch)
 {
@@ -89,7 +101,16 @@ bool sim_channel_schedule(sim_channel_t *ch, uint64_t now_ms,
 {
     (void)dir;
     double per = ch->per;
-    if (ch->cliff_enabled && ch->snr_db < mode_cliff_db(freedv_mode))
+    if (ch->mode_per_count > 0)
+    {
+        for (int i = 0; i < ch->mode_per_count; i++)
+            if (ch->mode_per[i].freedv_mode == freedv_mode)
+            {
+                per = ch->mode_per[i].per;
+                break;
+            }
+    }
+    else if (ch->cliff_enabled && ch->snr_db < mode_cliff_db(freedv_mode))
         per = SIM_CLIFF_PER;
     if (sim_channel_next_rand(ch) < per)
         return false;   /* erased */

--- a/tests/sim/sim_channel.c
+++ b/tests/sim/sim_channel.c
@@ -3,9 +3,38 @@
  * Copyright (C) 2026 Rhizomatica */
 #include "sim_channel.h"
 #include "arq_protocol.h"
+#include "freedv_api.h"
 #include <stdlib.h>
 
-struct sim_channel { uint64_t state; double per; uint32_t guard_ms; };
+struct sim_channel {
+    uint64_t state;
+    double   per;
+    uint32_t guard_ms;
+    bool     cliff_enabled;   /* mode-aware erasure (see sim_channel_set_snr) */
+    double   snr_db;          /* current channel SNR when cliff_enabled */
+};
+
+/* Per-mode SNR cliff (dB): below this the mode effectively stops decoding.
+ * Approximates the MPP delivery curves in docs/MODES.md. */
+static double mode_cliff_db(int freedv_mode)
+{
+    switch (freedv_mode)
+    {
+    case FREEDV_MODE_QAM16C2: return 13.0;
+    case FREEDV_MODE_DATAC17: return  8.0;
+    case FREEDV_MODE_DATAC1:  return  5.0;
+    case FREEDV_MODE_DATAC3:  return  0.0;
+    case FREEDV_MODE_DATAC4:  return -4.0;
+    case FREEDV_MODE_DATAC13: return -4.0;
+    case FREEDV_MODE_DATAC14: return -2.0;
+    default:                  return -7.0;  /* DATAC15 / DATAC16 floor modes */
+    }
+}
+
+/* Erasure probability of a frame above its mode's cliff.  Not 1.0: even a
+ * dead mode occasionally lands a frame on real HF, and a tiny success rate
+ * keeps unbounded-retry pathologies observable rather than instantly fatal. */
+#define SIM_CLIFF_PER 0.90
 
 sim_channel_t *sim_channel_create(const sim_channel_cfg_t *cfg)
 {
@@ -18,6 +47,21 @@ sim_channel_t *sim_channel_create(const sim_channel_cfg_t *cfg)
 }
 
 void sim_channel_destroy(sim_channel_t *ch) { free(ch); }
+
+void sim_channel_set_per(sim_channel_t *ch, double per)
+{
+    if (ch)
+        ch->per = per;
+}
+
+void sim_channel_set_snr(sim_channel_t *ch, double snr_db)
+{
+    if (ch)
+    {
+        ch->cliff_enabled = true;
+        ch->snr_db        = snr_db;
+    }
+}
 
 /* SplitMix64: deterministic, seedable, no global state. */
 double sim_channel_next_rand(sim_channel_t *ch)
@@ -44,7 +88,10 @@ bool sim_channel_schedule(sim_channel_t *ch, uint64_t now_ms,
                           uint64_t *deliver_at_ms)
 {
     (void)dir;
-    if (sim_channel_next_rand(ch) < ch->per)
+    double per = ch->per;
+    if (ch->cliff_enabled && ch->snr_db < mode_cliff_db(freedv_mode))
+        per = SIM_CLIFF_PER;
+    if (sim_channel_next_rand(ch) < per)
         return false;   /* erased */
     uint32_t air = sim_channel_airtime_ms(freedv_mode, frame_size);
     *deliver_at_ms = now_ms + air + ch->guard_ms;

--- a/tests/sim/sim_channel.h
+++ b/tests/sim/sim_channel.h
@@ -17,6 +17,16 @@ typedef struct sim_channel sim_channel_t;
 
 sim_channel_t *sim_channel_create(const sim_channel_cfg_t *cfg);
 void           sim_channel_destroy(sim_channel_t *ch);
+/* Change the erasure probability mid-simulation (models a fade onset). */
+void           sim_channel_set_per(sim_channel_t *ch, double per);
+
+/* Enable the mode-aware cliff model: frames in a mode whose SNR cliff lies
+ * above the current channel SNR are erased with high probability (0.9);
+ * modes below their cliff see the base per.  This is what makes "downgrade
+ * to a more robust mode" the winning strategy, as on real HF — a mode-blind
+ * per cannot reward downgrades.  Cliffs approximate the MPP curves in
+ * docs/MODES.md. */
+void           sim_channel_set_snr(sim_channel_t *ch, double snr_db);
 uint32_t       sim_channel_airtime_ms(int freedv_mode, size_t frame_size);
 bool           sim_channel_schedule(sim_channel_t *ch, uint64_t now_ms,
                                      int dir, int freedv_mode, size_t frame_size,

--- a/tests/sim/sim_channel.h
+++ b/tests/sim/sim_channel.h
@@ -27,6 +27,16 @@ void           sim_channel_set_per(sim_channel_t *ch, double per);
  * per cannot reward downgrades.  Cliffs approximate the MPP curves in
  * docs/MODES.md. */
 void           sim_channel_set_snr(sim_channel_t *ch, double snr_db);
+
+/* Empirical per-mode erasure model: each entry maps a FreeDV mode to a
+ * measured frame-erasure probability from a reference channel run (e.g. a
+ * pathsim NVIS characterization).  Modes not listed use the base per.
+ * Takes precedence over the cliff model while installed (count > 0). */
+typedef struct { int freedv_mode; double per; } sim_mode_per_t;
+#define SIM_MODE_PER_MAX 12
+void           sim_channel_set_mode_per(sim_channel_t *ch,
+                                        const sim_mode_per_t *table, int count);
+
 uint32_t       sim_channel_airtime_ms(int freedv_mode, size_t frame_size);
 bool           sim_channel_schedule(sim_channel_t *ch, uint64_t now_ms,
                                      int dir, int freedv_mode, size_t frame_size,

--- a/tests/sim/sim_core.c
+++ b/tests/sim/sim_core.c
@@ -183,6 +183,13 @@ void sim_set_snr(sim_t *s, double snr_db)
     s->rx_snr_db = (float)snr_db;
 }
 
+void sim_set_mode_per(sim_t *s, const sim_mode_per_t *table, int count,
+                      float rx_snr_db)
+{
+    sim_channel_set_mode_per(s->ch, table, count);
+    s->rx_snr_db = rx_snr_db;
+}
+
 void sim_inject(sim_t *s, sim_endpoint_t *ep, const arq_event_t *ev)
 {
     sim_endpoint_set_active(ep);

--- a/tests/sim/sim_core.c
+++ b/tests/sim/sim_core.c
@@ -49,6 +49,8 @@ struct sim {
     sim_pending_t    pending[SIM_PENDING_MAX];
     int              pending_count;
 
+    float            rx_snr_db;  /* SNR stamped on delivered frames */
+
     arq_timing_ctx_t timing;  /* shared timing context (metrics only, not correctness) */
 };
 
@@ -93,7 +95,7 @@ static void drain_outframes_from(sim_t *s, sim_endpoint_t *sender,
                 .target     = peer,
                 .kind       = SIM_PENDING_FRAME,
                 .frame_len  = of.len,
-                .rx_snr     = 12.0f,  /* fixed simulated SNR; adequate for mode inference */
+                .rx_snr     = s->rx_snr_db, /* default 12 dB; sim_set_rx_snr models fades */
             };
             memcpy(frame_ev.frame, of.buf, of.len);
             enqueue(s, &frame_ev);
@@ -141,6 +143,7 @@ sim_t *sim_create(const sim_channel_cfg_t *chan_cfg,
     s->b  = sim_endpoint_create(call_b, call_a);
     s->ch = sim_channel_create(chan_cfg);
     if (!s->a || !s->b || !s->ch) { sim_destroy(s); return NULL; }
+    s->rx_snr_db = 12.0f;
 
     arq_timing_init(&s->timing);
     /* Register shared callbacks once; they read s_active for per-call context. */
@@ -165,6 +168,20 @@ sim_endpoint_t *sim_a(sim_t *s) { return s->a; }
 sim_endpoint_t *sim_b(sim_t *s) { return s->b; }
 
 int sim_frames_in_flight(sim_t *s) { return s->pending_count; }
+
+/* Fade controls: change channel loss and delivered-frame SNR mid-simulation
+ * (a real fade degrades both — surviving frames also arrive weaker). */
+void sim_set_per(sim_t *s, double per)      { sim_channel_set_per(s->ch, per); }
+void sim_set_rx_snr(sim_t *s, float snr_db) { s->rx_snr_db = snr_db; }
+
+/* Coherent SNR change: enables the channel's mode-aware cliff model AND
+ * stamps the same SNR on delivered frames, so the FSM's SNR feedback agrees
+ * with the channel physics (as on real HF). */
+void sim_set_snr(sim_t *s, double snr_db)
+{
+    sim_channel_set_snr(s->ch, snr_db);
+    s->rx_snr_db = (float)snr_db;
+}
 
 void sim_inject(sim_t *s, sim_endpoint_t *ep, const arq_event_t *ev)
 {

--- a/tests/sim/sim_core.h
+++ b/tests/sim/sim_core.h
@@ -28,4 +28,10 @@ uint64_t        sim_run_until_idle(sim_t *s, uint64_t max_ms);
 /* Number of pending channel events (for liveness checks). */
 int             sim_frames_in_flight(sim_t *s);
 
+/* Fade controls: change channel loss / delivered-frame SNR mid-simulation. */
+void            sim_set_per(sim_t *s, double per);
+void            sim_set_rx_snr(sim_t *s, float snr_db);
+/* Coherent fade: cliff-model channel SNR + delivered-frame SNR together. */
+void            sim_set_snr(sim_t *s, double snr_db);
+
 #endif

--- a/tests/sim/sim_core.h
+++ b/tests/sim/sim_core.h
@@ -34,4 +34,10 @@ void            sim_set_rx_snr(sim_t *s, float snr_db);
 /* Coherent fade: cliff-model channel SNR + delivered-frame SNR together. */
 void            sim_set_snr(sim_t *s, double snr_db);
 
+/* Empirical per-mode erasure table (see sim_channel_set_mode_per) plus the
+ * SNR stamped on delivered frames — models ISI-limited channels (e.g. NVIS
+ * disturbed) where the SNR reads healthy while fast modes fail. */
+void            sim_set_mode_per(sim_t *s, const sim_mode_per_t *table,
+                                 int count, float rx_snr_db);
+
 #endif

--- a/tests/sim/test_arq_sim.c
+++ b/tests/sim/test_arq_sim.c
@@ -333,6 +333,52 @@ void test_sim_fade_cliff_downgrades(void)
     sim_destroy(s);
 }
 
+void test_sim_peer_loss_disconnects(void)
+{
+    /* Peer-death teardown: mid-transfer the channel goes fully dark (peer
+     * off the air).  The ISS must reach a disconnected/listening state
+     * within a bounded time — the no-progress budget plus one retry-
+     * exhaustion round — instead of keying the radio forever.
+     *
+     * Regression guard for Pedro's estacao6/estacao10 OTA finding on the S1
+     * build ("IRS desconectou e a ISS continuou transmitindo"): the mid-
+     * window mode probe fired on hard-loss, its failed MODE_REQ negotiation
+     * reset the data retry budget, and the loop repeated every ~200 s —
+     * permanently preempting the retry-exhaustion branch that owns the
+     * no-progress disconnect.  Fixed by never probing once the no-progress
+     * budget is spent. */
+    sim_channel_cfg_t chan = { .seed = 5, .per = 0.02, .guard_ms = 150 };
+    sim_t *s = make_connected(&chan);
+    TEST_ASSERT_NOT_NULL(s);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED,
+                          sim_endpoint_session(sim_a(s))->conn_state);
+
+    static uint8_t blob[4000];
+    for (int i = 0; i < (int)sizeof(blob); i++) blob[i] = (uint8_t)(i & 0xFF);
+    sim_endpoint_queue_tx(sim_a(s), blob, sizeof(blob));
+    arq_event_t dready = { .id = ARQ_EV_APP_DATA_READY };
+    sim_inject(s, sim_a(s), &dready);
+
+    /* A short slice only: the blackout must land MID-TRANSFER with backlog
+     * still queued, so the ISS is in the DATA_TX/WAIT_ACK retry cycle (the
+     * path with the probe loop).  NB sim_run_until_idle never goes "idle"
+     * while connected (keepalive deadlines stay armed), so this consumes the
+     * full slice of virtual time. */
+    sim_run_until_idle(s, 15000);
+
+    sim_set_per(s, 1.0);            /* peer vanishes: total blackout */
+
+    /* Budget (180 s) + a full retry-exhaustion round (~190 s) + margin. */
+    sim_run_until_idle(s, 900000);
+
+    TEST_ASSERT_NOT_EQUAL(ARQ_CONN_CONNECTED,
+                          sim_endpoint_session(sim_a(s))->conn_state);
+    TEST_ASSERT_NOT_EQUAL(ARQ_CONN_CONNECTED,
+                          sim_endpoint_session(sim_b(s))->conn_state);
+
+    sim_destroy(s);
+}
+
 /* ======================================================================
  * Task 8: Seeded fuzz loop
  * ====================================================================== */
@@ -461,6 +507,7 @@ int main(void)
     RUN_TEST(test_sim_transfer_clean);
     RUN_TEST(test_sim_transfer_lossy_per20);
     RUN_TEST(test_sim_fade_cliff_downgrades);
+    RUN_TEST(test_sim_peer_loss_disconnects);
 
     /* Task 8: seeded fuzz loop */
     RUN_TEST(test_sim_fuzz);

--- a/tests/sim/test_arq_sim.c
+++ b/tests/sim/test_arq_sim.c
@@ -475,6 +475,115 @@ void test_sim_fuzz(void)
     }
 }
 
+/* SplitMix64 helper: n-th derived uniform double in [0,1) from a seed. */
+static double splitmix_u(uint64_t seed, int n)
+{
+    uint64_t st = seed;
+    uint64_t z = 0;
+    for (int i = 0; i <= n; i++) {
+        z = (st += 0x9E3779B97F4A7C15ULL);
+        z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+        z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+        z ^= (z >> 31);
+    }
+    return (double)(z >> 11) / (double)(1ULL << 53);
+}
+
+void test_sim_fuzz_fading(void)
+{
+    /* Fading/ISI fuzz over the S1 code paths (cliff model + empirical
+     * per-mode PER), which test_sim_fuzz (flat AWGN erasure) never reaches.
+     * Each seed connects clean, then a fade lands mid-transfer — either a
+     * mode-aware SNR cliff or an ISI-limited per-mode PER profile (NVIS-like:
+     * healthy SNR, fast modes fail) — the exact regime the S1 fix targets.
+     *
+     * Two invariants that MUST hold on ANY channel, checked every seed:
+     *   (a) NO CORRUPTION — whatever the peer received is a byte-exact prefix
+     *       of what was sent (retransmission ARQ may deliver less under a
+     *       brutal fade, but never wrong bytes; the restage path is the new
+     *       risk here);
+     *   (b) CLEAN TERMINATION — within a generous budget the session either
+     *       completed or disconnected; it is never left CONNECTED-but-stuck
+     *       cycling retries forever (the peer-death pathology, generalized). */
+    const int SEEDS = 60;
+    for (int seed = 1; seed <= SEEDS; seed++)
+    {
+        sim_channel_cfg_t cfg = { .seed = (uint64_t)seed,
+                                  .per = 0.02, .guard_ms = 150 };
+        sim_t *s = sim_create(&cfg, "A0AAA", "B0BBB");
+        if (!s) { TEST_FAIL_MESSAGE("sim_create failed"); return; }
+
+        arq_event_t listen = { .id = ARQ_EV_APP_LISTEN };
+        sim_inject(s, sim_b(s), &listen);
+        arq_event_t conn = { .id = ARQ_EV_APP_CONNECT };
+        snprintf(conn.remote_call, CALLSIGN_MAX_SIZE, "%s", "B0BBB");
+        sim_inject(s, sim_a(s), &conn);
+        sim_run_until_idle(s, 60000);
+        if (sim_endpoint_session(sim_a(s))->conn_state != ARQ_CONN_CONNECTED) {
+            sim_destroy(s); continue;  /* connect-under-loss is tested elsewhere */
+        }
+
+        size_t xfer = 500 + (size_t)(splitmix_u(seed, 0) * 4000.0); /* [500,4500) */
+        double sel  = splitmix_u(seed, 1);
+
+        if (sel < 0.5) {
+            /* Mode-aware SNR cliff: fade to a random depth [-6, +4) dB. */
+            double snr = -6.0 + splitmix_u(seed, 2) * 10.0;
+            sim_set_snr(s, snr);
+        } else {
+            /* ISI-limited per-mode PER, scaled by severity [0.6, 1.0). */
+            double sev = 0.6 + splitmix_u(seed, 2) * 0.4;
+            sim_mode_per_t tbl[] = {
+                { FREEDV_MODE_DATAC15, 0.15 * sev }, { FREEDV_MODE_DATAC16, 0.15 * sev },
+                { FREEDV_MODE_DATAC13, 0.25 * sev }, { FREEDV_MODE_DATAC14, 0.25 * sev },
+                { FREEDV_MODE_DATAC4,  0.45 * sev }, { FREEDV_MODE_DATAC3,  0.67 * sev },
+                { FREEDV_MODE_DATAC1,  0.89 * sev }, { FREEDV_MODE_DATAC17, 0.93 * sev },
+                { FREEDV_MODE_QAM16C2, 0.95 * sev },
+            };
+            sim_set_mode_per(s, tbl, (int)(sizeof(tbl)/sizeof(tbl[0])), 10.0f);
+        }
+
+        uint8_t *blob = malloc(xfer);
+        if (!blob) { sim_destroy(s); continue; }
+        for (size_t i = 0; i < xfer; i++) blob[i] = (uint8_t)((i * 3 + seed) & 0xFF);
+        sim_endpoint_queue_tx(sim_a(s), blob, xfer);
+        arq_event_t dready = { .id = ARQ_EV_APP_DATA_READY };
+        sim_inject(s, sim_a(s), &dready);
+
+        sim_run_until_idle(s, 45 * 60 * 1000);  /* 45 virtual min ceiling */
+
+        /* (a) no corruption: delivered is a byte-exact prefix of sent. */
+        uint8_t *got = malloc(xfer);
+        if (!got) { free(blob); sim_destroy(s); continue; }
+        size_t n = sim_endpoint_delivered(sim_b(s), got, xfer);
+        if (n > xfer || memcmp(blob, got, n) != 0) {
+            char msg[192];
+            snprintf(msg, sizeof(msg),
+                     "fading fuzz seed=%d xfer=%zu: CORRUPT at/after byte %zu",
+                     seed, xfer, n);
+            free(got); free(blob); sim_destroy(s);
+            TEST_FAIL_MESSAGE(msg);
+            return;
+        }
+
+        /* (b) clean termination: complete, or disconnected — never stuck. */
+        int cs = sim_endpoint_session(sim_a(s))->conn_state;
+        bool complete = (n == xfer);
+        bool terminated = (cs != ARQ_CONN_CONNECTED);
+        if (!complete && !terminated) {
+            char msg[192];
+            snprintf(msg, sizeof(msg),
+                     "fading fuzz seed=%d xfer=%zu: STUCK connected, only %zu/%zu delivered",
+                     seed, xfer, n, xfer);
+            free(got); free(blob); sim_destroy(s);
+            TEST_FAIL_MESSAGE(msg);
+            return;
+        }
+
+        free(got); free(blob); sim_destroy(s);
+    }
+}
+
 /* ======================================================================
  * Unity main
  * ====================================================================== */
@@ -511,6 +620,7 @@ int main(void)
 
     /* Task 8: seeded fuzz loop */
     RUN_TEST(test_sim_fuzz);
+    RUN_TEST(test_sim_fuzz_fading);
 
     return UNITY_END();
 }

--- a/tests/sim/test_arq_sim.c
+++ b/tests/sim/test_arq_sim.c
@@ -282,12 +282,55 @@ void test_sim_transfer_lossy_per20(void)
 
 void test_sim_fade_cliff_downgrades(void)
 {
-    /* This test documents the S1 fade-cliff regression: when the channel PER
-     * is high enough that the current payload mode cannot deliver, the FSM
-     * should downgrade to the DATAC15 floor, but the dead-code path in the
-     * current HEAD means it never does.  This test is an executable proof of
-     * the S1 regression and will be un-ignored when S1 is fixed. */
-    TEST_IGNORE_MESSAGE("documents S1 fade-cliff regression; un-ignore when S1 is fixed");
+    /* S1 fade-cliff regression.  Connect and start transferring on a good
+     * channel (12 dB — the payload mode may climb), then the band fades to
+     * -5.5 dB: on the channel's mode-aware cliff model every mode above
+     * DATAC15/DATAC16 now loses ~90% of its frames, so downgrading to the
+     * floor is the ONLY way to keep moving — exactly the real-HF fade cliff.
+     *
+     * Before the S1 fix, the reverse-loss hold in record_tx_outcome() was
+     * unbounded: with an SNR reading that still looked adequate, every retry
+     * was attributed to reverse ACK loss, which froze OLLA and
+     * consecutive_retries and made every downgrade path (including the
+     * hard-loss floor drop) unreachable — the transfer starved above the
+     * cliff.  With the bounded hold the delivery feedback breaks through,
+     * the mode descends to DATAC15, and the transfer completes. */
+    sim_channel_cfg_t chan = { .seed = 42, .per = 0.02, .guard_ms = 150 };
+    sim_t *s = make_connected(&chan);
+    TEST_ASSERT_NOT_NULL(s);
+
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED,
+                          sim_endpoint_session(sim_a(s))->conn_state);
+    sim_set_snr(s, 12.0);   /* good band: cliff model on, all modes usable */
+
+    /* Sized so the good phase (below) moves only part of it: the fade must
+     * land MID-TRANSFER with a large backlog still queued at the fast mode. */
+    static uint8_t blob[16000];
+    for (int i = 0; i < (int)sizeof(blob); i++)
+        blob[i] = (uint8_t)((i * 11 + 5) & 0xFF);
+    sim_endpoint_queue_tx(sim_a(s), blob, sizeof(blob));
+
+    arq_event_t dready = { .id = ARQ_EV_APP_DATA_READY };
+    sim_inject(s, sim_a(s), &dready);
+
+    /* Let the transfer run on the good band briefly (mode climbs). */
+    sim_run_until_idle(s, 90000);
+
+    /* Fade onset: only the DATAC15/DATAC16 floor survives below -5.5 dB. */
+    sim_set_snr(s, -5.5);
+
+    /* The floor moves ~22 user bytes per ~11 s cycle; give the remainder
+     * ample virtual time.  Before the fix this starved above the cliff. */
+    sim_run_until_idle(s, 3600000); /* up to 1 virtual hour */
+
+    sim_verdict_t floor_v =
+        sim_prop_mode_floor_reached(sim_a(s), FREEDV_MODE_DATAC15, 0);
+    TEST_ASSERT_TRUE_MESSAGE(floor_v.ok, floor_v.detail);
+
+    sim_verdict_t v = sim_prop_integrity(s, sim_a(s), sim_b(s), blob, sizeof(blob));
+    TEST_ASSERT_TRUE_MESSAGE(v.ok, v.detail);
+
+    sim_destroy(s);
 }
 
 /* ======================================================================
@@ -298,9 +341,9 @@ void test_sim_fuzz(void)
 {
     /* 50 deterministic seeds keep CI runtime under a few seconds.  Each
      * seed drives a different (per, guard_ms, transfer_size) combination.
-     * PER ceiling is 0.25 — below the S1 fade-cliff stall threshold — so
-     * the loop stays green on current HEAD.  Once S1 is fixed, raise to 0.40
-     * and un-ignore test_sim_fade_cliff_downgrades. */
+     * PER ceiling is 0.40 (raised from 0.25 with the S1 fade-cliff fix): the
+     * FSM must now push through erasure rates that used to stall it above the
+     * cliff, on any seed, always delivering every byte. */
     const int SEEDS = 50;
 
     for (int seed = 1; seed <= SEEDS; seed++)
@@ -329,9 +372,19 @@ void test_sim_fuzz(void)
         z ^= (z >> 31);
         double r2 = (double)(z >> 11) / (double)(1ULL << 53);
 
-        cfg.per      = r0 * 0.25;                         /* [0, 0.25) */
+        cfg.per      = r0 * 0.40;                         /* [0, 0.40) */
         cfg.guard_ms = 100 + (uint32_t)(r1 * 800.0);     /* [100, 900) ms */
         size_t xfer  = 100 + (size_t)(r2 * 1900.0);      /* [100, 2000) bytes */
+
+        /* Connect on a clean channel, then apply the seed's loss to the DATA
+         * transfer.  The fuzz loop stresses the data path — retransmission,
+         * mode adaptation, the S1 downgrade — across randomized loss; the
+         * CALL/ACCEPT handshake has its own (fixed-mode, separately tuned)
+         * reliability envelope and would otherwise simply fail to connect
+         * above ~0.3 erasure, masking the data-path coverage this test is
+         * for.  Connect-under-loss is exercised elsewhere. */
+        double xfer_per = cfg.per;
+        cfg.per = 0.0;
 
         sim_t *s = sim_create(&cfg, "A0AAA", "B0BBB");
         if (!s) {
@@ -344,9 +397,10 @@ void test_sim_fuzz(void)
         arq_event_t conn = { .id = ARQ_EV_APP_CONNECT };
         snprintf(conn.remote_call, CALLSIGN_MAX_SIZE, "%s", "B0BBB");
         sim_inject(s, sim_a(s), &conn);
+        sim_run_until_idle(s, 60000);           /* establish the link */
 
-        /* Queue transfer data before the connection is established so the
-         * caller starts sending immediately on RX_ACCEPT. */
+        sim_set_per(s, xfer_per);               /* loss hits the data phase */
+
         uint8_t *blob = malloc(xfer);
         if (!blob) { sim_destroy(s); continue; }
         for (size_t i = 0; i < xfer; i++) blob[i] = (uint8_t)((i + seed) & 0xFF);


### PR DESCRIPTION
bounded reverse-loss hold + mid-window downgrade

On a channel that fades below the active payload mode's cliff, transfers stalled instead of dropping to the DATAC15 floor. Root cause: the asymmetric-link reverse-loss hold in record_tx_outcome() was UNBOUNDED — while the SNR of the few surviving frames still looked adequate, every retry was attributed to reverse-path ACK loss, which froze OLLA and consecutive_retries so no downgrade path (not even the hard-loss floor) could ever fire.  A second lockout compounded it: the 'never change mode with an unACKed window' guard is permanent when the window can't drain because the mode can't deliver.

Fixes:
- Bound the reverse-loss hold to ARQ_REVERSE_HOLD_MAX (3) consecutive holds; a clean delivery re-arms it.  An isolated ACK-loss run stays protected (the bench-validated asymmetric-link case); a sustained fade breaks through to normal delivery feedback.
- Advance consecutive_retries per ACK timeout (the only failure evidence a fade produces — no ACK ever arrives to run record_tx_outcome), driving the hard-loss floor drop.  OLLA's tuned first-try-FER accounting is untouched.
- Let a bounded 'mode_probe' issue MODE_REQ with an unACKed window.  The MODE_ACK now carries the peer's rx_expected (ARQ_FLAG_CTRL_ACKSEQ): frames the peer already delivered are ACK-progressed, undelivered bytes are restaged (re-buffered in strict stream order) and re-framed at the new mode.
- arq_protocol_encode_snr: floorf() instead of truncation so negative SNRs round correctly (a -1 dB reading was flattered to 0 dB, right at the cliff).

Testing: two-FSM sim gains a mode-aware cliff channel model (sim_set_snr) and un-ignores test_sim_fade_cliff_downgrades (connect clean, fade below the cliff, assert descent to DATAC15 + full delivery); fuzz PER ceiling raised 0.25->0.40 (connect clean, loss on the data phase).  Full unit + integration suites pass. arq_test_stubs gains opt-in SIM_TRACE_LOGS for FSM log visibility under the sim.