### PR TITLE
modem: add channel-busy detector with VARA-compatible BUSY ON/OFF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ MERCURY_LINK_INPUTS = \
 	main.o common/cfg_utils.o common/iniparser/iniparser.o common/iniparser/dictionary.o \
 	datalink_arq/arq.o datalink_arq/arq_tnc.o datalink_arq/arith.o datalink_arq/arq_channels.o \
 	datalink_arq/arq_fsm.o datalink_arq/arq_protocol.o datalink_arq/arq_timing.o datalink_arq/arq_modem.o \
-	datalink_broadcast/broadcast.o datalink_broadcast/kiss.o modem/modem.o modem/framer.o modem/freedv/libfreedvdata.a \
+	datalink_broadcast/broadcast.o datalink_broadcast/kiss.o modem/modem.o modem/framer.o modem/channel_busy.o modem/freedv/libfreedvdata.a \
 	audioio/audioio.a common/os_interop.o common/ring_buffer_posix.o common/shm_posix.o common/crc6.o common/hermes_log.o \
 	common/chan.o common/queue.o data_interfaces/tcp_interfaces.o data_interfaces/net.o \
 	gui_interface/ui_communication.o \

--- a/common/cfg_utils.c
+++ b/common/cfg_utils.c
@@ -64,6 +64,11 @@ void cfg_set_defaults(mercury_config *cfg)
     cfg->keepalive_miss_limit        = ARQ_KEEPALIVE_MISS_LIMIT_DEFAULT;
     cfg->peer_payload_hold_s         = ARQ_PEER_PAYLOAD_HOLD_S_DEFAULT;
     cfg->startup_max_s               = ARQ_STARTUP_MAX_S_DEFAULT;
+    cfg->busy_detect                 = false;
+    cfg->busy_threshold_db           = 10;
+    cfg->busy_hysteresis_db          = 3;
+    cfg->busy_on_debounce_ms         = 300;
+    cfg->busy_hang_ms                = 1500;
 }
 
 /* Map a sound-system name to the AUDIO_SUBSYSTEM_* constant.
@@ -216,6 +221,21 @@ bool cfg_read(mercury_config *cfg, const char *ini_path)
     i = iniparser_getint(ini, CFG_KEY_ARQ_STARTUP_MAX_S, cfg->startup_max_s);
     if (i >= 2 && i <= 60)   cfg->startup_max_s = i;
 
+    cfg->busy_detect = (bool) iniparser_getboolean(ini, CFG_KEY_BUSY_DETECT,
+                                                   cfg->busy_detect ? 1 : 0);
+
+    i = iniparser_getint(ini, CFG_KEY_BUSY_THRESHOLD_DB, cfg->busy_threshold_db);
+    if (i >= 3 && i <= 40)      cfg->busy_threshold_db = i;
+
+    i = iniparser_getint(ini, CFG_KEY_BUSY_HYSTERESIS_DB, cfg->busy_hysteresis_db);
+    if (i >= 0 && i <= 20)      cfg->busy_hysteresis_db = i;
+
+    i = iniparser_getint(ini, CFG_KEY_BUSY_ON_DEBOUNCE_MS, cfg->busy_on_debounce_ms);
+    if (i >= 0 && i <= 5000)    cfg->busy_on_debounce_ms = i;
+
+    i = iniparser_getint(ini, CFG_KEY_BUSY_HANG_MS, cfg->busy_hang_ms);
+    if (i >= 0 && i <= 10000)   cfg->busy_hang_ms = i;
+
     double d = iniparser_getdouble(ini, CFG_KEY_TX_GAIN_DB, (double)cfg->tx_gain_db);
     if (!isfinite(d)) d = 0.0;  /* malformed/non-finite INI value -> default */
     if (d < -20.0) d = -20.0;
@@ -316,6 +336,13 @@ bool cfg_write(const mercury_config *cfg, const char *ini_path)
     fprintf(f, "keepalive_miss_limit = %d\n", cfg->keepalive_miss_limit);
     fprintf(f, "peer_payload_hold_s = %d\n", cfg->peer_payload_hold_s);
     fprintf(f, "startup_max_s = %d\n", cfg->startup_max_s);
+
+    fprintf(f, "\n[channel]\n");
+    fprintf(f, "busy_detect = %s\n", cfg->busy_detect ? "true" : "false");
+    fprintf(f, "busy_threshold_db = %d\n", cfg->busy_threshold_db);
+    fprintf(f, "busy_hysteresis_db = %d\n", cfg->busy_hysteresis_db);
+    fprintf(f, "busy_on_debounce_ms = %d\n", cfg->busy_on_debounce_ms);
+    fprintf(f, "busy_hang_ms = %d\n", cfg->busy_hang_ms);
 
     fprintf(f, "\n[audio]\n");
     fprintf(f, "tx_gain_db = %.2f\n", cfg->tx_gain_db);

--- a/common/cfg_utils.h
+++ b/common/cfg_utils.h
@@ -56,6 +56,11 @@
 #define CFG_KEY_ARQ_KEEPALIVE_MISS_LIMIT      "arq:keepalive_miss_limit"
 #define CFG_KEY_ARQ_PEER_PAYLOAD_HOLD_S       "arq:peer_payload_hold_s"
 #define CFG_KEY_ARQ_STARTUP_MAX_S             "arq:startup_max_s"
+#define CFG_KEY_BUSY_DETECT                   "channel:busy_detect"
+#define CFG_KEY_BUSY_THRESHOLD_DB             "channel:busy_threshold_db"
+#define CFG_KEY_BUSY_HYSTERESIS_DB            "channel:busy_hysteresis_db"
+#define CFG_KEY_BUSY_ON_DEBOUNCE_MS           "channel:busy_on_debounce_ms"
+#define CFG_KEY_BUSY_HANG_MS                  "channel:busy_hang_ms"
 
 /* Holds all values read from the init configuration file */
 typedef struct {
@@ -109,6 +114,16 @@ typedef struct {
     int      tnc_buffer_report_ms;  /* BUFFER report interval on the TNC
                                     * control port. Default 1000, clamped
                                     * 100..10000.                          */
+    bool     busy_detect;           /* Channel-busy detector on/off. Default
+                                    * false (opt-in). Emits VARA "BUSY ON/OFF". */
+    int      busy_threshold_db;     /* Passband peak dB above noise floor to
+                                    * call BUSY. Default 10, clamped 3..40.  */
+    int      busy_hysteresis_db;    /* Release hysteresis in dB. Default 3,
+                                    * clamped 0..20.                          */
+    int      busy_on_debounce_ms;   /* Sustain above threshold before BUSY.
+                                    * Default 300, clamped 0..5000.           */
+    int      busy_hang_ms;          /* Sustain below release before CLEAR.
+                                    * Default 1500, clamped 0..10000.         */
 } mercury_config;
 
 /* Load configuration from an INI file into |cfg|.

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -1294,6 +1294,15 @@ void tnc_send_sn(float snr)
     (void)tnc_queue_line(buffer);
 }
 
+void tnc_send_busy(bool busy)
+{
+    /* VARA-compatible channel-occupancy notification: hosts (VarAC, BPQ32,
+     * Winlink) already understand "BUSY ON" / "BUSY OFF".  Edge-triggered by
+     * the caller (the channel-busy detector), so this only fires on a real
+     * CLEAR<->BUSY transition. */
+    (void)tnc_queue_line(busy ? "BUSY ON\r" : "BUSY OFF\r");
+}
+
 void tnc_send_bitrate(uint32_t speed_level, uint32_t bps)
 {
     char buffer[64];

--- a/data_interfaces/tcp_interfaces.h
+++ b/data_interfaces/tcp_interfaces.h
@@ -23,6 +23,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #define DEFAULT_ARQ_PORT 8300
 #define DEFAULT_BROADCAST_PORT 8100
@@ -53,6 +54,7 @@ void tnc_send_cqframe(const char *source_call, int bw_hz);
 void tnc_send_disconnected();
 void tnc_send_buffer(uint32_t bytes);
 void tnc_send_sn(float snr);
+void tnc_send_busy(bool busy);
 void tnc_send_bitrate(uint32_t speed_level, uint32_t bps);
 
 // Getters for cached telemetry (thread-safe reads of last reported values)

--- a/docs/TNC.md
+++ b/docs/TNC.md
@@ -340,6 +340,8 @@ These are sent on the **control port** without a preceding command.
 | `PTT OFF\r`                                 | Radio transmitter unkeyed                    |
 | `BUFFER <bytes>\r`                          | TX buffer level update (periodic)            |
 | `SN <value>\r`                              | SNR update                                   |
+| `BUSY ON\r`                                 | Channel became occupied (busy detector)      |
+| `BUSY OFF\r`                                | Channel became clear (busy detector)         |
 | `BITRATE (<level>) <bps> BPS\r`            | Throughput update                            |
 | `IAMALIVE\r`                                | Heartbeat (sent periodically while idle)     |
 
@@ -375,6 +377,19 @@ the session, and `<destcall>` is always the station that was called.
 Sent when Mercury decodes a compact DATAC13 CQ frame on the air.
 `<sourcecall>` is the transmitting station and `<bandwidth>` is the BW token
 advertised inside that CQ frame (`500`, `2300`, or `2750`).
+
+### BUSY ON / BUSY OFF
+
+Emitted by the optional channel-busy (occupancy) detector when it observes the
+HF channel transition between clear and occupied, using VARA's exact wording so
+existing VARA-compatible hosts (VarAC, BPQ32, Winlink) act on them unchanged.
+Edge-triggered: `BUSY ON\r` on clear→busy, `BUSY OFF\r` on busy→clear.
+
+The detector is **disabled by default** and enabled via the `[channel]` section
+of `mercury.ini` (`busy_detect = true`); its sensitivity/timing knobs
+(`busy_threshold_db`, `busy_hysteresis_db`, `busy_on_debounce_ms`,
+`busy_hang_ms`) typically need on-air tuning per band/noise environment. When
+disabled, these notifications are never sent. See `mercury.ini.example`.
 
 ### DISCONNECTED
 

--- a/main.c
+++ b/main.c
@@ -262,6 +262,11 @@ int main(int argc, char *argv[])
             arq_set_peer_payload_hold_s(mcfg.peer_payload_hold_s);
             arq_set_startup_max_s(mcfg.startup_max_s);
             modem_set_tx_gain(powf(10.0f, mcfg.tx_gain_db / 20.0f));
+            modem_set_busy_cfg((float)mcfg.busy_threshold_db,
+                               (float)mcfg.busy_hysteresis_db,
+                               (uint32_t)mcfg.busy_on_debounce_ms,
+                               (uint32_t)mcfg.busy_hang_ms);
+            modem_set_busy_detect_enabled(mcfg.busy_detect);
         }
     }
 

--- a/mercury.ini.example
+++ b/mercury.ini.example
@@ -140,6 +140,29 @@ peer_payload_hold_s = 15
 ; handshake (e.g. UUCP) times out before the first data frames get through.
 startup_max_s = 10
 
+[channel]
+; Channel-busy (occupancy) detector.  When enabled, Mercury classifies the HF
+; channel as busy/clear from the RX spectrum and reports transitions to the host
+; with VARA-compatible "BUSY ON" / "BUSY OFF" notifications on the control port.
+; Disabled by default (opt-in); thresholds typically need on-air tuning.
+busy_detect = false
+
+; Passband peak level, in dB above the tracked noise floor, required to call the
+; channel BUSY (default 10, range 3..40).  Lower = more sensitive.
+busy_threshold_db = 10
+
+; Release hysteresis in dB: the channel is only declared CLEAR once the peak
+; falls below (busy_threshold_db - this) (default 3, range 0..20).
+busy_hysteresis_db = 3
+
+; Milliseconds the peak must stay above threshold before asserting BUSY
+; (debounce against transients; default 300, range 0..5000).
+busy_on_debounce_ms = 300
+
+; Milliseconds the peak must stay below the release level before declaring CLEAR
+; (hang time; default 1500, range 0..10000).
+busy_hang_ms = 1500
+
 [tnc]
 ; IAMALIVE interval sent on the TNC control port to tell connected clients
 ; the TNC is still alive. Valid range: 5..600 seconds. (default: 60)

--- a/modem/Makefile
+++ b/modem/Makefile
@@ -4,13 +4,16 @@ CFLAGS = $(COMMON_CFLAGS) -Wno-strict-overflow -fPIC -I. -I../common -I../modem 
 
 .PHONY: all freedv 
 
-all: freedv modem.o framer.o
+all: freedv modem.o framer.o channel_busy.o
 
 freedv:
 	$(MAKE) -C freedv
 
 modem.o: modem.c modem.h
 	$(CC) $(CFLAGS) -c modem.c
+
+channel_busy.o: channel_busy.c channel_busy.h
+	$(CC) $(CFLAGS) -c channel_busy.c
 
 framer.o: framer.c framer.h
 	$(CC) $(CFLAGS) -c framer.c

--- a/modem/channel_busy.c
+++ b/modem/channel_busy.c
@@ -1,0 +1,120 @@
+/* HERMES Modem — channel-busy (occupancy) detector
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * See channel_busy.h for the interface contract.  The classifier keeps a
+ * slowly-tracked passband noise floor and asserts BUSY when the passband peak
+ * rises threshold_db above that floor for on_debounce_ms, releasing only after
+ * it falls below (threshold_db - hysteresis_db) for hang_ms.
+ */
+#include "channel_busy.h"
+
+#include <math.h>
+#include <stddef.h>
+
+/* Noise-floor tracker asymmetric EMA: fall fast toward a lower reading (so a
+ * genuinely quiet channel re-establishes a low floor quickly), rise slowly
+ * toward a higher reading (so a sustained signal does NOT get absorbed into the
+ * floor and mask itself).  Coefficients are per-update; the RX spectrum arrives
+ * ~20x/s so these give multi-second rise, sub-second fall. */
+#define BUSY_FLOOR_FALL 0.20f   /* toward a new, lower minimum   */
+#define BUSY_FLOOR_RISE 0.01f   /* toward a new, higher level    */
+
+void channel_busy_init(busy_state_t *st)
+{
+    if (!st) return;
+    st->busy           = false;
+    st->noise_floor_db = 0.0f;
+    st->inited         = false;
+    st->above_since_ms = 0;
+    st->below_since_ms = 0;
+}
+
+/* Map a passband edge frequency to a spectrum bin index. Real-input FFT: bin i
+ * is centred at i * (Fs/2)/nbins, so bin = f / ((Fs/2)/nbins). */
+static int freq_to_bin(int freq_hz, int nbins, int sample_rate_hz)
+{
+    if (sample_rate_hz <= 0 || nbins <= 0) return 0;
+    float hz_per_bin = (float)(sample_rate_hz / 2) / (float)nbins;
+    if (hz_per_bin <= 0.0f) return 0;
+    int bin = (int)(freq_hz / hz_per_bin);
+    if (bin < 0) bin = 0;
+    if (bin > nbins - 1) bin = nbins - 1;
+    return bin;
+}
+
+bool channel_busy_update(busy_state_t *st, const busy_cfg_t *cfg,
+                         const float *spectrum_dB, int nbins,
+                         int sample_rate_hz, uint64_t now_ms,
+                         bool *out_busy)
+{
+    if (!st || !cfg || !spectrum_dB || nbins <= 0) {
+        if (out_busy && st) *out_busy = st->busy;
+        return false;
+    }
+
+    int lo = freq_to_bin(BUSY_PASSBAND_LO_HZ, nbins, sample_rate_hz);
+    int hi = freq_to_bin(BUSY_PASSBAND_HI_HZ, nbins, sample_rate_hz);
+    if (hi <= lo) { if (out_busy) *out_busy = st->busy; return false; }
+
+    /* Passband statistics: peak (occupancy evidence) and median-ish low value
+     * (noise-floor candidate).  A running min over the passband is a robust,
+     * allocation-free proxy for the quiet-bin level. */
+    float peak = -1e9f;
+    float minv =  1e9f;
+    for (int i = lo; i <= hi; i++) {
+        float v = spectrum_dB[i];
+        if (v > peak) peak = v;
+        if (v < minv) minv = v;
+    }
+
+    /* Seed / track the noise floor from the passband minimum (quiet bins). */
+    if (!st->inited) {
+        st->noise_floor_db = minv;
+        st->inited = true;
+    } else if (minv < st->noise_floor_db) {
+        st->noise_floor_db += BUSY_FLOOR_FALL * (minv - st->noise_floor_db);
+    } else {
+        st->noise_floor_db += BUSY_FLOOR_RISE * (minv - st->noise_floor_db);
+    }
+
+    float excess       = peak - st->noise_floor_db;
+    float assert_level = cfg->threshold_db;
+    float release_level = cfg->threshold_db - cfg->hysteresis_db;
+
+    bool changed = false;
+
+    if (!st->busy) {
+        /* Currently CLEAR — look for a sustained rise above the assert level. */
+        if (excess >= assert_level) {
+            if (st->above_since_ms == 0)
+                st->above_since_ms = now_ms ? now_ms : 1;  /* 0 is the "unset" sentinel */
+            if (now_ms - st->above_since_ms >= cfg->on_debounce_ms) {
+                st->busy = true;
+                st->above_since_ms = 0;
+                st->below_since_ms = 0;
+                changed = true;
+            }
+        } else {
+            st->above_since_ms = 0;  /* dipped back down — restart debounce */
+        }
+    } else {
+        /* Currently BUSY — release only after a sustained drop below release. */
+        if (excess < release_level) {
+            if (st->below_since_ms == 0)
+                st->below_since_ms = now_ms ? now_ms : 1;
+            if (now_ms - st->below_since_ms >= cfg->hang_ms) {
+                st->busy = false;
+                st->above_since_ms = 0;
+                st->below_since_ms = 0;
+                changed = true;
+            }
+        } else {
+            st->below_since_ms = 0;  /* still active — restart hang timer */
+        }
+    }
+
+    if (out_busy) *out_busy = st->busy;
+    return changed;
+}

--- a/modem/channel_busy.h
+++ b/modem/channel_busy.h
@@ -1,0 +1,70 @@
+/* HERMES Modem — channel-busy (occupancy) detector
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * A VARA-style "channel busy" detector: it classifies the HF channel as BUSY
+ * or CLEAR from the RX power spectrum (the same FFT already produced for the
+ * UI waterfall), using a tracked noise floor plus hysteresis and hang/debounce
+ * timing to avoid flapping.  The host is notified with VARA's exact
+ * "BUSY ON" / "BUSY OFF" syntax (see tnc_send_busy()).
+ *
+ * The classifier is a pure, clock-injected state machine so it is unit-testable
+ * without any audio hardware.
+ */
+#ifndef CHANNEL_BUSY_H
+#define CHANNEL_BUSY_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* Occupancy band: the SSB passband we actually care about (Hz).  Energy
+ * outside this range (DC/LF artefacts, out-of-passband splatter) is ignored. */
+#define BUSY_PASSBAND_LO_HZ 300
+#define BUSY_PASSBAND_HI_HZ 2700
+
+typedef struct {
+    float    threshold_db;     /* BUSY when passband peak >= floor + threshold_db     */
+    float    hysteresis_db;    /* CLEAR only when peak < floor + threshold - hyst      */
+    uint32_t on_debounce_ms;   /* peak must stay above for this long to assert BUSY    */
+    uint32_t hang_ms;          /* peak must stay below for this long to release BUSY   */
+} busy_cfg_t;
+
+typedef struct {
+    bool     busy;             /* current debounced occupancy state                    */
+    float    noise_floor_db;   /* slowly-tracked passband noise floor                  */
+    bool     inited;           /* false until the first update seeds the floor         */
+    uint64_t above_since_ms;   /* 0 = not currently above the assert threshold         */
+    uint64_t below_since_ms;   /* 0 = not currently below the release threshold        */
+} busy_state_t;
+
+/* Sensible defaults for HF NVIS.  Detector is opt-in (disabled unless a config
+ * enables it); these are the values used when it is on and unconfigured. */
+static const busy_cfg_t BUSY_CFG_DEFAULT = {
+    .threshold_db   = 10.0f,
+    .hysteresis_db  = 3.0f,
+    .on_debounce_ms = 300,
+    .hang_ms        = 1500,
+};
+
+/* Reset a detector to the pre-seed state. */
+void channel_busy_init(busy_state_t *st);
+
+/* Feed one RX power-spectrum frame.
+ *
+ *   spectrum_dB[0..nbins-1] : magnitude spectrum in dB; bin i is centred at
+ *                             frequency i * (sample_rate_hz/2) / nbins
+ *                             (real-input FFT, bins span 0 .. Fs/2).
+ *   now_ms                  : monotonic milliseconds (injected for testability).
+ *
+ * Updates the tracked noise floor and the debounced BUSY/CLEAR state.  Returns
+ * true iff the debounced state CHANGED on this call, with *out_busy set to the
+ * new state (edge-triggered — matches VARA's BUSY ON/OFF emission).  Returns
+ * false (and leaves *out_busy at the current state) when nothing changed or the
+ * inputs are unusable. */
+bool channel_busy_update(busy_state_t *st, const busy_cfg_t *cfg,
+                         const float *spectrum_dB, int nbins,
+                         int sample_rate_hz, uint64_t now_ms,
+                         bool *out_busy);
+
+#endif /* CHANNEL_BUSY_H */

--- a/modem/modem.c
+++ b/modem/modem.c
@@ -37,6 +37,7 @@
 #include "../datalink_arq/arq_modem.h"
 #include "../datalink_arq/arq_protocol.h"
 #include "tcp_interfaces.h"
+#include "channel_busy.h"
 #include "freedv_api.h"
 #include "fsk.h"
 #include "ldpc_codes.h"
@@ -161,6 +162,44 @@ static atomic_bool g_spectrum_enabled = true;
 void modem_set_spectrum_enabled(bool enabled)
 {
     atomic_store_explicit(&g_spectrum_enabled, enabled, memory_order_relaxed);
+}
+
+/* --- Channel-busy (occupancy) detector --------------------------------------
+ * VARA-style "channel busy" detection off the RX spectrum FFT.  Opt-in
+ * (disabled by default); when enabled the RX worker classifies occupancy and
+ * emits VARA-compatible "BUSY ON"/"BUSY OFF" to the host on each transition.
+ * g_channel_busy is the latched debounced state for the TX-initiation gate. */
+static atomic_bool  g_busy_enabled = false;
+static atomic_bool  g_channel_busy = false;
+static busy_cfg_t   g_busy_cfg     = { .threshold_db = 10.0f, .hysteresis_db = 3.0f,
+                                       .on_debounce_ms = 300, .hang_ms = 1500 };
+static pthread_mutex_t g_busy_cfg_lock = PTHREAD_MUTEX_INITIALIZER;
+/* Owned solely by the RX worker thread — no lock needed. */
+static busy_state_t g_busy_state   = { .busy = false, .noise_floor_db = 0.0f,
+                                       .inited = false, .above_since_ms = 0,
+                                       .below_since_ms = 0 };
+
+void modem_set_busy_detect_enabled(bool enabled)
+{
+    atomic_store_explicit(&g_busy_enabled, enabled, memory_order_relaxed);
+    if (!enabled)
+        atomic_store_explicit(&g_channel_busy, false, memory_order_relaxed);
+}
+
+void modem_set_busy_cfg(float threshold_db, float hysteresis_db,
+                        uint32_t on_debounce_ms, uint32_t hang_ms)
+{
+    pthread_mutex_lock(&g_busy_cfg_lock);
+    g_busy_cfg.threshold_db   = threshold_db;
+    g_busy_cfg.hysteresis_db  = hysteresis_db;
+    g_busy_cfg.on_debounce_ms = on_debounce_ms;
+    g_busy_cfg.hang_ms        = hang_ms;
+    pthread_mutex_unlock(&g_busy_cfg_lock);
+}
+
+bool modem_channel_busy(void)
+{
+    return atomic_load_explicit(&g_channel_busy, memory_order_relaxed);
 }
 
 static uint64_t monotonic_ms(void)
@@ -1638,10 +1677,12 @@ void *rx_thread(void *g_modem)
                                     metrics.frame_decoded);
         }
 
-        /* --- Update spectrum buffer for UI waterfall display --- */
-        /* Throttle FFT to match the 50 ms publish interval (~20 fps);
-         * skip entirely when no UI consumer exists (-W or UI disabled). */
-        if (atomic_load_explicit(&g_spectrum_enabled, memory_order_relaxed))
+        /* --- Update spectrum buffer for UI waterfall + channel-busy detect --- */
+        /* Throttle FFT to match the 50 ms publish interval (~20 fps).  The FFT
+         * is computed when either the UI waterfall (-W/UI) OR the channel-busy
+         * detector needs it, so a headless station can still detect occupancy. */
+        bool busy_on = atomic_load_explicit(&g_busy_enabled, memory_order_relaxed);
+        if (atomic_load_explicit(&g_spectrum_enabled, memory_order_relaxed) || busy_on)
         {
             uint64_t now_ms = monotonic_ms();
             if (now_ms >= spectrum_next_ms)
@@ -1661,6 +1702,11 @@ void *rx_thread(void *g_modem)
                     rx_fdm[i].real = (float)capture_i16[i];
                     rx_fdm[i].imag = 0.0f;
                 }
+
+                /* Snapshot of the spectrum + sample rate for out-of-lock use by
+                 * the busy classifier (avoids holding g_spectrum_lock across it). */
+                float busy_spec[MODEM_STATS_NSPEC];
+                int   busy_sr = 8000;
 
                 pthread_mutex_lock(&g_spectrum_lock);
                 if (!g_spectrum_stats_inited)
@@ -1682,7 +1728,33 @@ void *rx_thread(void *g_modem)
                           spec_nin, g_spectrum_sample_rate, g_rx_spectrum_dB[0]);
                     spectrum_first_log = false;
                 }
+                if (busy_on)
+                {
+                    memcpy(busy_spec, g_rx_spectrum_dB, sizeof(busy_spec));
+                    busy_sr = g_spectrum_sample_rate;
+                }
                 pthread_mutex_unlock(&g_spectrum_lock);
+
+                /* Channel-busy classification (RX-only: never while we key). */
+                if (busy_on && arq_get_trx() != TX)
+                {
+                    busy_cfg_t cfg;
+                    pthread_mutex_lock(&g_busy_cfg_lock);
+                    cfg = g_busy_cfg;
+                    pthread_mutex_unlock(&g_busy_cfg_lock);
+
+                    bool now_busy = false;
+                    if (channel_busy_update(&g_busy_state, &cfg, busy_spec,
+                                            MODEM_STATS_NSPEC, busy_sr, now_ms,
+                                            &now_busy))
+                    {
+                        atomic_store_explicit(&g_channel_busy, now_busy,
+                                              memory_order_relaxed);
+                        tnc_send_busy(now_busy);
+                        HLOGI("modem-rx", "channel %s (floor=%.1f dB)",
+                              now_busy ? "BUSY" : "CLEAR", g_busy_state.noise_floor_db);
+                    }
+                }
             }
         }
 

--- a/modem/modem.h
+++ b/modem/modem.h
@@ -64,6 +64,15 @@ int modem_get_rx_spectrum(float *out_dB, int max_bins);
 /* Enable/disable the RX spectrum FFT (skipped when no UI consumes it). */
 void modem_set_spectrum_enabled(bool enabled);
 
+/* Channel-busy (occupancy) detector — VARA-style "BUSY ON"/"BUSY OFF".
+ * Opt-in: disabled by default.  When enabled, the RX worker classifies the
+ * channel from the spectrum FFT and reports transitions to the host. */
+void modem_set_busy_detect_enabled(bool enabled);
+void modem_set_busy_cfg(float threshold_db, float hysteresis_db,
+                        uint32_t on_debounce_ms, uint32_t hang_ms);
+/* Latched debounced occupancy state, for an optional TX-initiation gate. */
+bool modem_channel_busy(void);
+
 // TX audio gain (linear multiplier on modulator output samples).
 // Default 1.0f = no change. Hot-tunable from any thread; the modulator
 // reads it once per burst.  Applied with int32 saturation, so any value

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -44,7 +44,7 @@ ARQ_STUBS = datalink_arq/arq_test_stubs.c
 # Test executables
 TEST_BINS = test_ring_buffer test_arq_protocol test_arq_timing test_arq_fsm \
             test_tcp_interfaces test_resampler test_arq_olla test_arq_sim \
-            test_arq_conn test_cfg_utils test_arq_tnc
+            test_arq_conn test_cfg_utils test_arq_tnc test_channel_busy
 
 .PHONY: all test clean
 
@@ -119,6 +119,10 @@ test_cfg_utils: common/test_cfg_utils.c $(UNITY_SRC) \
 # ARQ→TNC seam test (standalone TU, no threads/bus)
 test_arq_tnc: datalink_arq/test_arq_tnc.c $(UNITY_SRC) ../datalink_arq/arq_tnc.c
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+# Channel-busy classifier test (pure state machine, virtual clock)
+test_channel_busy: modem/test_channel_busy.c $(UNITY_SRC) ../modem/channel_busy.c
+	$(CC) $(CFLAGS) -I../modem -o $@ $^ $(LDFLAGS) -lm
 
 clean:
 	rm -f $(TEST_BINS)

--- a/tests/common/test_cfg_utils.c
+++ b/tests/common/test_cfg_utils.c
@@ -45,6 +45,11 @@ void test_defaults_match_constants(void)
     TEST_ASSERT_EQUAL_INT(5,   c.keepalive_miss_limit);
     TEST_ASSERT_EQUAL_INT(15,  c.peer_payload_hold_s);
     TEST_ASSERT_EQUAL_INT(10,  c.startup_max_s);
+    TEST_ASSERT_FALSE(c.busy_detect);
+    TEST_ASSERT_EQUAL_INT(10,   c.busy_threshold_db);
+    TEST_ASSERT_EQUAL_INT(3,    c.busy_hysteresis_db);
+    TEST_ASSERT_EQUAL_INT(300,  c.busy_on_debounce_ms);
+    TEST_ASSERT_EQUAL_INT(1500, c.busy_hang_ms);
 }
 
 /* Set non-default values, write, read back, assert preserved. */
@@ -62,6 +67,11 @@ void test_arq_tunables_roundtrip(void)
     w.keepalive_miss_limit        = 8;
     w.peer_payload_hold_s         = 25;
     w.startup_max_s               = 20;
+    w.busy_detect                 = true;
+    w.busy_threshold_db           = 14;
+    w.busy_hysteresis_db          = 5;
+    w.busy_on_debounce_ms         = 500;
+    w.busy_hang_ms                = 2000;
     TEST_ASSERT_TRUE(cfg_write(&w, TMP));
 
     mercury_config r;
@@ -77,6 +87,11 @@ void test_arq_tunables_roundtrip(void)
     TEST_ASSERT_EQUAL_INT(8,    r.keepalive_miss_limit);
     TEST_ASSERT_EQUAL_INT(25,   r.peer_payload_hold_s);
     TEST_ASSERT_EQUAL_INT(20,   r.startup_max_s);
+    TEST_ASSERT_TRUE(r.busy_detect);
+    TEST_ASSERT_EQUAL_INT(14,   r.busy_threshold_db);
+    TEST_ASSERT_EQUAL_INT(5,    r.busy_hysteresis_db);
+    TEST_ASSERT_EQUAL_INT(500,  r.busy_on_debounce_ms);
+    TEST_ASSERT_EQUAL_INT(2000, r.busy_hang_ms);
 }
 
 /* Out-of-range INI values are rejected (field keeps its pre-read default). */

--- a/tests/modem/test_channel_busy.c
+++ b/tests/modem/test_channel_busy.c
@@ -1,0 +1,157 @@
+/* Deterministic unit tests for the channel-busy (occupancy) classifier.
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Drives channel_busy_update() with synthetic 512-bin spectra on a virtual
+ * clock (no audio, no threads).  Verifies: stays CLEAR on noise; asserts BUSY
+ * only after the on-debounce; releases only after the hang time; and does not
+ * flap on a borderline signal.
+ */
+#include "unity.h"
+#include "channel_busy.h"
+
+#include <string.h>
+
+#define NBINS 512
+#define FS    8000            /* bin i centred at i*(FS/2)/NBINS = i*7.8125 Hz  */
+
+static busy_cfg_t   cfg;
+static busy_state_t st;
+static float        spec[NBINS];
+
+void setUp(void)
+{
+    cfg = BUSY_CFG_DEFAULT;   /* threshold 10 dB, hyst 3, on 300 ms, hang 1500  */
+    channel_busy_init(&st);
+}
+void tearDown(void) {}
+
+/* Fill the whole spectrum with a flat noise level (dB). */
+static void fill_noise(float noise_db)
+{
+    for (int i = 0; i < NBINS; i++) spec[i] = noise_db;
+}
+
+/* Add an in-passband signal (a peak `signal_db` at ~1500 Hz => bin 192). */
+static void add_passband_signal(float signal_db)
+{
+    spec[192] = signal_db;
+    spec[191] = signal_db - 2.0f;
+    spec[193] = signal_db - 2.0f;
+}
+
+/* Feed one spectrum frame; returns true if the debounced state changed. */
+static bool feed(uint64_t now_ms, bool *busy_out)
+{
+    return channel_busy_update(&st, &cfg, spec, NBINS, FS, now_ms, busy_out);
+}
+
+/* --- Tests --------------------------------------------------------------- */
+
+/* Flat noise only: never goes BUSY. */
+void test_noise_stays_clear(void)
+{
+    bool busy = true;
+    for (uint64_t t = 0; t <= 5000; t += 50) {
+        fill_noise(-100.0f);
+        bool changed = feed(t, &busy);
+        TEST_ASSERT_FALSE(changed);
+        TEST_ASSERT_FALSE(busy);
+    }
+}
+
+/* A strong in-band signal asserts BUSY, but only after on_debounce_ms. */
+void test_signal_asserts_busy_after_debounce(void)
+{
+    bool busy = false;
+
+    /* Seed the noise floor first (a few quiet frames). */
+    for (uint64_t t = 0; t < 500; t += 50) { fill_noise(-100.0f); feed(t, &busy); }
+    TEST_ASSERT_FALSE(busy);
+
+    /* Signal 25 dB over floor appears at t=500; on_debounce is 300 ms. */
+    bool became_busy = false;
+    uint64_t busy_at = 0;
+    for (uint64_t t = 500; t <= 1200; t += 50) {
+        fill_noise(-100.0f);
+        add_passband_signal(-75.0f);   /* 25 dB above the -100 floor */
+        if (feed(t, &busy) && busy) { became_busy = true; busy_at = t; break; }
+    }
+    TEST_ASSERT_TRUE(became_busy);
+    /* First crossing at t=500 starts debounce; BUSY asserts >= 300 ms later. */
+    TEST_ASSERT_GREATER_OR_EQUAL_UINT64(800, busy_at);
+}
+
+/* Once BUSY, a brief signal drop does NOT immediately clear (hang time). */
+void test_busy_holds_through_hang(void)
+{
+    bool busy = false;
+    /* Drive to BUSY. */
+    for (uint64_t t = 0; t <= 1500; t += 50) {
+        fill_noise(-100.0f);
+        if (t >= 400) add_passband_signal(-70.0f);
+        feed(t, &busy);
+    }
+    TEST_ASSERT_TRUE(busy);
+
+    /* Signal gone from t=1500; hang is 1500 ms => must stay BUSY until ~3000. */
+    bool cleared_early = false;
+    for (uint64_t t = 1550; t < 2900; t += 50) {
+        fill_noise(-100.0f);
+        bool changed = feed(t, &busy);
+        if (changed && !busy) { cleared_early = true; break; }
+    }
+    TEST_ASSERT_FALSE(cleared_early);
+    TEST_ASSERT_TRUE(busy);
+
+    /* After the full hang elapses it finally clears. */
+    bool cleared = false;
+    for (uint64_t t = 2900; t < 3600; t += 50) {
+        fill_noise(-100.0f);
+        if (feed(t, &busy) && !busy) { cleared = true; break; }
+    }
+    TEST_ASSERT_TRUE(cleared);
+    TEST_ASSERT_FALSE(busy);
+}
+
+/* A signal that hovers right at the threshold must not rapidly flap. */
+void test_borderline_does_not_flap(void)
+{
+    bool busy = false;
+    int transitions = 0;
+
+    for (uint64_t t = 0; t <= 8000; t += 50) {
+        fill_noise(-100.0f);
+        /* Oscillate the peak around ~threshold (floor -100 + ~10 dB). */
+        float peak = (((t / 50) % 2) == 0) ? -90.5f : -89.5f;
+        add_passband_signal(peak);
+        if (feed(t, &busy)) transitions++;
+    }
+    /* Hysteresis + debounce/hang must keep this from chattering every frame. */
+    TEST_ASSERT_LESS_THAN_INT(4, transitions);
+}
+
+/* Out-of-passband energy (below 300 Hz / above 2700 Hz) is ignored. */
+void test_out_of_band_energy_ignored(void)
+{
+    bool busy = true;
+    for (uint64_t t = 0; t <= 3000; t += 50) {
+        fill_noise(-100.0f);
+        spec[5]   = -50.0f;   /* ~39 Hz  — below passband  */
+        spec[400] = -50.0f;   /* ~3125 Hz — above passband */
+        feed(t, &busy);
+    }
+    TEST_ASSERT_FALSE(busy);
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_noise_stays_clear);
+    RUN_TEST(test_signal_asserts_busy_after_debounce);
+    RUN_TEST(test_busy_holds_through_hang);
+    RUN_TEST(test_borderline_does_not_flap);
+    RUN_TEST(test_out_of_band_energy_ignored);
+    return UNITY_END();
+}


### PR DESCRIPTION
Mercury had no channel-occupancy / carrier-sense: ptt_on() keyed the radio unconditionally, so a station could transmit straight over another user on frequency. VARA HF reports channel occupancy to the host as async "BUSY ON" / "BUSY OFF" lines that VARA-speaking hosts (VarAC, BPQ32, Winlink) already act on.

Add an opt-in occupancy detector that reuses the RX spectrum FFT already produced for the UI waterfall and reports transitions with VARA's exact syntax, so hosts get a busy indicator with zero host-side changes.

- modem/channel_busy.{c,h}: pure, clock-injected classifier. Tracks a passband (300-2700 Hz) noise floor (asymmetric EMA: fall fast, rise slow so a signal can't mask itself), asserts BUSY when the passband peak sits >= threshold_db above the floor for on_debounce_ms, releases only after it drops below (threshold - hysteresis) for hang_ms. Edge-triggered output.
- modem/modem.c: compute the FFT when the UI waterfall OR the busy detector is enabled (headless stations have no UI), classify out-of-lock, skip while we key (RX-only), and emit transitions. New setters + modem_channel_busy().
- data_interfaces/tcp_interfaces.c: tnc_send_busy() emits "BUSY ON\r"/"BUSY OFF\r" via the same tnc_queue_line() path as SN/PTT notifications.
- Config: new [channel] INI section (busy_detect off by default, busy_threshold_db / busy_hysteresis_db / busy_on_debounce_ms / busy_hang_ms), wired through cfg_utils + main.c, documented in mercury.ini.example and TNC.md.
- Tests: test_channel_busy (5 deterministic cases: noise stays clear, BUSY after debounce, hold through hang, no flapping on borderline, out-of-band ignored)
  + extended test_cfg_utils for the new keys.

Detector OFF by default => zero behavioral change (no extra FFT cost when both UI-spectrum and busy detection are disabled). Thresholds expected to need on-air tuning. TX-initiation defer (busy_defer_tx) intentionally left for a follow-up so this change is report-only and does not touch ARQ event-loop timing.

Clean build (no warnings); full unit suite green (incl. 5 new channel-busy tests).