### PR TITLE
arq: replace extern-in-.c TNC coupling with arq_tnc_callbacks_t

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ LDFLAGS=$(FFAUDIO_LINKFLAGS) -lm $(HAMLIB_LDFLAGS)
 
 MERCURY_LINK_INPUTS = \
 	main.o common/cfg_utils.o common/iniparser/iniparser.o common/iniparser/dictionary.o \
-	datalink_arq/arq.o datalink_arq/arith.o datalink_arq/arq_channels.o \
+	datalink_arq/arq.o datalink_arq/arq_tnc.o datalink_arq/arith.o datalink_arq/arq_channels.o \
 	datalink_arq/arq_fsm.o datalink_arq/arq_protocol.o datalink_arq/arq_timing.o datalink_arq/arq_modem.o \
 	datalink_broadcast/broadcast.o datalink_broadcast/kiss.o modem/modem.o modem/framer.o modem/freedv/libfreedvdata.a \
 	audioio/audioio.a common/os_interop.o common/ring_buffer_posix.o common/shm_posix.o common/crc6.o common/hermes_log.o \

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -38,6 +38,7 @@
 #include "os_interop.h"
 
 #include "tcp_interfaces.h"
+#include "arq_tnc.h"
 #include <errno.h>
 #include <string.h>
 #include "ring_buffer_posix.h"
@@ -1273,6 +1274,17 @@ void tnc_send_buffer(uint32_t bytes)
         atomic_store_explicit(&tnc_last_buffer_sent, (int)bytes, memory_order_relaxed);
 }
 
+/* TNC notification callbacks registered into the ARQ layer.  Decouples ARQ
+ * from this file: ARQ calls arq_tnc_send_*(), which dispatch here. */
+static const arq_tnc_callbacks_t g_arq_tnc_cbs = {
+    .send_pending       = tnc_send_pending,
+    .send_cancelpending = tnc_send_cancelpending,
+    .send_connected     = tnc_send_connected,
+    .send_cqframe       = tnc_send_cqframe,
+    .send_disconnected  = tnc_send_disconnected,
+    .send_buffer        = tnc_send_buffer,
+};
+
 void tnc_send_sn(float snr)
 {
     char buffer[64];
@@ -1307,6 +1319,7 @@ uint32_t tnc_get_last_bitrate_bps(void)
 
 int interfaces_init(int arq_tcp_base_port, int broadcast_tcp_port, size_t broadcast_frame_size)
 {
+    arq_set_tnc_callbacks(&g_arq_tnc_cbs);
     arq_tcp_base_port_cfg = arq_tcp_base_port;
     broadcast_tcp_port_cfg = broadcast_tcp_port;
     broadcast_frame_size_cfg = broadcast_frame_size;

--- a/datalink_arq/Makefile
+++ b/datalink_arq/Makefile
@@ -25,10 +25,13 @@ CFLAGS = $(COMMON_CFLAGS) -I../modem/freedv -I../modem -I../datalink_broadcast -
 
 LDFLAGS=$(FFAUDIO_LINKFLAGS) -lm
 
-all: arq.o arith.o arq_channels.o arq_fsm.o arq_protocol.o arq_timing.o arq_modem.o
+all: arq.o arq_tnc.o arith.o arq_channels.o arq_fsm.o arq_protocol.o arq_timing.o arq_modem.o
 
 arq.o: arq.c
 	$(CC) $(CFLAGS) -c arq.c
+
+arq_tnc.o: arq_tnc.c arq_tnc.h
+	$(CC) $(CFLAGS) -c arq_tnc.c
 
 
 arith.o: arith.c

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -8,6 +8,7 @@
 
 #include "arq.h"
 #include "arq_fsm.h"
+#include "arq_tnc.h"
 #include "arq_protocol.h"
 #include "arq_timing.h"
 #include "arq_modem.h"
@@ -47,13 +48,6 @@ arq_info   arq_conn;
 extern cbuf_handle_t data_tx_buffer_arq;
 extern cbuf_handle_t data_tx_buffer_arq_control;
 extern cbuf_handle_t data_rx_buffer_arq;
-
-extern void tnc_send_pending(void);
-extern void tnc_send_cancelpending(void);
-extern void tnc_send_connected(void);
-extern void tnc_send_cqframe(const char *source_call, int bw_hz);
-extern void tnc_send_disconnected(void);
-extern void tnc_send_buffer(uint32_t bytes);
 
 extern void init_model(void);
 
@@ -209,20 +203,20 @@ static void cb_notify_connected(const char *remote_call)
      * of the previous session have time to drain to the TCP socket before
      * the buffer is cleared (clearing on disconnect races with UUCP reads). */
     clear_buffer(data_rx_buffer_arq);
-    tnc_send_connected();
+    arq_tnc_send_connected();
     HLOGI(LOG_COMP, "Connected to %s", remote_call);
 }
 
 static void cb_notify_pending(const char *remote_call)
 {
-    tnc_send_pending();
+    arq_tnc_send_pending();
     HLOGI(LOG_COMP, "Incoming connection from %s (pending)", remote_call);
 }
 
 static void cb_notify_cancelpending(void)
 {
     arq_conn.session_bw = 0;
-    tnc_send_cancelpending();
+    arq_tnc_send_cancelpending();
     HLOGI(LOG_COMP, "Incoming connection cancelled");
 }
 
@@ -241,7 +235,7 @@ static void cb_notify_disconnected(bool to_no_client)
     pthread_mutex_lock(&g_app_tx_mtx);
     clear_buffer(g_app_tx_buf);
     pthread_mutex_unlock(&g_app_tx_mtx);
-    tnc_send_disconnected();
+    arq_tnc_send_disconnected();
     HLOGI(LOG_COMP, "Disconnected");
     /* Return to LISTENING after any disconnection (failed call, cancelled call,
      * or ended session) as long as listen mode is active.  The was_connected
@@ -286,7 +280,7 @@ static int cb_tx_read(uint8_t *buf, size_t len)
 
 static void cb_send_buffer_status(int backlog_bytes)
 {
-    tnc_send_buffer((uint32_t)(backlog_bytes < 0 ? 0 : backlog_bytes));
+    arq_tnc_send_buffer((uint32_t)(backlog_bytes < 0 ? 0 : backlog_bytes));
 }
 
 static int normalize_bandwidth_hz(int bw_hz)
@@ -446,7 +440,7 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
          * here: the FSM drains any bytes still queued, then completes a clean
          * air-side DISCONNECT handshake.  The retry-exhaustion path bounds the
          * drain so a dead channel still tears down quickly (see arq_fsm.c). */
-        tnc_send_disconnected();
+        arq_tnc_send_disconnected();
         ev.id = ARQ_EV_APP_DISCONNECT;
         break;
 
@@ -455,7 +449,7 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
          * pending data and transitions to DISCONNECTED without deferral.
          * No air-side DISCONNECT frame is sent — the peer will time out. */
         clear_connection_data();
-        tnc_send_disconnected();
+        arq_tnc_send_disconnected();
         ev.id = ARQ_EV_APP_DISCONNECT;
         break;
 
@@ -629,20 +623,20 @@ bool arq_handle_incoming_cq_frame(uint8_t *data, size_t frame_size)
         return false;
     }
 
-    tnc_send_cqframe(source_call, normalize_bandwidth_hz(bw_hz));
+    arq_tnc_send_cqframe(source_call, normalize_bandwidth_hz(bw_hz));
     HLOGI(LOG_COMP, "CQ frame decoded from %s (%d Hz)", source_call, bw_hz);
     return true;
 }
 
 void arq_notify_cq_tx_started(void)
 {
-    tnc_send_pending();
+    arq_tnc_send_pending();
     HLOGI(LOG_COMP, "CQ transmission started");
 }
 
 void arq_notify_cq_tx_complete(void)
 {
-    tnc_send_cancelpending();
+    arq_tnc_send_cancelpending();
     HLOGI(LOG_COMP, "CQ transmission completed");
 }
 

--- a/datalink_arq/arq_tnc.c
+++ b/datalink_arq/arq_tnc.c
@@ -1,0 +1,48 @@
+/* HERMES Modem — ARQ→TNC notification seam
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#include "arq_tnc.h"
+#include <stddef.h>
+
+/* Registered once at startup by the TNC layer (interfaces_init).  All
+ * invokers below NULL-guard both the table and the individual field, so
+ * the ARQ layer is safe to call them before registration (mirrors how the
+ * FSM NULL-guards g_cbs in arq_fsm.c). */
+static const arq_tnc_callbacks_t *g_tnc;
+
+void arq_set_tnc_callbacks(const arq_tnc_callbacks_t *cbs)
+{
+    g_tnc = cbs;
+}
+
+void arq_tnc_send_pending(void)
+{
+    if (g_tnc && g_tnc->send_pending) g_tnc->send_pending();
+}
+
+void arq_tnc_send_cancelpending(void)
+{
+    if (g_tnc && g_tnc->send_cancelpending) g_tnc->send_cancelpending();
+}
+
+void arq_tnc_send_connected(void)
+{
+    if (g_tnc && g_tnc->send_connected) g_tnc->send_connected();
+}
+
+void arq_tnc_send_cqframe(const char *source_call, int bw_hz)
+{
+    if (g_tnc && g_tnc->send_cqframe) g_tnc->send_cqframe(source_call, bw_hz);
+}
+
+void arq_tnc_send_disconnected(void)
+{
+    if (g_tnc && g_tnc->send_disconnected) g_tnc->send_disconnected();
+}
+
+void arq_tnc_send_buffer(uint32_t bytes)
+{
+    if (g_tnc && g_tnc->send_buffer) g_tnc->send_buffer(bytes);
+}

--- a/datalink_arq/arq_tnc.h
+++ b/datalink_arq/arq_tnc.h
@@ -1,0 +1,40 @@
+/* HERMES Modem — ARQ→TNC notification seam
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Decouples the ARQ datalink from the TCP TNC layer above it.  The TNC
+ * layer registers a table of notification callbacks via
+ * arq_set_tnc_callbacks(); the ARQ layer emits notifications through the
+ * arq_tnc_send_*() invokers, which are NULL-safe before registration.
+ */
+#ifndef ARQ_TNC_H
+#define ARQ_TNC_H
+
+#include <stdint.h>
+
+typedef struct
+{
+    void (*send_pending)(void);
+    void (*send_cancelpending)(void);
+    void (*send_connected)(void);
+    void (*send_cqframe)(const char *source_call, int bw_hz);
+    void (*send_disconnected)(void);
+    void (*send_buffer)(uint32_t bytes);
+} arq_tnc_callbacks_t;
+
+/* Register the TNC notification callbacks (call once, after arq_init()).
+ * Passing NULL clears the registration. The pointed-to struct must outlive
+ * all subsequent arq_tnc_send_* calls (register a static/const table). */
+void arq_set_tnc_callbacks(const arq_tnc_callbacks_t *cbs);
+
+/* NULL-safe notification invokers. No-op if no table is registered or the
+ * specific callback is NULL. */
+void arq_tnc_send_pending(void);
+void arq_tnc_send_cancelpending(void);
+void arq_tnc_send_connected(void);
+void arq_tnc_send_cqframe(const char *source_call, int bw_hz);
+void arq_tnc_send_disconnected(void);
+void arq_tnc_send_buffer(uint32_t bytes);
+
+#endif /* ARQ_TNC_H */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -43,7 +43,7 @@ ARQ_STUBS = datalink_arq/arq_test_stubs.c
 
 # Test executables
 TEST_BINS = test_ring_buffer test_arq_protocol test_arq_timing test_arq_fsm \
-            test_tcp_interfaces test_resampler test_arq_olla
+            test_tcp_interfaces test_resampler test_arq_olla test_arq_tnc
 
 .PHONY: all test clean
 
@@ -94,6 +94,10 @@ test_arq_fsm: datalink_arq/test_arq_fsm.c $(UNITY_SRC) $(ARQ_STUBS) \
 # Uses #include "tcp_interfaces.c" — framer.c provides write_frame_header
 test_tcp_interfaces: data_interfaces/test_tcp_interfaces.c $(UNITY_SRC) ../modem/framer.c
 	$(CC) $(CFLAGS) -I../modem/freedv -o $@ $^ $(LDFLAGS)
+
+# ARQ→TNC seam test (standalone TU, no threads/bus)
+test_arq_tnc: datalink_arq/test_arq_tnc.c $(UNITY_SRC) ../datalink_arq/arq_tnc.c
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 clean:
 	rm -f $(TEST_BINS)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -92,7 +92,9 @@ test_arq_fsm: datalink_arq/test_arq_fsm.c $(UNITY_SRC) $(ARQ_STUBS) \
 
 # TCP TNC interface tests (command parsing, status emitters, broadcast framing)
 # Uses #include "tcp_interfaces.c" — framer.c provides write_frame_header
-test_tcp_interfaces: data_interfaces/test_tcp_interfaces.c $(UNITY_SRC) ../modem/framer.c
+# arq_tnc.c needed because interfaces_init() calls arq_set_tnc_callbacks()
+test_tcp_interfaces: data_interfaces/test_tcp_interfaces.c $(UNITY_SRC) ../modem/framer.c \
+                     ../datalink_arq/arq_tnc.c
 	$(CC) $(CFLAGS) -I../modem/freedv -o $@ $^ $(LDFLAGS)
 
 # ARQ→TNC seam test (standalone TU, no threads/bus)

--- a/tests/datalink_arq/test_arq_tnc.c
+++ b/tests/datalink_arq/test_arq_tnc.c
@@ -1,0 +1,105 @@
+/* Unit tests for the ARQ→TNC notification seam.
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#include <stdint.h>
+#include "unity.h"
+#include "fff.h"
+#include "arq_tnc.h"
+
+DEFINE_FFF_GLOBALS;
+
+FAKE_VOID_FUNC(fake_send_pending);
+FAKE_VOID_FUNC(fake_send_cancelpending);
+FAKE_VOID_FUNC(fake_send_connected);
+FAKE_VOID_FUNC(fake_send_cqframe, const char *, int);
+FAKE_VOID_FUNC(fake_send_disconnected);
+FAKE_VOID_FUNC(fake_send_buffer, uint32_t);
+
+static const arq_tnc_callbacks_t test_cbs = {
+    .send_pending       = fake_send_pending,
+    .send_cancelpending = fake_send_cancelpending,
+    .send_connected     = fake_send_connected,
+    .send_cqframe       = fake_send_cqframe,
+    .send_disconnected  = fake_send_disconnected,
+    .send_buffer        = fake_send_buffer,
+};
+
+void setUp(void)
+{
+    RESET_FAKE(fake_send_pending);
+    RESET_FAKE(fake_send_cancelpending);
+    RESET_FAKE(fake_send_connected);
+    RESET_FAKE(fake_send_cqframe);
+    RESET_FAKE(fake_send_disconnected);
+    RESET_FAKE(fake_send_buffer);
+    FFF_RESET_HISTORY();
+    arq_set_tnc_callbacks(NULL);   /* start each test unregistered */
+}
+
+void tearDown(void) {}
+
+/* Before registration, every invoker is a silent no-op (no crash). */
+void test_invokers_are_noop_before_registration(void)
+{
+    arq_tnc_send_connected();
+    arq_tnc_send_pending();
+    arq_tnc_send_cancelpending();
+    arq_tnc_send_disconnected();
+    arq_tnc_send_buffer(42);
+    arq_tnc_send_cqframe("W1AW", 2300);
+    TEST_ASSERT_EQUAL_INT(0, fake_send_connected_fake.call_count);
+    TEST_ASSERT_EQUAL_INT(0, fake_send_cqframe_fake.call_count);
+}
+
+/* After registration, invokers dispatch to the registered callbacks. */
+void test_invokers_dispatch_after_registration(void)
+{
+    arq_set_tnc_callbacks(&test_cbs);
+
+    arq_tnc_send_connected();
+    arq_tnc_send_pending();
+    arq_tnc_send_cancelpending();
+    arq_tnc_send_disconnected();
+
+    TEST_ASSERT_EQUAL_INT(1, fake_send_connected_fake.call_count);
+    TEST_ASSERT_EQUAL_INT(1, fake_send_pending_fake.call_count);
+    TEST_ASSERT_EQUAL_INT(1, fake_send_cancelpending_fake.call_count);
+    TEST_ASSERT_EQUAL_INT(1, fake_send_disconnected_fake.call_count);
+}
+
+/* Arguments are forwarded intact. */
+void test_invokers_forward_arguments(void)
+{
+    arq_set_tnc_callbacks(&test_cbs);
+
+    arq_tnc_send_buffer(1234);
+    arq_tnc_send_cqframe("KM6LYW", 500);
+
+    TEST_ASSERT_EQUAL_UINT32(1234, fake_send_buffer_fake.arg0_val);
+    TEST_ASSERT_EQUAL_STRING("KM6LYW", fake_send_cqframe_fake.arg0_val);
+    TEST_ASSERT_EQUAL_INT(500, fake_send_cqframe_fake.arg1_val);
+}
+
+/* A partially-populated table (some NULL fields) does not crash. */
+void test_partial_table_null_fields_are_safe(void)
+{
+    static const arq_tnc_callbacks_t partial = { .send_connected = fake_send_connected };
+    arq_set_tnc_callbacks(&partial);
+
+    arq_tnc_send_connected();    /* fires */
+    arq_tnc_send_pending();      /* NULL field — no-op, no crash */
+
+    TEST_ASSERT_EQUAL_INT(1, fake_send_connected_fake.call_count);
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_invokers_are_noop_before_registration);
+    RUN_TEST(test_invokers_dispatch_after_registration);
+    RUN_TEST(test_invokers_forward_arguments);
+    RUN_TEST(test_partial_table_null_fields_are_safe);
+    return UNITY_END();
+}


### PR DESCRIPTION
`arq.c` currently declares six TNC notification functions via a bare `extern` block inside the .c file. This creates an upward dependency — the ARQ layer reaches into the TNC layer at link time with no header, no interface contract, and no way to substitute an alternative implementation for testing.

This PR introduces `datalink_arq/arq_tnc.{h,c}`, a small registered-callback seam matching the pattern already used for the FSM callbacks (`arq_fsm_callbacks_t`).

**What changes:**
- New `arq_tnc_callbacks_t` struct with 6 function pointers matching the exact signatures of the `tnc_send_*` functions
- `arq_set_tnc_callbacks()` registration function; invokers are NULL-guarded
- `arq.c`: extern block removed; all 10 call sites converted to dispatch through the seam
- `tcp_interfaces.c`: populates a static callback table and registers it as the first line of `interfaces_init()`
- `init_model()` is left as a plain extern (out of scope here)

No behavior change at runtime. All 10 call sites converted. Clean build, 28 tests pass including 4 new `test_arq_tnc` unit tests.