### PR TITLE
arq: fix S4 CQ race — move pending_burst_frames to arq_session_t

### DIFF
--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -159,9 +159,13 @@ static void cb_send_tx_frame(int packet_type, int mode,
 {
     /* Frames of one PTT burst arrive as consecutive calls (FSM event loop
      * is single-threaded); the modem action is enqueued once, when the
-     * last frame (burst_remaining == 0) lands in the ring. */
-    static int pending_burst_frames = 0;
-
+     * last frame (burst_remaining == 0) lands in the ring.
+     *
+     * The counter lives in g_sess.pending_burst_frames rather than a
+     * function-static so that it is covered by g_sess_lock — both this
+     * call path (event loop, already under g_sess_lock) and the cmd-bridge
+     * SEND_CQ path (which now holds g_sess_lock across this call) share the
+     * same lock, preventing a burst-drop race. */
     if (!frame || frame_size == 0 || frame_size > INT_BUFFER_SIZE)
         return;
 
@@ -176,13 +180,13 @@ static void cb_send_tx_frame(int packet_type, int mode,
     }
     else
     {
-        pending_burst_frames++;
+        g_sess.pending_burst_frames++;
     }
 
     if (burst_remaining > 0)
         return;  /* more frames of this burst follow */
 
-    if (pending_burst_frames == 0)
+    if (g_sess.pending_burst_frames == 0)
         return;  /* every write failed — nothing to transmit */
 
     arq_action_t action = {
@@ -190,9 +194,9 @@ static void cb_send_tx_frame(int packet_type, int mode,
                        ? ARQ_ACTION_TX_PAYLOAD : ARQ_ACTION_TX_CONTROL,
         .mode        = mode,
         .frame_size  = frame_size,
-        .frame_count = pending_burst_frames,
+        .frame_count = g_sess.pending_burst_frames,
     };
-    pending_burst_frames = 0;
+    g_sess.pending_burst_frames = 0;
     arq_modem_enqueue(&action);
 }
 
@@ -432,8 +436,10 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
 
         pthread_mutex_lock(&g_sess_lock);
         int cq_mode = g_sess.control_mode;
-        pthread_mutex_unlock(&g_sess_lock);
+        /* Hold g_sess_lock across the call so that g_sess.pending_burst_frames
+         * is protected — the event loop also holds this lock during dispatch. */
         cb_send_tx_frame(PACKET_TYPE_ARQ_CQ, cq_mode, (size_t)n, frame, 0);
+        pthread_mutex_unlock(&g_sess_lock);
         HLOGI(LOG_COMP, "Queued CQ frame from %s (%d Hz)", source_call, bw_hz);
         return;
     }

--- a/datalink_arq/arq_fsm.h
+++ b/datalink_arq/arq_fsm.h
@@ -204,6 +204,11 @@ typedef struct
 
     /* --- Data bookkeeping --- */
     int      tx_backlog_bytes;         /* bytes pending in TX buffer           */
+    int      pending_burst_frames;     /* frames accumulated for current PTT burst;
+                                        * written by cb_send_tx_frame under g_sess_lock
+                                        * (replaces the former function-static so that
+                                        * the cmd-bridge SEND_CQ path and the FSM event
+                                        * loop do not race on a shared static) */
 
     /* --- Connection lifecycle --- */
     bool     listen_enabled;           /* app listen intent (LISTEN ON/OFF):


### PR DESCRIPTION
Fixes the data race reported in issue #105.

`cb_send_tx_frame` used a function-scoped `static int pending_burst_frames` shared between two threads with no synchronization:
- event loop (`g_loop_tid`) via `arq_fsm_dispatch → g_cbs.send_tx_frame`
- cmd-bridge (`g_cmd_tid`) via `handle_cmd(ARQ_CMD_SEND_CQ)` directly

The SEND_CQ path zeroed the static mid-burst, causing the event loop's final frame call to see `frame_count=0`, hit the zero-guard, and silently drop the burst action. No crash — just missing frames in the TX ring and ring desync until restart.

**Fix:**

1. Move `pending_burst_frames` into `arq_session_t`. It is per-session state; the static was a convenience. Initialization is free — `arq_fsm_init` opens with `memset(sess, 0, ...)`.

2. In `handle_cmd` SEND_CQ: move `pthread_mutex_unlock(&g_sess_lock)` to after the `cb_send_tx_frame` call. The event loop already holds `g_sess_lock` across `arq_fsm_dispatch` (verified at arq.c:546–558); the cmd-bridge now matches, making the two paths mutually exclusive on `g_sess.pending_burst_frames`.

The lock extension is safe: `write_buffer` can block if the ring fills, but the modem drains `data_tx_buffer_arq` using only the ring's internal mutex — no `g_sess_lock` — so no deadlock is possible. This is identical behavior to the event-loop path, which already held `g_sess_lock` across the same write.

Narrow window at K=1 today; widens substantially at K>1 bursts.