### PR TITLE
arq: protect arq_conn with g_conn_lock (rebased #111 + complete FSM-thread reads)

### DIFF
--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -1190,13 +1190,13 @@ void *tcp_server_thread(void *port_ptr)
 /*********** TNC / radio functions ***********/
 void ptt_on()
 {
-    arq_conn.TRX = TX;
+    arq_set_trx(TX);
     if (radio_io_enabled())
         radio_io_key_on();
     /* Queue "PTT ON\r" asynchronously so a transient write failure on the
      * non-blocking CTL socket does NOT set NET_RESTART and kill the DATA
      * socket (which would send EOF to uucico and abort the UUCP session).
-     * The PTT state change (arq_conn.TRX = TX) is already synchronous and
+     * The PTT state change (arq_set_trx(TX)) is already synchronous and
      * is what the modem RX thread actually polls; the TCP notification to
      * uucpd is informational only. */
     (void)tnc_queue_line("PTT ON\r");
@@ -1205,7 +1205,7 @@ void ptt_on()
 
 void ptt_off()
 {
-    arq_conn.TRX = RX;
+    arq_set_trx(RX);
     if (radio_io_enabled())
         radio_io_key_off();
     /* Same reasoning as ptt_on(): queue asynchronously. */
@@ -1216,14 +1216,13 @@ void ptt_off()
 void tnc_send_connected()
 {
     char buffer[128];
-    const char *source_call = arq_conn.src_addr[0]
-                              ? arq_conn.src_addr
-                              : arq_conn.my_call_sign;
-    const char *dest_call = arq_conn.dst_addr[0]
-                            ? arq_conn.dst_addr
-                            : arq_conn.my_call_sign;
+    char my_call[CALLSIGN_MAX_SIZE], src[CALLSIGN_MAX_SIZE], dst[CALLSIGN_MAX_SIZE];
+    arq_conn_get_calls(my_call, src, dst, CALLSIGN_MAX_SIZE);
+    const char *source_call = src[0] ? src : my_call;
+    const char *dest_call   = dst[0] ? dst : my_call;
+    int bw = arq_reported_bandwidth_hz();   /* separate locked call, AFTER the getter returns */
     snprintf(buffer, sizeof(buffer), "CONNECTED %s %s %d\r",
-            source_call, dest_call, arq_reported_bandwidth_hz());
+             source_call, dest_call, bw);
     if (tnc_queue_line(buffer) < 0)
         HLOGW("tcp-ctl", "Error queuing connected message");
 }

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -370,6 +370,14 @@ void arq_conn_get_calls(char *my_call, char *src_addr, char *dst_addr, size_t bu
     pthread_mutex_unlock(&g_conn_lock);
 }
 
+int arq_get_bw(void)
+{
+    pthread_mutex_lock(&g_conn_lock);
+    int bw = arq_conn.bw;
+    pthread_mutex_unlock(&g_conn_lock);
+    return bw;
+}
+
 bool arq_bandwidth_allows_mode(int mode)
 {
     /* Wideband payload modes (~1.7-2.2 kHz) need more than the narrow

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -87,6 +87,17 @@ static uint8_t         g_app_tx_storage[APP_TX_BUF_SIZE];
 static cbuf_handle_t   g_app_tx_buf;
 static pthread_mutex_t g_app_tx_mtx = PTHREAD_MUTEX_INITIALIZER;
 
+/* Guards the process-global arq_conn.  arq_conn is read and written from five
+ * threads (event loop, cmd bridge, modem RX frame handlers, modem TX PTT path,
+ * and the GUI status thread), so every field access is a data race without
+ * this lock.  It is a LEAF lock: it is never held while acquiring g_sess_lock
+ * or g_app_tx_mtx.  That is deliberate -- arq_get_runtime_snapshot() takes
+ * g_app_tx_mtx (via cb_tx_backlog) before g_sess_lock, while cb_notify_
+ * disconnected() writes arq_conn and then takes g_app_tx_mtx; guarding
+ * arq_conn with either of those locks would invert an ordering and deadlock.
+ * A separate leaf lock has no ordering relationship to maintain. */
+static pthread_mutex_t g_conn_lock = PTHREAD_MUTEX_INITIALIZER;
+
 /* Internal event queue */
 #define ARQ_EV_QUEUE_CAP 64
 static arq_event_t     g_evq[ARQ_EV_QUEUE_CAP];
@@ -202,18 +213,20 @@ static void cb_send_tx_frame(int packet_type, int mode,
 
 static void cb_notify_connected(const char *remote_call)
 {
+    pthread_mutex_lock(&g_conn_lock);
     if (arq_conn.src_addr[0] == '\0')
     {
         snprintf(arq_conn.src_addr, CALLSIGN_MAX_SIZE, "%s", remote_call);
         snprintf(arq_conn.dst_addr, CALLSIGN_MAX_SIZE, "%s", arq_conn.my_call_sign);
     }
     arq_conn.TRX = RX;
+    pthread_mutex_unlock(&g_conn_lock);
     /* Flush any stale RX bytes from the previous session before notifying
      * UUCP.  Moved here from cb_notify_disconnected so that the last bytes
      * of the previous session have time to drain to the TCP socket before
      * the buffer is cleared (clearing on disconnect races with UUCP reads). */
     clear_buffer(data_rx_buffer_arq);
-    tnc_send_connected();
+    tnc_send_connected();   /* takes g_conn_lock internally via arq_conn_get_calls; must be outside our lock */
     HLOGI(LOG_COMP, "Connected to %s", remote_call);
 }
 
@@ -225,7 +238,9 @@ static void cb_notify_pending(const char *remote_call)
 
 static void cb_notify_cancelpending(void)
 {
+    pthread_mutex_lock(&g_conn_lock);
     arq_conn.session_bw = 0;
+    pthread_mutex_unlock(&g_conn_lock);
     tnc_send_cancelpending();
     HLOGI(LOG_COMP, "Incoming connection cancelled");
 }
@@ -233,11 +248,14 @@ static void cb_notify_cancelpending(void)
 static void cb_notify_disconnected(bool to_no_client)
 {
     (void)to_no_client;
+    pthread_mutex_lock(&g_conn_lock);
     bool was_connected = arq_conn.dst_addr[0] != '\0';
     memset(arq_conn.src_addr, 0, sizeof(arq_conn.src_addr));
     memset(arq_conn.dst_addr, 0, sizeof(arq_conn.dst_addr));
     arq_conn.session_bw = 0;
     arq_conn.TRX = RX;
+    bool relisten = (arq_conn.listen && arq_conn.my_call_sign[0] != '\0');
+    pthread_mutex_unlock(&g_conn_lock);   /* release BEFORE g_app_tx_mtx: leaf discipline */
     /* Flush stale TX bytes from the previous session.  RX bytes are flushed
      * at connection start (cb_notify_connected) instead of here, so that the
      * last delivered bytes have time to drain to the TCP socket before the
@@ -253,7 +271,7 @@ static void cb_notify_disconnected(bool to_no_client)
      * DISCONNECTED, but fsm_disconnected has no APP_DISCONNECT handler, so
      * notify_disconnected is never called from that path. */
     (void)was_connected;
-    if (arq_conn.listen && arq_conn.my_call_sign[0] != '\0')
+    if (relisten)
     {
         arq_event_t ev = { .id = ARQ_EV_APP_LISTEN };
         evq_push(&ev);
@@ -305,10 +323,13 @@ static int normalize_bandwidth_hz(int bw_hz)
 
 static int active_session_bandwidth_hz(void)
 {
-    if (arq_conn.session_bw != 0)
-        return normalize_bandwidth_hz(arq_conn.session_bw);
-
-    return normalize_bandwidth_hz(arq_conn.bw);
+    pthread_mutex_lock(&g_conn_lock);
+    int session_bw = arq_conn.session_bw;
+    int bw         = arq_conn.bw;
+    pthread_mutex_unlock(&g_conn_lock);
+    if (session_bw != 0)
+        return normalize_bandwidth_hz(session_bw);
+    return normalize_bandwidth_hz(bw);
 }
 
 int arq_effective_bandwidth_hz(void)
@@ -322,6 +343,31 @@ int arq_effective_bandwidth_hz(void)
 int arq_reported_bandwidth_hz(void)
 {
     return active_session_bandwidth_hz();
+}
+
+void arq_set_trx(int trx)
+{
+    pthread_mutex_lock(&g_conn_lock);
+    arq_conn.TRX = trx;
+    pthread_mutex_unlock(&g_conn_lock);
+}
+
+int arq_get_trx(void)
+{
+    pthread_mutex_lock(&g_conn_lock);
+    int t = arq_conn.TRX;
+    pthread_mutex_unlock(&g_conn_lock);
+    return t;
+}
+
+void arq_conn_get_calls(char *my_call, char *src_addr, char *dst_addr, size_t bufsz)
+{
+    if (bufsz == 0) return;
+    pthread_mutex_lock(&g_conn_lock);
+    if (my_call)  { snprintf(my_call,  bufsz, "%s", arq_conn.my_call_sign); }
+    if (src_addr) { snprintf(src_addr, bufsz, "%s", arq_conn.src_addr); }
+    if (dst_addr) { snprintf(dst_addr, bufsz, "%s", arq_conn.dst_addr); }
+    pthread_mutex_unlock(&g_conn_lock);
 }
 
 bool arq_bandwidth_allows_mode(int mode)
@@ -347,42 +393,54 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
     switch (msg->type)
     {
     case ARQ_CMD_SET_CALLSIGN:
+        pthread_mutex_lock(&g_conn_lock);
         snprintf(arq_conn.my_call_sign, CALLSIGN_MAX_SIZE, "%s", msg->arg0);
         /* Setting a new primary callsign clears all secondary callsigns */
         memset(arq_conn.secondary_calls, 0, sizeof(arq_conn.secondary_calls));
         arq_conn.secondary_call_count = 0;
-        HLOGI(LOG_COMP, "My callsign: %s", arq_conn.my_call_sign);
+        pthread_mutex_unlock(&g_conn_lock);
+        HLOGI(LOG_COMP, "My callsign: %s", msg->arg0);   /* log msg->arg0, not the shared field */
         return;
 
     case ARQ_CMD_ADD_SECONDARY_CALLSIGN:
+    {
+        int new_count = -1;
+        pthread_mutex_lock(&g_conn_lock);
         if (arq_conn.secondary_call_count < CALLSIGN_MAX_SECONDARY)
         {
             snprintf(arq_conn.secondary_calls[arq_conn.secondary_call_count],
                      CALLSIGN_MAX_SIZE, "%s", msg->arg0);
             arq_conn.secondary_call_count++;
-            HLOGI(LOG_COMP, "Secondary callsign added: %s (total=%d)",
-                  msg->arg0, arq_conn.secondary_call_count);
+            new_count = arq_conn.secondary_call_count;
         }
+        pthread_mutex_unlock(&g_conn_lock);
+        if (new_count >= 0)
+            HLOGI(LOG_COMP, "Secondary callsign added: %s (total=%d)", msg->arg0, new_count);
         else
-        {
             HLOGW(LOG_COMP, "Secondary callsign list full (max=%d), ignoring %s",
                   CALLSIGN_MAX_SECONDARY, msg->arg0);
-        }
         return;
+    }
 
     case ARQ_CMD_CLEAR_SECONDARY_CALLSIGNS:
+        pthread_mutex_lock(&g_conn_lock);
         memset(arq_conn.secondary_calls, 0, sizeof(arq_conn.secondary_calls));
         arq_conn.secondary_call_count = 0;
+        pthread_mutex_unlock(&g_conn_lock);
         HLOGI(LOG_COMP, "Secondary callsigns cleared");
         return;
 
     case ARQ_CMD_SET_BANDWIDTH:
+        pthread_mutex_lock(&g_conn_lock);
         arq_conn.bw = normalize_bandwidth_hz(msg->value);
+        pthread_mutex_unlock(&g_conn_lock);
         return;
 
     case ARQ_CMD_SET_RETRY:
+        pthread_mutex_lock(&g_conn_lock);
         arq_conn.retry_slots = msg->value;
-        arq_set_retry_slots(msg->value);
+        pthread_mutex_unlock(&g_conn_lock);
+        arq_set_retry_slots(msg->value);   /* outside lock: takes g_sess_lock internally */
         return;
 
     case ARQ_CMD_SET_CALLINT:
@@ -404,19 +462,25 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
         return;
 
     case ARQ_CMD_LISTEN_ON:
+        pthread_mutex_lock(&g_conn_lock);
         arq_conn.listen = true;
+        pthread_mutex_unlock(&g_conn_lock);
         ev.id = ARQ_EV_APP_LISTEN;
         break;
 
     case ARQ_CMD_LISTEN_OFF:
+        pthread_mutex_lock(&g_conn_lock);
         arq_conn.listen = false;
+        pthread_mutex_unlock(&g_conn_lock);
         ev.id = ARQ_EV_APP_STOP_LISTEN;
         break;
 
     case ARQ_CMD_CONNECT:
+        pthread_mutex_lock(&g_conn_lock);
         snprintf(arq_conn.src_addr, CALLSIGN_MAX_SIZE, "%s", msg->arg0);
         snprintf(arq_conn.dst_addr, CALLSIGN_MAX_SIZE, "%s", msg->arg1);
         arq_conn.session_bw = 0;
+        pthread_mutex_unlock(&g_conn_lock);
         snprintf(ev.remote_call, CALLSIGN_MAX_SIZE, "%s", msg->arg1);
         ev.id = ARQ_EV_APP_CONNECT;
         break;
@@ -424,7 +488,11 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
     case ARQ_CMD_SEND_CQ:
     {
         uint8_t frame[INT_BUFFER_SIZE];
-        const char *source_call = msg->arg0[0] ? msg->arg0 : arq_conn.my_call_sign;
+        char cq_my_call[CALLSIGN_MAX_SIZE];
+        pthread_mutex_lock(&g_conn_lock);
+        snprintf(cq_my_call, sizeof(cq_my_call), "%s", arq_conn.my_call_sign);
+        pthread_mutex_unlock(&g_conn_lock);
+        const char *source_call = msg->arg0[0] ? msg->arg0 : cq_my_call;
         int bw_hz = normalize_bandwidth_hz(msg->value);
         int n = arq_protocol_build_cq(frame, sizeof(frame), source_call, bw_hz);
         if (n <= 0)
@@ -592,14 +660,24 @@ bool arq_handle_incoming_connect_frame(uint8_t *data, size_t frame_size)
         return false;
     }
 
+    /* Copy callsigns out under g_conn_lock, compare CRCs unlocked */
+    char my_call[CALLSIGN_MAX_SIZE];
+    char sec[CALLSIGN_MAX_SECONDARY][CALLSIGN_MAX_SIZE];
+    int  sec_count;
+    pthread_mutex_lock(&g_conn_lock);
+    snprintf(my_call, sizeof(my_call), "%s", arq_conn.my_call_sign);
+    sec_count = arq_conn.secondary_call_count;
+    memcpy(sec, arq_conn.secondary_calls, sizeof(sec));
+    pthread_mutex_unlock(&g_conn_lock);
+
     /* Validate that DST CRC16 matches our own callsign or a secondary */
-    if (arq_conn.my_call_sign[0] != 0)
+    if (my_call[0] != 0)
     {
         uint16_t frame_crc = (uint16_t)data[ARQ_CONNECT_PAYLOAD_IDX]
                            | ((uint16_t)data[ARQ_CONNECT_PAYLOAD_IDX + 1] << 8);
-        bool match = (frame_crc == arq_protocol_callsign_crc16(arq_conn.my_call_sign));
-        for (int i = 0; !match && i < arq_conn.secondary_call_count; i++)
-            match = (frame_crc == arq_protocol_callsign_crc16(arq_conn.secondary_calls[i]));
+        bool match = (frame_crc == arq_protocol_callsign_crc16(my_call));
+        for (int i = 0; !match && i < sec_count; i++)
+            match = (frame_crc == arq_protocol_callsign_crc16(sec[i]));
         if (!match)
         {
             HLOGD(LOG_COMP, "CALL/ACCEPT not for us (DST CRC16 mismatch)");
@@ -612,11 +690,13 @@ bool arq_handle_incoming_connect_frame(uint8_t *data, size_t frame_size)
     ev.session_id = session_id;
     /* src = transmitting side's callsign */
     snprintf(ev.remote_call, CALLSIGN_MAX_SIZE, "%s", src);
+    pthread_mutex_lock(&g_conn_lock);
+    int local_bw = normalize_bandwidth_hz(arq_conn.bw);
     if (is_accept)
         arq_conn.session_bw = normalize_bandwidth_hz(bw_hz);
     else
-        arq_conn.session_bw = normalize_bandwidth_hz(
-            bw_hz < normalize_bandwidth_hz(arq_conn.bw) ? bw_hz : normalize_bandwidth_hz(arq_conn.bw));
+        arq_conn.session_bw = normalize_bandwidth_hz(bw_hz < local_bw ? bw_hz : local_bw);
+    pthread_mutex_unlock(&g_conn_lock);
     evq_push(&ev);
     return true;
 }
@@ -765,6 +845,7 @@ int arq_init(size_t frame_size, int mode)
         return -1;
     }
 
+    /* single-threaded: before worker threads start -- no lock needed */
     memset(&arq_conn, 0, sizeof(arq_conn));
     arq_conn.frame_size      = frame_size;
     arq_conn.mode            = mode;
@@ -915,8 +996,10 @@ void arq_set_active_modem_mode(int mode, size_t frame_size)
     if (mode != g_sess.control_mode)
         g_sess.payload_mode = mode;
     pthread_mutex_unlock(&g_sess_lock);
+    pthread_mutex_lock(&g_conn_lock);
     arq_conn.mode       = mode;
     arq_conn.frame_size = frame_size;
+    pthread_mutex_unlock(&g_conn_lock);
 }
 
 void arq_update_link_metrics(int sync, float snr, int rx_status, bool frame_decoded)
@@ -949,10 +1032,11 @@ bool arq_get_runtime_snapshot(arq_runtime_snapshot_t *snapshot)
 {
     if (!snapshot || !g_initialized) return false;
     int backlog = cb_tx_backlog();   /* takes g_app_tx_mtx; compute before g_sess_lock */
+    int trx     = arq_get_trx();     /* takes g_conn_lock (leaf); before g_sess_lock */
     pthread_mutex_lock(&g_sess_lock);
     snapshot->initialized      = true;
     snapshot->connected        = (g_sess.conn_state == ARQ_CONN_CONNECTED);
-    snapshot->trx              = arq_conn.TRX;
+    snapshot->trx              = trx;
     snapshot->tx_backlog_bytes = backlog + g_sess.tx_inflight_bytes;
     snapshot->speed_level      = g_sess.speed_level;
     snapshot->payload_mode      = g_sess.payload_mode;

--- a/datalink_arq/arq.h
+++ b/datalink_arq/arq.h
@@ -106,6 +106,8 @@ extern arq_info arq_conn;
  * None may be called while the caller already holds the connection lock. */
 void arq_set_trx(int trx);
 int  arq_get_trx(void);
+/* Configured (non-session) bandwidth in Hz, read under g_conn_lock. */
+int  arq_get_bw(void);
 /* Copy the current callsign strings out under g_conn_lock.  Each of my_call,
  * src_addr, dst_addr may be NULL to skip; each receives up to bufsz bytes,
  * always NUL-terminated. */

--- a/datalink_arq/arq.h
+++ b/datalink_arq/arq.h
@@ -102,6 +102,15 @@ typedef struct
 
 extern arq_info arq_conn;
 
+/* Thread-safe accessors for arq_conn (see g_conn_lock in arq.c).
+ * None may be called while the caller already holds the connection lock. */
+void arq_set_trx(int trx);
+int  arq_get_trx(void);
+/* Copy the current callsign strings out under g_conn_lock.  Each of my_call,
+ * src_addr, dst_addr may be NULL to skip; each receives up to bufsz bytes,
+ * always NUL-terminated. */
+void arq_conn_get_calls(char *my_call, char *src_addr, char *dst_addr, size_t bufsz);
+
 /**
  * @brief Initialize ARQ subsystem.
  * @param frame_size Active modem frame size in bytes.

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -609,8 +609,12 @@ static void send_call_accept(arq_session_t *sess, bool is_accept)
 {
     uint8_t frame[INT_BUFFER_SIZE];
     int n;
-    const char *my_call = arq_conn.my_call_sign;
-    int bw_hz = is_accept ? arq_reported_bandwidth_hz() : arq_conn.bw;
+    /* Read shared arq_conn through the locked accessors (g_conn_lock):
+     * this runs on the FSM/event-loop thread while handle_cmd may be writing
+     * my_call_sign/bw from the command-bridge thread. */
+    char my_call[CALLSIGN_MAX_SIZE];
+    arq_conn_get_calls(my_call, NULL, NULL, sizeof(my_call));
+    int bw_hz = is_accept ? arq_reported_bandwidth_hz() : arq_get_bw();
     if (is_accept)
         n = arq_protocol_build_accept(frame, sizeof(frame), sess->session_id,
                                       my_call, sess->remote_call, bw_hz);

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -201,18 +201,19 @@ void *ui_publisher_thread(void *arg)
 
         int bitrate = (int)tnc_get_last_bitrate_bps();
         double snr = (double)tnc_get_last_snr();
-        const char *user_call = arq_conn.my_call_sign;
+        char my_call[CALLSIGN_MAX_SIZE], src_call[CALLSIGN_MAX_SIZE], dst_call[CALLSIGN_MAX_SIZE];
+        arq_conn_get_calls(my_call, src_call, dst_call, CALLSIGN_MAX_SIZE);
+        const char *user_call = my_call;
         /* Determine remote peer for UI display.
          * src_addr/dst_addr follow TNC convention (initiator/target):
          *   ISS (caller):   src_addr = self,   dst_addr = remote
          *   IRS (receiver): src_addr = remote,  dst_addr = self
          * Pick whichever is NOT our own callsign. */
         const char *dest_call;
-        if (arq_conn.dst_addr[0] != '\0' &&
-            strcmp(arq_conn.dst_addr, arq_conn.my_call_sign) != 0)
-            dest_call = arq_conn.dst_addr;   /* ISS: dst is remote */
+        if (dst_call[0] != '\0' && strcmp(dst_call, my_call) != 0)
+            dest_call = dst_call;   /* ISS: dst is remote */
         else
-            dest_call = arq_conn.src_addr;   /* IRS: src is remote */
+            dest_call = src_call;   /* IRS: src is remote */
         int sync = 0;
         modem_direction_t dir = DIR_RX;
         int tcp_connected = 0;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -43,7 +43,8 @@ ARQ_STUBS = datalink_arq/arq_test_stubs.c
 
 # Test executables
 TEST_BINS = test_ring_buffer test_arq_protocol test_arq_timing test_arq_fsm \
-            test_tcp_interfaces test_resampler test_arq_olla test_arq_sim
+            test_tcp_interfaces test_resampler test_arq_olla test_arq_sim \
+            test_arq_conn
 
 .PHONY: all test clean
 
@@ -102,6 +103,11 @@ test_arq_sim: sim/test_arq_sim.c $(UNITY_SRC) $(ARQ_STUBS) $(SIM_SRC) \
               ../datalink_arq/arq_fsm.c ../datalink_arq/arq_protocol.c \
               ../datalink_arq/arq_timing.c ../datalink_arq/arith.c
 	$(CC) $(CFLAGS) -Isim -I../modem/freedv -o $@ $^ $(LDFLAGS)
+
+# arq_conn accessor correctness tests (single-threaded; locking verified by TSan)
+test_arq_conn: datalink_arq/test_arq_conn.c $(UNITY_SRC) \
+               datalink_arq/arq_conn_accessors.c
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 clean:
 	rm -f $(TEST_BINS)

--- a/tests/data_interfaces/test_tcp_interfaces.c
+++ b/tests/data_interfaces/test_tcp_interfaces.c
@@ -87,6 +87,17 @@ int arq_reported_bandwidth_hz(void)
 
 bool arq_bandwidth_allows_mode(int mode) { (void)mode; return true; }
 
+void arq_set_trx(int trx) { arq_conn.TRX = trx; }
+int  arq_get_trx(void)    { return arq_conn.TRX; }
+
+void arq_conn_get_calls(char *my_call, char *src_addr, char *dst_addr, size_t bufsz)
+{
+    if (bufsz == 0) return;
+    if (my_call)  snprintf(my_call,  bufsz, "%s", arq_conn.my_call_sign);
+    if (src_addr) snprintf(src_addr, bufsz, "%s", arq_conn.src_addr);
+    if (dst_addr) snprintf(dst_addr, bufsz, "%s", arq_conn.dst_addr);
+}
+
 /* ---- net stubs ---- */
 
 int cli_ctl_sockfd = -1;

--- a/tests/datalink_arq/arq_conn_accessors.c
+++ b/tests/datalink_arq/arq_conn_accessors.c
@@ -1,0 +1,29 @@
+/* Standalone build of the arq_conn accessors for unit testing.
+ * Copyright (C) 2025 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+#include <pthread.h>
+#include <string.h>
+#include <stdio.h>
+#include "arq.h"
+#include "arq_conn_accessors.h"
+
+arq_info arq_conn;
+static pthread_mutex_t g_conn_lock = PTHREAD_MUTEX_INITIALIZER;
+
+void arq_conn_test_reset(void) { memset(&arq_conn, 0, sizeof(arq_conn)); }
+
+void arq_set_trx(int trx)
+{ pthread_mutex_lock(&g_conn_lock); arq_conn.TRX = trx; pthread_mutex_unlock(&g_conn_lock); }
+
+int arq_get_trx(void)
+{ pthread_mutex_lock(&g_conn_lock); int t = arq_conn.TRX; pthread_mutex_unlock(&g_conn_lock); return t; }
+
+void arq_conn_get_calls(char *my_call, char *src_addr, char *dst_addr, size_t bufsz)
+{
+    if (bufsz == 0) return;
+    pthread_mutex_lock(&g_conn_lock);
+    if (my_call)  snprintf(my_call,  bufsz, "%s", arq_conn.my_call_sign);
+    if (src_addr) snprintf(src_addr, bufsz, "%s", arq_conn.src_addr);
+    if (dst_addr) snprintf(dst_addr, bufsz, "%s", arq_conn.dst_addr);
+    pthread_mutex_unlock(&g_conn_lock);
+}

--- a/tests/datalink_arq/arq_conn_accessors.h
+++ b/tests/datalink_arq/arq_conn_accessors.h
@@ -1,0 +1,11 @@
+/* Test seam: exposes the arq_conn accessors and a reset for unit tests.
+ * Copyright (C) 2025 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+#ifndef ARQ_CONN_ACCESSORS_H
+#define ARQ_CONN_ACCESSORS_H
+#include <stddef.h>
+void arq_set_trx(int trx);
+int  arq_get_trx(void);
+void arq_conn_get_calls(char *my_call, char *src_addr, char *dst_addr, size_t bufsz);
+void arq_conn_test_reset(void);   /* test-only: zero arq_conn */
+#endif

--- a/tests/datalink_arq/arq_test_stubs.c
+++ b/tests/datalink_arq/arq_test_stubs.c
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
+#include <stdio.h>
 
 #include "hermes_log.h"
 #include "framer.h"
@@ -61,6 +62,21 @@ arq_info arq_conn = {0};
 int arq_reported_bandwidth_hz(void)
 {
     return ARQ_BANDWIDTH_FULL_HZ; /* default to 2300 Hz for tests */
+}
+
+/* Single-threaded test doubles: read straight from the arq_conn global so
+ * tests that seed arq_conn.my_call_sign / arq_conn.bw still observe them. */
+void arq_conn_get_calls(char *my_call, char *src_addr, char *dst_addr, size_t bufsz)
+{
+    if (bufsz == 0) return;
+    if (my_call)  { snprintf(my_call,  bufsz, "%s", arq_conn.my_call_sign); }
+    if (src_addr) { snprintf(src_addr, bufsz, "%s", arq_conn.src_addr); }
+    if (dst_addr) { snprintf(dst_addr, bufsz, "%s", arq_conn.dst_addr); }
+}
+
+int arq_get_bw(void)
+{
+    return arq_conn.bw;
 }
 
 bool arq_bandwidth_allows_mode(int mode)

--- a/tests/datalink_arq/test_arq_conn.c
+++ b/tests/datalink_arq/test_arq_conn.c
@@ -1,0 +1,61 @@
+/*
+ * arq_conn accessor unit tests (single-threaded correctness).
+ *
+ * These do NOT test the locking itself (that is covered by the ThreadSanitizer
+ * integration run); they pin the round-trip semantics of the new accessors so a
+ * refactor cannot silently break them.
+ *
+ * Copyright (C) 2025 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#include <string.h>
+#include "unity.h"
+#include "arq.h"
+#include "arq_conn_accessors.h"
+
+void setUp(void)    { arq_conn_test_reset(); }
+void tearDown(void) { }
+
+void test_trx_set_get_roundtrip(void)
+{
+    arq_set_trx(1);
+    TEST_ASSERT_EQUAL_INT(1, arq_get_trx());
+    arq_set_trx(0);
+    TEST_ASSERT_EQUAL_INT(0, arq_get_trx());
+}
+
+void test_get_calls_empty_yields_empty_strings(void)
+{
+    char my[16] = "x", src[16] = "x", dst[16] = "x";
+    arq_conn_get_calls(my, src, dst, sizeof(my));
+    TEST_ASSERT_EQUAL_STRING("", my);
+    TEST_ASSERT_EQUAL_STRING("", src);
+    TEST_ASSERT_EQUAL_STRING("", dst);
+}
+
+void test_get_calls_null_args_are_skipped(void)
+{
+    /* Must not crash when any pointer is NULL. */
+    arq_conn_get_calls(NULL, NULL, NULL, 16);
+    TEST_PASS();
+}
+
+void test_get_calls_truncates_to_bufsz(void)
+{
+    /* Seed a full-width callsign, read into a short buffer. */
+    extern arq_info arq_conn;
+    snprintf(arq_conn.my_call_sign, sizeof(arq_conn.my_call_sign), "ABCDEFGHIJKLMNO");
+    char my[4];
+    arq_conn_get_calls(my, NULL, NULL, sizeof(my));
+    TEST_ASSERT_EQUAL_size_t(3, strlen(my));   /* 3 chars + NUL */
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_trx_set_get_roundtrip);
+    RUN_TEST(test_get_calls_empty_yields_empty_strings);
+    RUN_TEST(test_get_calls_null_args_are_skipped);
+    RUN_TEST(test_get_calls_truncates_to_bufsz);
+    return UNITY_END();
+}


### PR DESCRIPTION
Rebases #111 (Tony Hagale's `arq_conn` locking refactor) onto current `mercuryv2` and completes it.

thagale's original commit is preserved with authorship (`arq: protect arq_conn with g_conn_lock, ...`). PR #111 could not be merged directly: its branch predates the sim-harness/#106/#107 merges, so GitHub reports it dirty and a server-side rebase-merge is not possible.

**Added completion commit:** #111 routed all *external* `arq_conn` access through `g_conn_lock` but left two direct reads in `arq_fsm.c` `send_call_accept()` (`my_call_sign`, `bw`) that run on the FSM/event-loop thread while `handle_cmd()` writes them from the command-bridge thread — the exact race the PR set out to close. These now go through the locked accessors (`arq_conn_get_calls()` + new `arq_get_bw()`), with matching single-threaded test doubles in `arq_test_stubs.c`.

No runtime behavior change. Full unit suite green (incl. the 4 new `test_arq_conn` cases). Supersedes #111.