### PR TITLE
ui: derive WebSocket URL port from the served page, not a hardcoded 10000

### DIFF
--- a/gui_interface/websocket/web/mercury.html
+++ b/gui_interface/websocket/web/mercury.html
@@ -1074,8 +1074,12 @@ document.getElementById("wsPort").addEventListener("keydown", function(e) {
  * =========================================================================*/
 
 (function init() {
-  // Set default host from current location
-  document.getElementById("wsHost").value = "127.0.0.1";
+  // Default the host and port from the location this page was served from, so
+  // the WebSocket connects back to the same Mercury instance — including when
+  // the UI port was overridden on the command line (-U).  Fall back to the
+  // historical defaults only when the page is opened without a host/port.
+  document.getElementById("wsHost").value = location.hostname || "127.0.0.1";
+  document.getElementById("wsPort").value = location.port || "10000";
 
   // Auto-connect
   autoReconnect = true;

--- a/gui_interface/websocket/web/test.html
+++ b/gui_interface/websocket/web/test.html
@@ -18,7 +18,9 @@
   <script>
     var host = self.location.hostname;
     var scheme = self.location.protocol === "https:" ? "wss://" : "ws://";
-    document.getElementById("url").value = scheme + host + ":10000/websocket";
+    // Use the port this page was served from (matches Mercury's -U override).
+    var port = self.location.port || "10000";
+    document.getElementById("url").value = scheme + host + ":" + port + "/websocket";
 </script>
 
   <script>

--- a/gui_interface/websocket/web/waterfall.html
+++ b/gui_interface/websocket/web/waterfall.html
@@ -293,7 +293,10 @@ function updateFreqAxis() {
 (function() {
   const host = location.hostname || "localhost";
   const scheme = location.protocol === "https:" ? "wss://" : "ws://";
-  document.getElementById("url").value = scheme + host + ":10000/websocket";
+  // Use the port this page was served from (matches Mercury's -U override),
+  // falling back to the default only when the page is opened without one.
+  const port = location.port || "10000";
+  document.getElementById("url").value = scheme + host + ":" + port + "/websocket";
 })();
 
 // --- Connect / Disconnect ---


### PR DESCRIPTION
Fixes #116.  Running several Mercury instances from one config file and overriding the UI port per instance with -U left every waterfall/UI page building its WebSocket URL against the hardcoded :10000, so the URL pointed at the wrong (or first) instance and had to be edited by hand.

The same server serves both the HTML page and the /websocket endpoint on the -U port, so location.port on the loaded page is exactly the effective UI port. Use it (falling back to "10000" only when absent):

- waterfall.html, test.html: build the default WS URL with location.port.
- mercury.html: the init() now seeds the Host/Port inputs from location.hostname / location.port (it previously hardcoded 127.0.0.1 and left the port field at 10000), so auto-connect targets the same instance, including when reached remotely.

Web assets are served from disk (mg_http_serve_dir), so this is an HTML/JS-only change with no rebuild required.