### PR TITLE
Updates for new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,9 +135,13 @@ jobs:
         run: |
           sed -i 's/"Mercury [0-9]*\.[0-9]*\.[0-9]*"/"Mercury ${{ inputs.version }}"/' mercury.1
 
+      - name: Update installer version
+        run: |
+          sed -i 's/#define MyAppVersion "[^"]*"/#define MyAppVersion "${{ inputs.version }}"/' windows-installer/installer.iss
+
       - name: Commit and push release files
         run: |
-          git add debian/changelog main.c mercury.1
+          git add debian/changelog main.c mercury.1 windows-installer/installer.iss
           git commit -m "Updates for release ${{ inputs.version }}"
           git push origin mercuryv2
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,37 @@ Radio control notes:
 
    The FreeDV codec is vendored in-tree — no external FreeDV or codec2 packages are needed.
 
+### Build targets
+
+| Target | Description |
+|--------|-------------|
+| `make` / `make all` | Build the standalone CLI `mercury` binary |
+| `make libmercury_core.a` | Compile all Mercury C objects into a host-arch static library (used by `fyne-ui`) |
+| `make fyne-ui` | Build the single-binary native GUI (`mercury-ui`), embedding the engine via CGo. Requires `make libmercury_core.a` first. |
+| `make libmercury_core_w64.a` | Cross-compile Mercury C objects for Windows x64 (requires `gcc-mingw-w64-x86-64`) |
+| `make fyne-ui-windows` | Cross-compile the single-binary GUI to `mercury-ui.exe`. Depends on `libmercury_core_w64.a`. |
+| `make windows-installer` | Full Windows installer pipeline: cross-compile engine + GUI, copy DLLs, patch config. Output goes to `windows-installer/`. Requires MinGW + Go. |
+| `make windows-zip` | Build standalone CLI + GUI Windows binaries and zip them for distribution |
+
+### Build the Fyne GUI (Linux)
+
+```bash
+sudo apt install golang-go libhamlib-dev libpulse-dev libasound2-dev
+make fyne-ui
+./gui_interface/fyne-ui/mercury-ui
+```
+
+### Cross-compile the Windows installer (from Linux)
+
+```bash
+sudo apt install golang-go gcc-mingw-w64-x86-64 mingw-w64-x86-64-dev
+make windows-installer
+# → windows-installer/ contains mercury-ui.exe + DLLs + mercury.ini
+# Use Inno Setup Compiler on Windows to build the .exe installer from installer.iss
+```
+
+   The FreeDV codec is vendored in-tree — no external FreeDV or codec2 packages are needed.
+
 ### Install via Debian package on Linux
 
 For now just Debian 13 (Trixie) packages are built, for both arm64 (works on both RaspberryPi OS and Debian) and amd64.
@@ -151,12 +182,11 @@ For now just Debian 13 (Trixie) packages are built, for both arm64 (works on bot
 
 **Note:** Installation via Debian package requires Debian 13 (Trixie)
 
-### Install ZIP package on Windows
+### Install on Windows
 
-1. Navigate to the releases page on the official GitHub repository: https://github.com/Rhizomatica/mercury/releases
-2. Download the ZIP package for the latest version
-3. Go to Downloads folder (or the folder where you downloaded the Mercury ZIP) and extract the files
-4. Click on the `mercury` executable file (``mercury.exe``) to run Mercury HF modem
+**Via installer (recommended):** Download the `Mercury_HF_Modem_Setup.exe` from the releases page, run it, and the single-binary GUI (`mercury-ui.exe`) will be installed. The GUI launches the Mercury engine in-process — no separate backend needed. Desktop and Start Menu shortcuts are created automatically.
+
+**Via ZIP:** Download the ZIP package from the releases page, extract it, and run `mercury-ui.exe` for the GUI or `mercury.exe` for the headless CLI.
 
 ## Configuration File
 
@@ -193,7 +223,8 @@ Mercury v2 currently uses FreeDV modulator code developed by David Rowe. We plan
 
 ## Graphical Interfaces
 
-Mercury v2 has two interfaces:
+Mercury v2 has three interfaces:
+- **Built-in Fyne UI** — a single-binary GUI embedded in the engine via CGo (this repository, `gui_interface/fyne-ui/`). Shows waterfall/spectrum, telemetry, and controls. Build with `make fyne-ui` (Linux) or `make windows-installer` (Windows cross-compile).
 - **Mercury-qt** (desktop): https://github.com/Rhizomatica/mercury-qt
 - **Web-based**: located in `docs/app/` in this repository, and accessible via https://rhizomatica.github.io/mercury/app/
 

--- a/common/mercury_engine.c
+++ b/common/mercury_engine.c
@@ -98,7 +98,7 @@ int mercury_engine_init(const mercury_config *cfg,
     bool waterfall_enabled = cfg->waterfall_enabled;
     int  radio_type       = cfg->radio_type;
     char radio_device[1024];
-    strncpy(radio_device, cfg->radio_device, sizeof(radio_device) - 1);
+    memcpy(radio_device, cfg->radio_device, sizeof(radio_device) - 1);
     radio_device[sizeof(radio_device) - 1] = '\0';
     int  radio_serial_speed = cfg->radio_serial_speed;
     int  freedv_verbosity   = cfg->freedv_verbosity;
@@ -107,9 +107,9 @@ int mercury_engine_init(const mercury_config *cfg,
     int  broadcast_port     = cfg->broadcast_tcp_port ? cfg->broadcast_tcp_port : 8100;
     bool verbose            = cfg->verbose;
 
-    strncpy(g_input_dev,  cfg->input_device,  sizeof(g_input_dev) - 1);
-    strncpy(g_output_dev, cfg->output_device, sizeof(g_output_dev) - 1);
+    memcpy(g_input_dev,  cfg->input_device,  sizeof(g_input_dev) - 1);
     g_input_dev[sizeof(g_input_dev) - 1]  = '\0';
+    memcpy(g_output_dev, cfg->output_device, sizeof(g_output_dev) - 1);
     g_output_dev[sizeof(g_output_dev) - 1] = '\0';
 
     int rx_input_channel = cfg->capture_channel;
@@ -227,10 +227,10 @@ int mercury_engine_init(const mercury_config *cfg,
     g_mcfg.tls_enabled       = tls_enabled;
     g_mcfg.waterfall_enabled = waterfall_enabled;
     g_mcfg.radio_type        = radio_type;
-    strncpy(g_mcfg.radio_device, radio_device, sizeof(g_mcfg.radio_device) - 1);
+    memcpy(g_mcfg.radio_device, radio_device, sizeof(g_mcfg.radio_device) - 1);
     g_mcfg.radio_device[sizeof(g_mcfg.radio_device) - 1] = '\0';
-    strncpy(g_mcfg.input_device,  g_input_dev,  sizeof(g_mcfg.input_device) - 1);
-    strncpy(g_mcfg.output_device, g_output_dev, sizeof(g_mcfg.output_device) - 1);
+    memcpy(g_mcfg.input_device,  g_input_dev,  sizeof(g_mcfg.input_device) - 1);
+    memcpy(g_mcfg.output_device, g_output_dev, sizeof(g_mcfg.output_device) - 1);
     g_mcfg.input_device[sizeof(g_mcfg.input_device) - 1]   = '\0';
     g_mcfg.output_device[sizeof(g_mcfg.output_device) - 1] = '\0';
     g_mcfg.capture_channel   = rx_input_channel;

--- a/common/mercury_engine.c
+++ b/common/mercury_engine.c
@@ -98,8 +98,7 @@ int mercury_engine_init(const mercury_config *cfg,
     bool waterfall_enabled = cfg->waterfall_enabled;
     int  radio_type       = cfg->radio_type;
     char radio_device[1024];
-    memcpy(radio_device, cfg->radio_device, sizeof(radio_device) - 1);
-    radio_device[sizeof(radio_device) - 1] = '\0';
+    snprintf(radio_device, sizeof(radio_device), "%s", cfg->radio_device);
     int  radio_serial_speed = cfg->radio_serial_speed;
     int  freedv_verbosity   = cfg->freedv_verbosity;
     int  hamlib_log_level   = cfg->hamlib_log_level;
@@ -107,10 +106,8 @@ int mercury_engine_init(const mercury_config *cfg,
     int  broadcast_port     = cfg->broadcast_tcp_port ? cfg->broadcast_tcp_port : 8100;
     bool verbose            = cfg->verbose;
 
-    memcpy(g_input_dev,  cfg->input_device,  sizeof(g_input_dev) - 1);
-    g_input_dev[sizeof(g_input_dev) - 1]  = '\0';
-    memcpy(g_output_dev, cfg->output_device, sizeof(g_output_dev) - 1);
-    g_output_dev[sizeof(g_output_dev) - 1] = '\0';
+    snprintf(g_input_dev,  sizeof(g_input_dev),  "%s", cfg->input_device);
+    snprintf(g_output_dev, sizeof(g_output_dev), "%s", cfg->output_device);
 
     int rx_input_channel = cfg->capture_channel;
 
@@ -227,12 +224,9 @@ int mercury_engine_init(const mercury_config *cfg,
     g_mcfg.tls_enabled       = tls_enabled;
     g_mcfg.waterfall_enabled = waterfall_enabled;
     g_mcfg.radio_type        = radio_type;
-    memcpy(g_mcfg.radio_device, radio_device, sizeof(g_mcfg.radio_device) - 1);
-    g_mcfg.radio_device[sizeof(g_mcfg.radio_device) - 1] = '\0';
-    memcpy(g_mcfg.input_device,  g_input_dev,  sizeof(g_mcfg.input_device) - 1);
-    memcpy(g_mcfg.output_device, g_output_dev, sizeof(g_mcfg.output_device) - 1);
-    g_mcfg.input_device[sizeof(g_mcfg.input_device) - 1]   = '\0';
-    g_mcfg.output_device[sizeof(g_mcfg.output_device) - 1] = '\0';
+    snprintf(g_mcfg.radio_device,  sizeof(g_mcfg.radio_device),  "%s", radio_device);
+    snprintf(g_mcfg.input_device,  sizeof(g_mcfg.input_device),  "%s", g_input_dev);
+    snprintf(g_mcfg.output_device, sizeof(g_mcfg.output_device), "%s", g_output_dev);
     g_mcfg.capture_channel   = rx_input_channel;
     g_mcfg.sound_system      = g_audio_system;
     g_mcfg.arq_tcp_base_port = base_tcp_port;

--- a/main.c
+++ b/main.c
@@ -90,12 +90,12 @@ static void handle_termination_signal(int sig)
     if (g_signal_count)
     {
         static const char msg[] = "Caught second signal, forcing exit.\n";
-        write(STDERR_FILENO, msg, sizeof(msg) - 1);
+        (void)!write(STDERR_FILENO, msg, sizeof(msg) - 1);
         _exit(1);
     }
     g_signal_count = 1;
     static const char msg[] = "Signal received, shutting down...\n";
-    write(STDERR_FILENO, msg, sizeof(msg) - 1);
+    (void)!write(STDERR_FILENO, msg, sizeof(msg) - 1);
     shutdown_ = true;
 }
 
@@ -230,7 +230,7 @@ int main(int argc, char *argv[])
             waterfall_enabled  = mcfg.waterfall_enabled;
             radio_type         = mcfg.radio_type;
             if (mcfg.radio_device[0]) {
-                strncpy(radio_device, mcfg.radio_device, sizeof(radio_device) - 1);
+                memcpy(radio_device, mcfg.radio_device, sizeof(radio_device) - 1);
                 radio_device[sizeof(radio_device) - 1] = '\0';
             }
             if (mcfg.input_device[0]) {

--- a/main.c
+++ b/main.c
@@ -230,8 +230,7 @@ int main(int argc, char *argv[])
             waterfall_enabled  = mcfg.waterfall_enabled;
             radio_type         = mcfg.radio_type;
             if (mcfg.radio_device[0]) {
-                memcpy(radio_device, mcfg.radio_device, sizeof(radio_device) - 1);
-                radio_device[sizeof(radio_device) - 1] = '\0';
+                snprintf(radio_device, sizeof(radio_device), "%s", mcfg.radio_device);
             }
             if (mcfg.input_device[0]) {
                 strncpy(input_dev, mcfg.input_device, MAX_PATH - 1);

--- a/radio_io/radio_io.c
+++ b/radio_io/radio_io.c
@@ -27,13 +27,9 @@
 
 #ifdef HAVE_HAMLIB
 #include <hamlib/rig.h>
-#if defined(__has_include)
-#if __has_include(<hamlib/port.h>)
-#include <hamlib/port.h>
-#endif
-#else
-#include <hamlib/port.h>
-#endif
+/* hamlib >= 4.6 ships the port struct inside rig.h directly.
+ * Including the separate port.h alongside would redefine it.
+ * Skip port.h — rig.h alone is sufficient on any supported version. */
 #include "rigctl_parse.h"
 #endif
 


### PR DESCRIPTION
- Fix compiler warnings by replacing `strncpy` with `memcpy`
- Update README with new build targets and installation instructions for Fyne GUI and Windows
- Update version on `installer.iss` in new release