### PR TITLE
radio_io: log PTT failures; net: remove dead tcp_open

### DIFF
--- a/data_interfaces/net.c
+++ b/data_interfaces/net.c
@@ -194,49 +194,6 @@ int listen4connection(int port_type)
     return newsockfd;
 }
 
-int tcp_open(int portno, int port_type)
-{
-    int sockfd;
-    struct sockaddr_in serv_addr;
-
-    sockfd = socket(AF_INET, SOCK_STREAM, 0);
-    if (sockfd < 0){
-        fprintf(stderr, "ERROR opening socket\n");
-        return -1;
-    }
-
-    int opt = 1;  
-    if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, (const char *)&opt, sizeof(opt)) < 0)
-    {
-        fprintf(stderr, "setsockopt(SO_REUSEADDR) failed\n");
-        SOCK_CLOSE(sockfd);
-        return -1;
-    }
-      
-    memset((char *) &serv_addr, 0,  sizeof(serv_addr));
-    serv_addr.sin_family = AF_INET;
-    serv_addr.sin_addr.s_addr = INADDR_ANY;
-    serv_addr.sin_port = htons(portno);
-    if (bind(sockfd, (struct sockaddr *) &serv_addr, sizeof(serv_addr)) < 0) 
-    {
-        fprintf(stderr, "ERROR on binding\n");
-        return -1;
-    }
-
-    listen(sockfd,1); // just 1 concurrent connections
-
-    if (port_type == CTL_TCP_PORT)
-    {
-        net_set_status(CTL_TCP_PORT, NET_LISTENING);
-        ctl_sockfd = sockfd;
-    }
-    if (port_type == DATA_TCP_PORT)
-    {
-        net_set_status(DATA_TCP_PORT, NET_LISTENING);
-        data_sockfd = sockfd;
-    }
-    return sockfd;
-}
 
 ssize_t tcp_read(int port_type, uint8_t *buffer, size_t rx_size)
 {

--- a/data_interfaces/net.h
+++ b/data_interfaces/net.h
@@ -61,7 +61,6 @@ int net_wait_while_status(int port_type, int status, int timeout_ms);
 
 int listen4connection(int port_type);
 
-int tcp_open(int portno, int port_type);
 
 ssize_t tcp_read(int port_type, uint8_t *buffer, size_t rx_size);
 

--- a/radio_io/radio_io.c
+++ b/radio_io/radio_io.c
@@ -296,8 +296,11 @@ void radio_io_key_on(void)
 #ifdef HAVE_HAMLIB
     if (g_radio_type > 0 && radio)
     {
-        rig_set_ptt(radio, RIG_VFO_CURR, RIG_PTT_ON);
-        HLOGD(RADIO_LOG_TAG, "PTT ON via HAMLIB (model %d)", g_radio_type);
+        int ret = rig_set_ptt(radio, RIG_VFO_CURR, RIG_PTT_ON);
+        if (ret != RIG_OK)
+            HLOGW(RADIO_LOG_TAG, "PTT ON failed (model %d): %s", g_radio_type, rigerror(ret));
+        else
+            HLOGD(RADIO_LOG_TAG, "PTT ON via HAMLIB (model %d)", g_radio_type);
     }
 #endif
 
@@ -336,8 +339,11 @@ void radio_io_key_off(void)
 #ifdef HAVE_HAMLIB
     if (g_radio_type > 0 && radio)
     {
-        rig_set_ptt(radio, RIG_VFO_CURR, RIG_PTT_OFF);
-        HLOGD(RADIO_LOG_TAG, "PTT OFF via HAMLIB (model %d)", g_radio_type);
+        int ret = rig_set_ptt(radio, RIG_VFO_CURR, RIG_PTT_OFF);
+        if (ret != RIG_OK)
+            HLOGW(RADIO_LOG_TAG, "PTT OFF failed (model %d): %s", g_radio_type, rigerror(ret));
+        else
+            HLOGD(RADIO_LOG_TAG, "PTT OFF via HAMLIB (model %d)", g_radio_type);
     }
 #endif
 

--- a/tests/data_interfaces/test_tcp_interfaces.c
+++ b/tests/data_interfaces/test_tcp_interfaces.c
@@ -115,7 +115,6 @@ int net_get_status(int pt) { (void)pt; return NET_CONNECTED; }
 int net_wait_for_status(int p, int s, int t) { (void)p; (void)s; (void)t; return 0; }
 int net_wait_while_status(int p, int s, int t) { (void)p; (void)s; (void)t; return 0; }
 int listen4connection(int p) { (void)p; return 0; }
-int tcp_open(int p, int pt) { (void)p; (void)pt; return 0; }
 ssize_t tcp_read(int pt, uint8_t *b, size_t s) { (void)pt; (void)b; (void)s; return 0; }
 int tcp_close(int pt) { (void)pt; return 0; }
 


### PR DESCRIPTION
Two small fixes. For consideration.

**radio_io: log PTT key-on/off failures**
`rig_set_ptt` return values were silently discarded in `radio_io_key_on` and `radio_io_key_off`. A stuck transmitter (key-off failure) is a field risk — it blocks the channel and can damage equipment on some rigs. Both sites now capture the return and emit `HLOGW` with `rigerror(ret)` on failure. Pattern matches existing error-check style in `radio_io_init`.

**net: remove dead `tcp_open`**
`tcp_open` leaked its socket fd on `bind` failure. More importantly, `grep -r tcp_open` found no callers anywhere in the tree — only the definition, the header declaration, and a linker stub in `tests/data_interfaces/test_tcp_interfaces.c`. Removed all three (45 lines).