### PR TITLE
arq: don't let data_retry_slots inflate CALL/ACCEPT retries (fix ACCEPTING linger)

### DIFF
--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -1117,6 +1117,20 @@ void arq_set_retry_slots(int slots)
           atomic_load(&arq_data_retry_slots), atomic_load(&arq_disconnect_retry_slots));
 }
 
+void arq_set_data_retry_slots(int slots)
+{
+    /* Data-plane only: how many times a DATA frame is retried before the
+     * mode-downgrade cycle.  Deliberately does NOT touch call/accept slots —
+     * connection setup wants to give up quickly (short CALL/ACCEPT defaults),
+     * whereas the data plane wants persistence.  The RETRIES TNC command
+     * (arq_set_retry_slots) is the explicit way to widen all three at runtime. */
+    if (slots <= 0)
+        atomic_store(&arq_data_retry_slots, ARQ_DATA_RETRY_SLOTS_DEFAULT);
+    else
+        atomic_store(&arq_data_retry_slots, slots);
+    HLOGI(LOG_COMP, "Data retry slots: %d", atomic_load(&arq_data_retry_slots));
+}
+
 void arq_set_channel_guard_ms(int ms)
 {
     if (ms < 200)  ms = (ms <= 0) ? ARQ_CHANNEL_GUARD_MS_DEFAULT : 200;

--- a/datalink_arq/arq.h
+++ b/datalink_arq/arq.h
@@ -329,6 +329,11 @@ void reset_arq_info(arq_info *arq_conn);
  */
 void arq_set_retry_slots(int slots);
 
+/* Set only the DATA-frame retry slots (leaves CALL/ACCEPT/DISCONNECT alone).
+ * Used by the startup config so a large data_retry_slots does not also inflate
+ * connection-setup (CALL/ACCEPT) retries. */
+void arq_set_data_retry_slots(int slots);
+
 /* Setters for the newly-atomic ARQ timing/ladder tunables. */
 void arq_set_channel_guard_ms(int ms);
 void arq_set_iss_post_ack_guard_ms(int ms);

--- a/main.c
+++ b/main.c
@@ -251,7 +251,7 @@ int main(int argc, char *argv[])
             radio_serial_speed = mcfg.radio_serial_speed;
             arq_set_no_progress_timeout_s(mcfg.no_progress_timeout_s);
             arq_set_disconnect_drain_timeout_s(mcfg.disconnect_drain_timeout_s);
-            arq_set_retry_slots(mcfg.data_retry_slots);
+            arq_set_data_retry_slots(mcfg.data_retry_slots);
             arq_set_mode_hold_after_downgrade_s(mcfg.mode_hold_after_downgrade_s);
             arq_set_ladder_up_successes(mcfg.ladder_up_successes);
             arq_set_retry_downgrade_threshold(mcfg.retry_downgrade_threshold);

--- a/mercury.ini.example
+++ b/mercury.ini.example
@@ -105,7 +105,9 @@ no_progress_timeout_s = 180
 disconnect_drain_timeout_s = 30
 
 ; Number of DATA-frame retries before a downgrade cycle (default 10, range 1..64).
-; Behaves like the RETRIES TNC command: also caps CALL/ACCEPT retries.
+; Affects the data plane only; connection-setup (CALL/ACCEPT) retries keep their
+; short defaults so a failed connect gives up quickly.  Use the RETRIES TNC
+; command at runtime to widen CALL/ACCEPT/DATA retries together.
 data_retry_slots = 10
 
 ; Seconds to hold the lower mode after a forced downgrade (default 6, range 0..60).

--- a/tests/datalink_arq/test_arq_fsm.c
+++ b/tests/datalink_arq/test_arq_fsm.c
@@ -149,6 +149,77 @@ void test_incoming_call_transitions_to_accepting(void)
     TEST_ASSERT_GREATER_THAN(0, fake_notify_pending_fake.call_count);
 }
 
+/* Helper: drive LISTENING -> ACCEPTING via an incoming CALL. */
+static void enter_accepting(void)
+{
+    arq_event_t ev = make_event(ARQ_EV_APP_LISTEN);
+    arq_fsm_dispatch(&sess, &ev);
+    ev = make_event(ARQ_EV_RX_CALL);
+    ev.session_id = 0x42;
+    strncpy(ev.remote_call, "REMOTE1", CALLSIGN_MAX_SIZE);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_ACCEPTING, sess.conn_state);
+}
+
+/* An IRS in ACCEPTING must give up (return to LISTENING) after the ACCEPT
+ * retry budget is spent, so it does NOT linger long after the caller stops.
+ * Regression guard for the field report where the IRS sat in ACCEPTING ~90 s
+ * after the ISS gave up — caused by CALL/ACCEPT slots being inflated to the
+ * DATA default (10) at startup; connection-setup slots stay short (4). */
+void test_accepting_gives_up_after_budget(void)
+{
+    enter_accepting();
+
+    /* No further RX_CALL: exhaust the ACCEPT retries. */
+    for (int i = 0; i < ARQ_ACCEPT_RETRY_SLOTS + 2; i++) {
+        arq_event_t ev = make_event(ARQ_EV_TIMER_RETRY);
+        mock_set_uptime_ms(1000 + (uint64_t)(i + 1) * 10000);
+        arq_fsm_dispatch(&sess, &ev);
+        if (sess.conn_state == ARQ_CONN_LISTENING)
+            break;
+    }
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_LISTENING, sess.conn_state);
+}
+
+/* A fresh RX_CALL while ACCEPTING re-arms the retry budget (so the window
+ * stays open while the caller is still calling); the give-up is bounded by
+ * the ACCEPT budget measured from the LAST heard CALL. */
+void test_accepting_rx_call_rearms_budget(void)
+{
+    enter_accepting();
+
+    /* Spend the budget down to (but not past) exhaustion. */
+    for (int i = 0; i < ARQ_ACCEPT_RETRY_SLOTS; i++) {
+        arq_event_t ev = make_event(ARQ_EV_TIMER_RETRY);
+        mock_set_uptime_ms(1000 + (uint64_t)(i + 1) * 10000);
+        arq_fsm_dispatch(&sess, &ev);
+    }
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_ACCEPTING, sess.conn_state);
+
+    /* Caller still calling -> budget re-armed. */
+    arq_event_t call = make_event(ARQ_EV_RX_CALL);
+    call.session_id = 0x42;
+    strncpy(call.remote_call, "REMOTE1", CALLSIGN_MAX_SIZE);
+    arq_fsm_dispatch(&sess, &call);
+
+    /* Survives another near-full round of retries because of the re-arm. */
+    for (int i = 0; i < ARQ_ACCEPT_RETRY_SLOTS - 1; i++) {
+        arq_event_t ev = make_event(ARQ_EV_TIMER_RETRY);
+        mock_set_uptime_ms(1000 + (uint64_t)(ARQ_ACCEPT_RETRY_SLOTS + i + 2) * 10000);
+        arq_fsm_dispatch(&sess, &ev);
+    }
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_ACCEPTING, sess.conn_state);
+}
+
+/* Connection-setup slots must stay short by default (not the DATA default of
+ * 10) so a failed connect and its mirror ACCEPT window give up quickly. */
+void test_default_call_accept_slots_are_short(void)
+{
+    TEST_ASSERT_EQUAL_INT(ARQ_CALL_RETRY_SLOTS_DEFAULT,   ARQ_CALL_RETRY_SLOTS);
+    TEST_ASSERT_EQUAL_INT(ARQ_ACCEPT_RETRY_SLOTS_DEFAULT, ARQ_ACCEPT_RETRY_SLOTS);
+    TEST_ASSERT_TRUE(ARQ_ACCEPT_RETRY_SLOTS < ARQ_DATA_RETRY_SLOTS_DEFAULT);
+}
+
 /* RX_ACCEPT from CALLING transitions to CONNECTED */
 void test_accept_transitions_to_connected(void)
 {
@@ -587,6 +658,9 @@ int main(void)
     /* Timeout tests */
     RUN_TEST(test_call_timeout);
     RUN_TEST(test_call_timeout_no_listen);
+    RUN_TEST(test_accepting_gives_up_after_budget);
+    RUN_TEST(test_accepting_rx_call_rearms_budget);
+    RUN_TEST(test_default_call_accept_slots_are_short);
     RUN_TEST(test_stop_listen);
     RUN_TEST(test_timeout_ms_idle);
     return UNITY_END();


### PR DESCRIPTION
## Problem
Pedro's OTA (jul_8, estacao6 ⇄ estacao10): after the ISS gives up connecting (`CALLING → LISTENING`), the IRS stayed in `ACCEPTING` **~90 s longer**, re-sending ACCEPT into a dead channel.

## Root cause — regression from the INI-tunables work (`82a50c1`)
Startup applied the config via `arq_set_retry_slots(mcfg.data_retry_slots)`, and that setter sets **CALL, ACCEPT and DATA** slots together (the RETRIES-command semantics). `data_retry_slots` defaults to **10**, so connection-setup retries jumped from their compiled default of **4 → 10**.

`ACCEPTING` re-arms its budget on every `RX_CALL` (to keep the window open while the caller is still calling), so the IRS gives up `accept_slots × retry_interval` after the caller's **last** CALL — at 10 × ~9 s that is the **~90 s** Pedro saw. The ISS itself did ~10 CALL retries instead of 4.

Log alignment: ISS gives up 08:01:55; IRS keeps re-sending ACCEPT until 08:03:42 (~107 s later).

## Fix
`data_retry_slots` is a **data-plane** knob and must not touch connection setup:
- New `arq_set_data_retry_slots()` sets only the data slot; the startup config path calls it.
- CALL/ACCEPT return to their short default (4) → ACCEPTING linger drops ~90 s → ~36 s (the known-good pre-regression behavior); the ISS gives up in ~4 CALL retries again.
- The **RETRIES TNC command** still uses `arq_set_retry_slots()` to widen all three at runtime (unchanged).
- `mercury.ini.example` corrected (dropped the stale "also caps CALL/ACCEPT retries" note).

## Tests
3 new deterministic `test_arq_fsm` cases: ACCEPTING gives up after its budget is spent; a fresh `RX_CALL` re-arms it; default CALL/ACCEPT slots stay short (< the DATA default). Full unit suite + connect-path/control integration tests green; clean build (no warnings).