### PR TITLE
arq: make ARQ timing constants INI-tunable

### DIFF
--- a/common/cfg_utils.c
+++ b/common/cfg_utils.c
@@ -54,6 +54,14 @@ void cfg_set_defaults(mercury_config *cfg)
     cfg->tnc_keepalive_s = 60;
     cfg->tnc_buffer_report_ms = 1000;
     cfg->tx_gain_db            = 0.0f;
+    cfg->data_retry_slots            = ARQ_DATA_RETRY_SLOTS_DEFAULT;
+    cfg->mode_hold_after_downgrade_s = ARQ_MODE_HOLD_AFTER_DOWNGRADE_S_DEFAULT;
+    cfg->ladder_up_successes         = ARQ_LADDER_UP_SUCCESSES_DEFAULT;
+    cfg->retry_downgrade_threshold   = ARQ_RETRY_DOWNGRADE_THRESHOLD_DEFAULT;
+    cfg->channel_guard_ms            = ARQ_CHANNEL_GUARD_MS_DEFAULT;
+    cfg->iss_post_ack_guard_ms       = ARQ_ISS_POST_ACK_GUARD_MS_DEFAULT;
+    cfg->keepalive_interval_s        = ARQ_KEEPALIVE_INTERVAL_S_DEFAULT;
+    cfg->keepalive_miss_limit        = ARQ_KEEPALIVE_MISS_LIMIT_DEFAULT;
 }
 
 /* Map a sound-system name to the AUDIO_SUBSYSTEM_* constant.
@@ -176,6 +184,30 @@ bool cfg_read(mercury_config *cfg, const char *ini_path)
     if (i >= 100 && i <= 10000)
         cfg->tnc_buffer_report_ms = i;
 
+    i = iniparser_getint(ini, CFG_KEY_ARQ_DATA_RETRY_SLOTS, cfg->data_retry_slots);
+    if (i >= 1 && i <= 64)   cfg->data_retry_slots = i;
+
+    i = iniparser_getint(ini, CFG_KEY_ARQ_MODE_HOLD_DOWNGRADE_S, cfg->mode_hold_after_downgrade_s);
+    if (i >= 0 && i <= 60)   cfg->mode_hold_after_downgrade_s = i;
+
+    i = iniparser_getint(ini, CFG_KEY_ARQ_LADDER_UP_SUCCESSES, cfg->ladder_up_successes);
+    if (i >= 1 && i <= 16)   cfg->ladder_up_successes = i;
+
+    i = iniparser_getint(ini, CFG_KEY_ARQ_RETRY_DOWNGRADE_THRESHOLD, cfg->retry_downgrade_threshold);
+    if (i >= 1 && i <= 16)   cfg->retry_downgrade_threshold = i;
+
+    i = iniparser_getint(ini, CFG_KEY_ARQ_CHANNEL_GUARD_MS, cfg->channel_guard_ms);
+    if (i >= 200 && i <= 3000) cfg->channel_guard_ms = i;
+
+    i = iniparser_getint(ini, CFG_KEY_ARQ_ISS_POST_ACK_GUARD_MS, cfg->iss_post_ack_guard_ms);
+    if (i >= 200 && i <= 3000) cfg->iss_post_ack_guard_ms = i;
+
+    i = iniparser_getint(ini, CFG_KEY_ARQ_KEEPALIVE_INTERVAL_S, cfg->keepalive_interval_s);
+    if (i >= 5 && i <= 120)  cfg->keepalive_interval_s = i;
+
+    i = iniparser_getint(ini, CFG_KEY_ARQ_KEEPALIVE_MISS_LIMIT, cfg->keepalive_miss_limit);
+    if (i >= 2 && i <= 20)   cfg->keepalive_miss_limit = i;
+
     double d = iniparser_getdouble(ini, CFG_KEY_TX_GAIN_DB, (double)cfg->tx_gain_db);
     if (!isfinite(d)) d = 0.0;  /* malformed/non-finite INI value -> default */
     if (d < -20.0) d = -20.0;
@@ -266,6 +298,14 @@ bool cfg_write(const mercury_config *cfg, const char *ini_path)
     fprintf(f, "\n[arq]\n");
     fprintf(f, "no_progress_timeout_s = %d\n", cfg->no_progress_timeout_s);
     fprintf(f, "disconnect_drain_timeout_s = %d\n", cfg->disconnect_drain_timeout_s);
+    fprintf(f, "data_retry_slots = %d\n", cfg->data_retry_slots);
+    fprintf(f, "mode_hold_after_downgrade_s = %d\n", cfg->mode_hold_after_downgrade_s);
+    fprintf(f, "ladder_up_successes = %d\n", cfg->ladder_up_successes);
+    fprintf(f, "retry_downgrade_threshold = %d\n", cfg->retry_downgrade_threshold);
+    fprintf(f, "channel_guard_ms = %d\n", cfg->channel_guard_ms);
+    fprintf(f, "iss_post_ack_guard_ms = %d\n", cfg->iss_post_ack_guard_ms);
+    fprintf(f, "keepalive_interval_s = %d\n", cfg->keepalive_interval_s);
+    fprintf(f, "keepalive_miss_limit = %d\n", cfg->keepalive_miss_limit);
 
     fprintf(f, "\n[audio]\n");
     fprintf(f, "tx_gain_db = %.2f\n", cfg->tx_gain_db);

--- a/common/cfg_utils.h
+++ b/common/cfg_utils.h
@@ -46,6 +46,14 @@
 #define CFG_KEY_TX_GAIN_DB          "audio:tx_gain_db"
 #define CFG_KEY_TNC_KEEPALIVE_S     "tnc:keepalive_s"
 #define CFG_KEY_TNC_BUFFER_REPORT_MS "tnc:buffer_report_ms"
+#define CFG_KEY_ARQ_DATA_RETRY_SLOTS          "arq:data_retry_slots"
+#define CFG_KEY_ARQ_MODE_HOLD_DOWNGRADE_S     "arq:mode_hold_after_downgrade_s"
+#define CFG_KEY_ARQ_LADDER_UP_SUCCESSES       "arq:ladder_up_successes"
+#define CFG_KEY_ARQ_RETRY_DOWNGRADE_THRESHOLD "arq:retry_downgrade_threshold"
+#define CFG_KEY_ARQ_CHANNEL_GUARD_MS          "arq:channel_guard_ms"
+#define CFG_KEY_ARQ_ISS_POST_ACK_GUARD_MS     "arq:iss_post_ack_guard_ms"
+#define CFG_KEY_ARQ_KEEPALIVE_INTERVAL_S      "arq:keepalive_interval_s"
+#define CFG_KEY_ARQ_KEEPALIVE_MISS_LIMIT      "arq:keepalive_miss_limit"
 
 /* Holds all values read from the init configuration file */
 typedef struct {
@@ -71,6 +79,22 @@ typedef struct {
     int      disconnect_drain_timeout_s;/* ARQ: absolute cap (s) on how long an
                                     * app DISCONNECT stays deferred while
                                     * draining the last TX bytes. Default 30. */
+    int      data_retry_slots;          /* ARQ: DATA retries before a downgrade
+                                         * cycle. Default 10, clamped 1..64.   */
+    int      mode_hold_after_downgrade_s;/* ARQ: hold lower mode after a forced
+                                         * downgrade. Default 6, clamped 0..60. */
+    int      ladder_up_successes;       /* ARQ: clean ACKs to step the mode
+                                         * ladder up. Default 2, clamped 1..16. */
+    int      retry_downgrade_threshold; /* ARQ: consecutive retries that force a
+                                         * downgrade. Default 2, clamped 1..16. */
+    int      channel_guard_ms;          /* ARQ: IRS response guard after decode.
+                                         * Default 700, clamped 200..3000.      */
+    int      iss_post_ack_guard_ms;     /* ARQ: ISS guard before resuming DATA
+                                         * TX after ACK. Default 900, 200..3000.*/
+    int      keepalive_interval_s;      /* ARQ: keepalive TX interval. Default
+                                         * 20, clamped 5..120.                  */
+    int      keepalive_miss_limit;      /* ARQ: missed keepalives before drop.
+                                         * Default 5, clamped 2..20.            */
     float    tx_gain_db;            /* Linear-equivalent gain on the modulator
                                     * TX samples, in dB. 0.0 = no change.
                                     * Range -20.0 .. +20.0 (clamped). */

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -1025,6 +1025,62 @@ void arq_set_retry_slots(int slots)
           atomic_load(&arq_data_retry_slots), atomic_load(&arq_disconnect_retry_slots));
 }
 
+void arq_set_channel_guard_ms(int ms)
+{
+    if (ms < 200)  ms = (ms <= 0) ? ARQ_CHANNEL_GUARD_MS_DEFAULT : 200;
+    if (ms > 3000) ms = 3000;
+    atomic_store(&arq_channel_guard_ms, ms);
+    HLOGI(LOG_COMP, "channel_guard_ms = %d", atomic_load(&arq_channel_guard_ms));
+}
+
+void arq_set_iss_post_ack_guard_ms(int ms)
+{
+    if (ms < 200)  ms = (ms <= 0) ? ARQ_ISS_POST_ACK_GUARD_MS_DEFAULT : 200;
+    if (ms > 3000) ms = 3000;
+    atomic_store(&arq_iss_post_ack_guard_ms, ms);
+    HLOGI(LOG_COMP, "iss_post_ack_guard_ms = %d", atomic_load(&arq_iss_post_ack_guard_ms));
+}
+
+void arq_set_keepalive_interval_s(int s)
+{
+    if (s < 5)   s = (s <= 0) ? ARQ_KEEPALIVE_INTERVAL_S_DEFAULT : 5;
+    if (s > 120) s = 120;
+    atomic_store(&arq_keepalive_interval_s, s);
+    HLOGI(LOG_COMP, "keepalive_interval_s = %d", atomic_load(&arq_keepalive_interval_s));
+}
+
+void arq_set_keepalive_miss_limit(int n)
+{
+    if (n < 2)  n = (n <= 0) ? ARQ_KEEPALIVE_MISS_LIMIT_DEFAULT : 2;
+    if (n > 20) n = 20;
+    atomic_store(&arq_keepalive_miss_limit, n);
+    HLOGI(LOG_COMP, "keepalive_miss_limit = %d", atomic_load(&arq_keepalive_miss_limit));
+}
+
+void arq_set_ladder_up_successes(int n)
+{
+    if (n < 1)  n = (n <= 0) ? ARQ_LADDER_UP_SUCCESSES_DEFAULT : 1;
+    if (n > 16) n = 16;
+    atomic_store(&arq_ladder_up_successes, n);
+    HLOGI(LOG_COMP, "ladder_up_successes = %d", atomic_load(&arq_ladder_up_successes));
+}
+
+void arq_set_retry_downgrade_threshold(int n)
+{
+    if (n < 1)  n = (n <= 0) ? ARQ_RETRY_DOWNGRADE_THRESHOLD_DEFAULT : 1;
+    if (n > 16) n = 16;
+    atomic_store(&arq_retry_downgrade_threshold, n);
+    HLOGI(LOG_COMP, "retry_downgrade_threshold = %d", atomic_load(&arq_retry_downgrade_threshold));
+}
+
+void arq_set_mode_hold_after_downgrade_s(int s)
+{
+    if (s < 0)  s = ARQ_MODE_HOLD_AFTER_DOWNGRADE_S_DEFAULT;
+    if (s > 60) s = 60;
+    atomic_store(&arq_mode_hold_after_downgrade_s, s);
+    HLOGI(LOG_COMP, "mode_hold_after_downgrade_s = %d", atomic_load(&arq_mode_hold_after_downgrade_s));
+}
+
 void reset_arq_info(arq_info *conn)
 {
     if (!conn) return;

--- a/datalink_arq/arq.h
+++ b/datalink_arq/arq.h
@@ -318,6 +318,15 @@ void reset_arq_info(arq_info *arq_conn);
  */
 void arq_set_retry_slots(int slots);
 
+/* Setters for the newly-atomic ARQ timing/ladder tunables. */
+void arq_set_channel_guard_ms(int ms);
+void arq_set_iss_post_ack_guard_ms(int ms);
+void arq_set_keepalive_interval_s(int s);
+void arq_set_keepalive_miss_limit(int n);
+void arq_set_ladder_up_successes(int n);
+void arq_set_retry_downgrade_threshold(int n);
+void arq_set_mode_hold_after_downgrade_s(int s);
+
 /**
  * @brief Trigger outgoing call attempt using current ARQ addresses.
  */

--- a/datalink_arq/arq_protocol.c
+++ b/datalink_arq/arq_protocol.c
@@ -20,6 +20,15 @@ _Atomic int arq_disconnect_retry_slots = ARQ_DISCONNECT_RETRY_SLOTS_DEFAULT;
 _Atomic int arq_no_progress_timeout_s  = ARQ_NO_PROGRESS_TIMEOUT_S_DEFAULT;
 _Atomic int arq_disconnect_drain_timeout_s = ARQ_DISCONNECT_DRAIN_TIMEOUT_S_DEFAULT;
 
+/* Runtime-configurable guard/keepalive/ladder constants */
+_Atomic int arq_channel_guard_ms            = ARQ_CHANNEL_GUARD_MS_DEFAULT;
+_Atomic int arq_iss_post_ack_guard_ms       = ARQ_ISS_POST_ACK_GUARD_MS_DEFAULT;
+_Atomic int arq_keepalive_interval_s        = ARQ_KEEPALIVE_INTERVAL_S_DEFAULT;
+_Atomic int arq_keepalive_miss_limit        = ARQ_KEEPALIVE_MISS_LIMIT_DEFAULT;
+_Atomic int arq_ladder_up_successes         = ARQ_LADDER_UP_SUCCESSES_DEFAULT;
+_Atomic int arq_retry_downgrade_threshold   = ARQ_RETRY_DOWNGRADE_THRESHOLD_DEFAULT;
+_Atomic int arq_mode_hold_after_downgrade_s = ARQ_MODE_HOLD_AFTER_DOWNGRADE_S_DEFAULT;
+
 /* Include FreeDV mode constants */
 #include "../modem/freedv/freedv_api.h"
 

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -190,24 +190,29 @@ typedef struct
 #define ARQ_CONTROL_MODE  FREEDV_MODE_DATAC16
 
 /* Timing constants shared across modules */
-#define ARQ_CHANNEL_GUARD_MS          700   /* IRS response guard after frame decode.
-                                            * OFDM decode fires ~200ms before sender
-                                            * PTT-OFF, so effective gap at sender is
-                                            * (guard - 200ms) ≈ 500ms.  Radio needs
-                                            * ~340ms for TX→RX switch → 160ms margin
-                                            * for preamble detection.  At 500ms the
-                                            * effective gap was ~300ms, causing ~50%
-                                            * ACK loss on DATAC1 (< 340ms switch).  */
-#define ARQ_ISS_POST_ACK_GUARD_MS     900   /* ISS guard before resuming DATA TX
-                                            * after receiving an ACK from the IRS.
-                                            * Larger than ARQ_CHANNEL_GUARD_MS:
-                                            * ack_rx fires ~168ms before IRS PTT-OFF,
-                                            * so the effective gap at IRS is only
-                                            * (guard + 100ms head) - 168ms.
-                                            * At 500ms: gap=432ms, too tight for
-                                            * DATAC1 re-sync after IRS ACK TX.
-                                            * At 900ms: gap=832ms — 492ms of clear
-                                            * air before the DATAC1 preamble. */
+#define ARQ_CHANNEL_GUARD_MS_DEFAULT      700   /* IRS response guard after frame decode.
+                                                * OFDM decode fires ~200ms before sender
+                                                * PTT-OFF, so effective gap at sender is
+                                                * (guard - 200ms) ~= 500ms.  Radio needs
+                                                * ~340ms for TX->RX switch -> 160ms margin
+                                                * for preamble detection.  At 500ms the
+                                                * effective gap was ~300ms, causing ~50%
+                                                * ACK loss on DATAC1 (< 340ms switch).  */
+extern _Atomic int arq_channel_guard_ms;
+#define ARQ_CHANNEL_GUARD_MS  atomic_load(&arq_channel_guard_ms)
+
+#define ARQ_ISS_POST_ACK_GUARD_MS_DEFAULT 900   /* ISS guard before resuming DATA TX
+                                                * after receiving an ACK from the IRS.
+                                                * Larger than ARQ_CHANNEL_GUARD_MS:
+                                                * ack_rx fires ~168ms before IRS PTT-OFF,
+                                                * so the effective gap at IRS is only
+                                                * (guard + 100ms head) - 168ms.
+                                                * At 500ms: gap=432ms, too tight for
+                                                * DATAC1 re-sync after IRS ACK TX.
+                                                * At 900ms: gap=832ms -- 492ms of clear
+                                                * air before the DATAC1 preamble. */
+extern _Atomic int arq_iss_post_ack_guard_ms;
+#define ARQ_ISS_POST_ACK_GUARD_MS  atomic_load(&arq_iss_post_ack_guard_ms)
 #define ARQ_TURN_WAIT_AFTER_ACK_MS   5000  /* IRS post-ACK wait before TURN_REQ:
                                             * ISS guard(900ms)+frame(3740ms)+margin */
 #define ARQ_ACCEPT_RX_WINDOW_MS      9000  /* ACCEPTING RX window after ACCEPT TX:
@@ -242,8 +247,13 @@ extern _Atomic float arq_callint_override_s;
 #define ARQ_DISCONNECT_RETRY_SLOTS atomic_load(&arq_disconnect_retry_slots)
 #define ARQ_CONNECT_GRACE_SLOTS       2     /* extra wait slots for ACCEPT         */
 #define ARQ_CONNECT_BUSY_EXT_S        2     /* busy-extension guard after CALL     */
-#define ARQ_KEEPALIVE_INTERVAL_S      20    /* keepalive TX interval               */
-#define ARQ_KEEPALIVE_MISS_LIMIT      5     /* missed keepalives before disconnect */
+#define ARQ_KEEPALIVE_INTERVAL_S_DEFAULT  20    /* keepalive TX interval               */
+extern _Atomic int arq_keepalive_interval_s;
+#define ARQ_KEEPALIVE_INTERVAL_S  atomic_load(&arq_keepalive_interval_s)
+
+#define ARQ_KEEPALIVE_MISS_LIMIT_DEFAULT  5     /* missed keepalives before disconnect */
+extern _Atomic int arq_keepalive_miss_limit;
+#define ARQ_KEEPALIVE_MISS_LIMIT  atomic_load(&arq_keepalive_miss_limit)
 #define ARQ_TURN_REQ_RETRIES          2
 #define ARQ_MODE_REQ_RETRIES          2
 #define ARQ_PEER_PAYLOAD_HOLD_S       15    /* hold peer payload mode after activity */
@@ -281,9 +291,17 @@ extern _Atomic float arq_callint_override_s;
 #define ARQ_BACKLOG_MIN_QAM16C2       1173  /* > DATAC17 usable payload      */
 #define ARQ_LADDER_LEVELS             6     /* 0=DATAC15, 1=DATAC4, 2=DATAC3,
                                              * 3=DATAC1, 4=DATAC17, 5=QAM16C2 */
-#define ARQ_LADDER_UP_SUCCESSES       2     /* clean ACKs required to step up    */
-#define ARQ_RETRY_DOWNGRADE_THRESHOLD 2     /* consecutive retries to force downgrade */
-#define ARQ_MODE_HOLD_AFTER_DOWNGRADE_S 6   /* hold lower mode after forced downgrade */
+#define ARQ_LADDER_UP_SUCCESSES_DEFAULT        2     /* clean ACKs required to step up    */
+extern _Atomic int arq_ladder_up_successes;
+#define ARQ_LADDER_UP_SUCCESSES  atomic_load(&arq_ladder_up_successes)
+
+#define ARQ_RETRY_DOWNGRADE_THRESHOLD_DEFAULT  2     /* consecutive retries to force downgrade */
+extern _Atomic int arq_retry_downgrade_threshold;
+#define ARQ_RETRY_DOWNGRADE_THRESHOLD  atomic_load(&arq_retry_downgrade_threshold)
+
+#define ARQ_MODE_HOLD_AFTER_DOWNGRADE_S_DEFAULT 6   /* hold lower mode after forced downgrade */
+extern _Atomic int arq_mode_hold_after_downgrade_s;
+#define ARQ_MODE_HOLD_AFTER_DOWNGRADE_S  atomic_load(&arq_mode_hold_after_downgrade_s)
 /* Hard total-link-loss net: OLLA's offset handles normal per-fade dips (the old
  * 2-retry forced downgrade fought OLLA and oscillated badly at low SNR — see
  * test_olla_low_snr_no_collapse).  Only a long unbroken fail run drops straight

--- a/main.c
+++ b/main.c
@@ -238,6 +238,14 @@ int main(int argc, char *argv[])
             radio_serial_speed = mcfg.radio_serial_speed;
             arq_set_no_progress_timeout_s(mcfg.no_progress_timeout_s);
             arq_set_disconnect_drain_timeout_s(mcfg.disconnect_drain_timeout_s);
+            arq_set_retry_slots(mcfg.data_retry_slots);
+            arq_set_mode_hold_after_downgrade_s(mcfg.mode_hold_after_downgrade_s);
+            arq_set_ladder_up_successes(mcfg.ladder_up_successes);
+            arq_set_retry_downgrade_threshold(mcfg.retry_downgrade_threshold);
+            arq_set_channel_guard_ms(mcfg.channel_guard_ms);
+            arq_set_iss_post_ack_guard_ms(mcfg.iss_post_ack_guard_ms);
+            arq_set_keepalive_interval_s(mcfg.keepalive_interval_s);
+            arq_set_keepalive_miss_limit(mcfg.keepalive_miss_limit);
             modem_set_tx_gain(powf(10.0f, mcfg.tx_gain_db / 20.0f));
         }
     }

--- a/mercury.ini.example
+++ b/mercury.ini.example
@@ -104,6 +104,32 @@ no_progress_timeout_s = 180
 ; the drain finishes in seconds, so this only bites on a stuck session.
 disconnect_drain_timeout_s = 30
 
+; Number of DATA-frame retries before a downgrade cycle (default 10, range 1..64).
+; Behaves like the RETRIES TNC command: also caps CALL/ACCEPT retries.
+data_retry_slots = 10
+
+; Seconds to hold the lower mode after a forced downgrade (default 6, range 0..60).
+mode_hold_after_downgrade_s = 6
+
+; Clean ACKs required to step the speed ladder up one level (default 2, range 1..16).
+ladder_up_successes = 2
+
+; Consecutive retries that force a one-step downgrade (default 2, range 1..16).
+retry_downgrade_threshold = 2
+
+; IRS response guard after decoding a frame, in ms (default 700, range 200..3000).
+; Raise if your radio's TX-to-RX switch is slow and you lose ACKs.
+channel_guard_ms = 700
+
+; ISS guard before resuming DATA TX after an ACK, in ms (default 900, range 200..3000).
+iss_post_ack_guard_ms = 900
+
+; Keepalive transmit interval in seconds (default 20, range 5..120).
+keepalive_interval_s = 20
+
+; Missed keepalives before the link is dropped (default 5, range 2..20).
+keepalive_miss_limit = 5
+
 [tnc]
 ; IAMALIVE interval on the TNC control port, seconds (5..600).
 ;keepalive_s = 60

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -43,7 +43,7 @@ ARQ_STUBS = datalink_arq/arq_test_stubs.c
 
 # Test executables
 TEST_BINS = test_ring_buffer test_arq_protocol test_arq_timing test_arq_fsm \
-            test_tcp_interfaces test_resampler test_arq_olla
+            test_tcp_interfaces test_resampler test_arq_olla test_cfg_utils
 
 .PHONY: all test clean
 
@@ -94,6 +94,11 @@ test_arq_fsm: datalink_arq/test_arq_fsm.c $(UNITY_SRC) $(ARQ_STUBS) \
 # Uses #include "tcp_interfaces.c" — framer.c provides write_frame_header
 test_tcp_interfaces: data_interfaces/test_tcp_interfaces.c $(UNITY_SRC) ../modem/framer.c
 	$(CC) $(CFLAGS) -I../modem/freedv -o $@ $^ $(LDFLAGS)
+
+test_cfg_utils: common/test_cfg_utils.c $(UNITY_SRC) \
+                ../common/cfg_utils.c \
+                ../common/iniparser/iniparser.c ../common/iniparser/dictionary.c
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 clean:
 	rm -f $(TEST_BINS)

--- a/tests/common/test_cfg_utils.c
+++ b/tests/common/test_cfg_utils.c
@@ -1,0 +1,98 @@
+/* HERMES Modem - Mercury Configuration Utilities
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * Author: Pedro Messetti <pedromessetti.rhizomatica@gmail.com>
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "unity.h"
+#include "cfg_utils.h"
+
+static const char *TMP = "test_cfg_roundtrip.ini";
+
+void setUp(void)   { }
+void tearDown(void){ unlink(TMP); }
+
+/* Defaults must equal the historical compile-time constants. */
+void test_defaults_match_constants(void)
+{
+    mercury_config c;
+    cfg_set_defaults(&c);
+    TEST_ASSERT_EQUAL_INT(10,  c.data_retry_slots);
+    TEST_ASSERT_EQUAL_INT(6,   c.mode_hold_after_downgrade_s);
+    TEST_ASSERT_EQUAL_INT(2,   c.ladder_up_successes);
+    TEST_ASSERT_EQUAL_INT(2,   c.retry_downgrade_threshold);
+    TEST_ASSERT_EQUAL_INT(700, c.channel_guard_ms);
+    TEST_ASSERT_EQUAL_INT(900, c.iss_post_ack_guard_ms);
+    TEST_ASSERT_EQUAL_INT(20,  c.keepalive_interval_s);
+    TEST_ASSERT_EQUAL_INT(5,   c.keepalive_miss_limit);
+}
+
+/* Set non-default values, write, read back, assert preserved. */
+void test_arq_tunables_roundtrip(void)
+{
+    mercury_config w;
+    cfg_set_defaults(&w);
+    w.data_retry_slots            = 14;
+    w.mode_hold_after_downgrade_s = 3;
+    w.ladder_up_successes         = 4;
+    w.retry_downgrade_threshold   = 3;
+    w.channel_guard_ms            = 800;
+    w.iss_post_ack_guard_ms       = 1000;
+    w.keepalive_interval_s        = 30;
+    w.keepalive_miss_limit        = 8;
+    TEST_ASSERT_TRUE(cfg_write(&w, TMP));
+
+    mercury_config r;
+    cfg_set_defaults(&r);
+    TEST_ASSERT_TRUE(cfg_read(&r, TMP));
+    TEST_ASSERT_EQUAL_INT(14,   r.data_retry_slots);
+    TEST_ASSERT_EQUAL_INT(3,    r.mode_hold_after_downgrade_s);
+    TEST_ASSERT_EQUAL_INT(4,    r.ladder_up_successes);
+    TEST_ASSERT_EQUAL_INT(3,    r.retry_downgrade_threshold);
+    TEST_ASSERT_EQUAL_INT(800,  r.channel_guard_ms);
+    TEST_ASSERT_EQUAL_INT(1000, r.iss_post_ack_guard_ms);
+    TEST_ASSERT_EQUAL_INT(30,   r.keepalive_interval_s);
+    TEST_ASSERT_EQUAL_INT(8,    r.keepalive_miss_limit);
+}
+
+/* Out-of-range INI values are rejected (field keeps its pre-read default). */
+void test_arq_tunables_clamp_rejects_garbage(void)
+{
+    FILE *f = fopen(TMP, "w");
+    TEST_ASSERT_NOT_NULL(f);
+    fputs("[arq]\nchannel_guard_ms = 999999\nkeepalive_miss_limit = 0\n", f);
+    fclose(f);
+
+    mercury_config r;
+    cfg_set_defaults(&r);
+    TEST_ASSERT_TRUE(cfg_read(&r, TMP));
+    TEST_ASSERT_EQUAL_INT(700, r.channel_guard_ms);   /* out of 200..3000 -> default kept */
+    TEST_ASSERT_EQUAL_INT(5,   r.keepalive_miss_limit);/* out of 2..20   -> default kept  */
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_defaults_match_constants);
+    RUN_TEST(test_arq_tunables_roundtrip);
+    RUN_TEST(test_arq_tunables_clamp_rejects_garbage);
+    return UNITY_END();
+}


### PR DESCRIPTION
Eight ARQ timing constants are currently hardcoded `#define`s. Operators running Mercury over unusual paths (long-distance HF, aircraft, marginal propagation) cannot tune them without recompiling. This makes them `_Atomic int` globals with clamped INI keys under `[arq]`.

**Constants added:**

| INI key | Default | Range | Notes |
|---|---|---|---|
| `channel_guard_ms` | 700 | 200–3000 | Inter-frame gap |
| `iss_post_ack_guard_ms` | 900 | 200–3000 | Post-ACK quiet time |
| `keepalive_interval_s` | 20 | 5–120 | |
| `keepalive_miss_limit` | 5 | 2–20 | Misses before disconnect |
| `ladder_up_successes` | 2 | 1–16 | Consecutive ACKs to step up |
| `retry_downgrade_threshold` | 2 | 1–16 | Retries to step down |
| `mode_hold_after_downgrade_s` | 6 | 0–60 | Hold period after step-down |
| `data_retry_slots` | (existing) | 1–32 | Was already atomic; INI key added |

All defaults match the current hardcoded values — no behavior change at defaults. `no_progress_timeout_s` and `disconnect_drain_timeout_s` are already atomic upstream and are untouched.

Each constant follows the pattern of the existing `_Atomic` globals in `arq_protocol.h`. Setter functions clamp on write; `cfg_utils.c` validates on parse. `mercury.ini.example` documents all eight keys.

Adds `tests/common/test_cfg_utils.c` (defaults, INI round-trip, out-of-range clamp rejection).