### PR TITLE
build(windows): Authenticode signing via Certum SimplySign (jsign) — validated, +CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ gui_interface/fyne-ui/mercury-fyne-ui
 gui_interface/fyne-ui/*.app
 *.dmg
 *.exe
+# Code-signing test material / artifacts — never commit
+*.pfx
+*.p12
+*.signed
 *.dll
 *.so
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,15 @@ gui_interface/fyne-ui/mercury-fyne-ui
 gui_interface/fyne-ui/*.app
 *.dmg
 *.exe
-# Code-signing test material / artifacts — never commit
+# Code-signing test material / artifacts / SECRETS — never commit
 *.pfx
 *.p12
 *.signed
+# Certum SimplySign secrets + local artifacts (keep the real ones OUTSIDE the repo)
+*otpauth*
+pass.txt
+*sunpkcs11*.conf
+jsign*.jar
 *.dll
 *.so
 

--- a/Makefile
+++ b/Makefile
@@ -336,16 +336,20 @@ fyne-ui-macos-universal-dmg: fyne-ui-macos-universal
 #   B) WIN_SIGN_PFX  unset, sign script available → sign via Certum SimplySign cloud (PKCS#11).
 #   C) Neither → unsigned build (default, no behaviour change).
 #
-# For mode B, the script at SIGN_SCRIPT automates the SimplySign Desktop login
-# (Xvfb + xdotool + TOTP) and then calls osslsigncode over PKCS#11.
-# See docs/WINDOWS-SIGNING.md for details.
+# For mode B, the in-repo script at SIGN_SCRIPT (code-signing/sign.sh) automates
+# the SimplySign Desktop login (Xvfb + xdotool + TOTP) and signs over PKCS#11
+# with jsign (SunPKCS11 — the SimplySign module is not enumerable by OpenSC).
+# It is OPT-IN: it only runs when CERTUM_EMAIL is set in the environment
+# (together with CERTUM_OTP_URI_FILE), so plain `windows-zip` stays unsigned by
+# default even though the script is present.  See docs/WINDOWS-SIGNING.md.
 #
 WIN_SIGN_PFX  ?=
 WIN_SIGN_PASS ?=
 WIN_SIGN_TS   ?= http://timestamp.digicert.com
 WIN_SIGN_NAME ?= Mercury HF Modem
 WIN_SIGN_URL  ?= https://github.com/Rhizomatica/mercury
-SIGN_SCRIPT   ?= $(HOME)/files/MYSELF/code-signing/sign.sh
+SIGN_SCRIPT   ?= $(CURDIR)/code-signing/sign.sh
+SIGN_LOGOUT   ?= $(CURDIR)/code-signing/sign-logout.sh
 
 # $(call win_sign,file) — sign in place if a signing method is available.
 define win_sign
@@ -354,7 +358,7 @@ define win_sign
 		osslsigncode sign -pkcs12 "$(WIN_SIGN_PFX)" -pass "$(WIN_SIGN_PASS)" \
 			-n "$(WIN_SIGN_NAME)" -i "$(WIN_SIGN_URL)" -h sha256 -ts "$(WIN_SIGN_TS)" \
 			-in "$(1)" -out "$(1).signed" && mv -f "$(1).signed" "$(1)"; \
-	elif [ -x "$(SIGN_SCRIPT)" ]; then \
+	elif [ -x "$(SIGN_SCRIPT)" ] && [ -n "$$CERTUM_EMAIL" ]; then \
 		echo "Signing (SimplySign cloud): $(1)"; \
 		$(SIGN_SCRIPT) "$(1)"; \
 	else \
@@ -380,6 +384,7 @@ windows-zip-signed: windows fyne-ui-windows
 	cp $(WINDOWS_INSTALLER_DIR)/$(FYNE_UI_BIN) $(WINDOWS_DIR)/
 	$(call win_sign,$(WINDOWS_DIR)/mercury.exe)
 	$(call win_sign,$(WINDOWS_DIR)/$(FYNE_UI_BIN))
+	@[ -x "$(SIGN_LOGOUT)" ] && [ -n "$$CERTUM_EMAIL" ] && $(SIGN_LOGOUT) || true
 	cp mercury.ini.example $(WINDOWS_DIR)/
 	if ls $(HAMLIB_W64_DIR)/bin/*.dll >/dev/null 2>&1; then \
 		cp $(HAMLIB_W64_DIR)/bin/*.dll $(WINDOWS_DIR)/; \

--- a/Makefile
+++ b/Makefile
@@ -362,17 +362,17 @@ define win_sign
 	fi
 endef
 
-# Sign the already-built mercury.exe (or any .exe).  Uses SimplySign cloud if
-# WIN_SIGN_PFX is not set (the common case for CI / developer workstations).
+# ---- Windows Authenticode signing targets ----
+# Sign the already-built mercury.exe (SimplySign cloud via PKCS#11).
 # Requires: sign.sh script, xvfb, fluxbox, xdotool, opensc, osslsigncode.
-sign: mercury.exe
+sign-windows: mercury.exe
 	$(call win_sign,mercury.exe)
 
-# Sign an arbitrary binary (e.g. make sign BIN=mercury-ui.exe)
-sign-bin:
+# Sign an arbitrary .exe (e.g. make sign-windows-bin BIN=mercury-ui.exe)
+sign-windows-bin:
 	$(call win_sign,$(BIN))
 
-# Sign both the payload .exe and the GUI .exe for the Windows zip.
+# Build + sign both payload .exe files + zip.
 windows-zip-signed: windows fyne-ui-windows
 	rm -rf $(WINDOWS_DIR) $(WINDOWS_ZIP)
 	mkdir -p $(WINDOWS_DIR)
@@ -425,7 +425,7 @@ windows-installer: fyne-ui-windows
 	@echo "  ISCC $(WINDOWS_INSTALLER_DIR)/installer.iss"
 	@echo ""
 	@echo "Then sign the resulting .exe on Linux:"
-	@echo "  make sign-bin BIN=Mercury_\$$(VERSION)_Setup.exe"
+	@echo "  make sign-windows-bin BIN=Mercury_\$$(VERSION)_Setup.exe"
 	@echo ""
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -330,24 +330,63 @@ fyne-ui-macos-universal-dmg: fyne-ui-macos-universal
 	rm -rf $(FYNE_UI_DIR)/dmg-stage
 	@echo "  -> $(abspath $(MACOS_DMG))  (universal)"
 
-# Optional Authenticode signing of the cross-built .exe (osslsigncode, on Linux).
-# Set WIN_SIGN_PFX (and WIN_SIGN_PASS) to sign; leave unset for an unsigned build
-# (default, no behaviour change). A self-signed cert only proves the mechanics —
-# it does not clear SmartScreen on untrusted machines. See docs/WINDOWS-SIGNING.md.
+# ---- Authenticode signing (Windows binaries) ----
+# Two modes:
+#   A) WIN_SIGN_PFX  set → sign with a local .pfx file via osslsigncode (self-signed test or OV/EV cert).
+#   B) WIN_SIGN_PFX  unset, sign script available → sign via Certum SimplySign cloud (PKCS#11).
+#   C) Neither → unsigned build (default, no behaviour change).
+#
+# For mode B, the script at SIGN_SCRIPT automates the SimplySign Desktop login
+# (Xvfb + xdotool + TOTP) and then calls osslsigncode over PKCS#11.
+# See docs/WINDOWS-SIGNING.md for details.
+#
 WIN_SIGN_PFX  ?=
 WIN_SIGN_PASS ?=
 WIN_SIGN_TS   ?= http://timestamp.digicert.com
 WIN_SIGN_NAME ?= Mercury HF Modem
 WIN_SIGN_URL  ?= https://github.com/Rhizomatica/mercury
-# $(call win_sign,file) — sign in place iff WIN_SIGN_PFX is set.
+SIGN_SCRIPT   ?= $(HOME)/files/MYSELF/code-signing/sign.sh
+
+# $(call win_sign,file) — sign in place if a signing method is available.
 define win_sign
 	@if [ -n "$(WIN_SIGN_PFX)" ]; then \
-		echo "Signing (Authenticode): $(1)"; \
+		echo "Signing (pfx): $(1)"; \
 		osslsigncode sign -pkcs12 "$(WIN_SIGN_PFX)" -pass "$(WIN_SIGN_PASS)" \
 			-n "$(WIN_SIGN_NAME)" -i "$(WIN_SIGN_URL)" -h sha256 -ts "$(WIN_SIGN_TS)" \
 			-in "$(1)" -out "$(1).signed" && mv -f "$(1).signed" "$(1)"; \
+	elif [ -x "$(SIGN_SCRIPT)" ]; then \
+		echo "Signing (SimplySign cloud): $(1)"; \
+		$(SIGN_SCRIPT) "$(1)"; \
+	else \
+		echo "WARNING: no signing method available — $(1) is unsigned"; \
 	fi
 endef
+
+# Sign the already-built mercury.exe (or any .exe).  Uses SimplySign cloud if
+# WIN_SIGN_PFX is not set (the common case for CI / developer workstations).
+# Requires: sign.sh script, xvfb, fluxbox, xdotool, opensc, osslsigncode.
+sign: mercury.exe
+	$(call win_sign,mercury.exe)
+
+# Sign an arbitrary binary (e.g. make sign BIN=mercury-ui.exe)
+sign-bin:
+	$(call win_sign,$(BIN))
+
+# Sign both the payload .exe and the GUI .exe for the Windows zip.
+windows-zip-signed: windows fyne-ui-windows
+	rm -rf $(WINDOWS_DIR) $(WINDOWS_ZIP)
+	mkdir -p $(WINDOWS_DIR)
+	cp mercury.exe $(WINDOWS_DIR)/
+	cp $(WINDOWS_INSTALLER_DIR)/$(FYNE_UI_BIN) $(WINDOWS_DIR)/
+	$(call win_sign,$(WINDOWS_DIR)/mercury.exe)
+	$(call win_sign,$(WINDOWS_DIR)/$(FYNE_UI_BIN))
+	cp mercury.ini.example $(WINDOWS_DIR)/
+	if ls $(HAMLIB_W64_DIR)/bin/*.dll >/dev/null 2>&1; then \
+		cp $(HAMLIB_W64_DIR)/bin/*.dll $(WINDOWS_DIR)/; \
+	fi
+	zip -9r $(WINDOWS_ZIP) $(WINDOWS_DIR)
+	rm -rf $(WINDOWS_DIR)
+	@echo "Created $(WINDOWS_ZIP) (signed)"
 
 windows-zip: windows fyne-ui-windows
 	rm -rf $(WINDOWS_DIR) $(WINDOWS_ZIP)

--- a/Makefile
+++ b/Makefile
@@ -420,6 +420,13 @@ windows-installer: fyne-ui-windows
 		cp $(HAMLIB_W64_DIR)/bin/*.dll $(WINDOWS_INSTALLER_DIR)/; \
 	fi
 	@echo "windows-installer ready: run Inno Setup on $(WINDOWS_INSTALLER_DIR)/installer.iss"
+	@echo ""
+	@echo "Full release pipeline:"
+	@echo "  1. make sign                     # sign mercury.exe on Linux (SimplySign cloud)"
+	@echo "  2. make windows-installer        # prepare Inno Setup files"
+	@echo "  3. On Windows VM with SimplySign Desktop running:"
+	@echo "     ISCC /DSIGN /Smercury=\"signtool sign /a /fd sha256 /tr http://time.certum.pl /td sha256 \044f\" installer.iss"
+	@echo ""
 
 clean:
 	rm -f mercury mercury.exe *.o .git_hash_stamp mercury-*.zip libmercury_core.a libmercury_core_w64.a

--- a/Makefile
+++ b/Makefile
@@ -330,11 +330,32 @@ fyne-ui-macos-universal-dmg: fyne-ui-macos-universal
 	rm -rf $(FYNE_UI_DIR)/dmg-stage
 	@echo "  -> $(abspath $(MACOS_DMG))  (universal)"
 
+# Optional Authenticode signing of the cross-built .exe (osslsigncode, on Linux).
+# Set WIN_SIGN_PFX (and WIN_SIGN_PASS) to sign; leave unset for an unsigned build
+# (default, no behaviour change). A self-signed cert only proves the mechanics —
+# it does not clear SmartScreen on untrusted machines. See docs/WINDOWS-SIGNING.md.
+WIN_SIGN_PFX  ?=
+WIN_SIGN_PASS ?=
+WIN_SIGN_TS   ?= http://timestamp.digicert.com
+WIN_SIGN_NAME ?= Mercury HF Modem
+WIN_SIGN_URL  ?= https://github.com/Rhizomatica/mercury
+# $(call win_sign,file) — sign in place iff WIN_SIGN_PFX is set.
+define win_sign
+	@if [ -n "$(WIN_SIGN_PFX)" ]; then \
+		echo "Signing (Authenticode): $(1)"; \
+		osslsigncode sign -pkcs12 "$(WIN_SIGN_PFX)" -pass "$(WIN_SIGN_PASS)" \
+			-n "$(WIN_SIGN_NAME)" -i "$(WIN_SIGN_URL)" -h sha256 -ts "$(WIN_SIGN_TS)" \
+			-in "$(1)" -out "$(1).signed" && mv -f "$(1).signed" "$(1)"; \
+	fi
+endef
+
 windows-zip: windows fyne-ui-windows
 	rm -rf $(WINDOWS_DIR) $(WINDOWS_ZIP)
 	mkdir -p $(WINDOWS_DIR)
 	cp mercury.exe $(WINDOWS_DIR)/
 	cp $(WINDOWS_INSTALLER_DIR)/$(FYNE_UI_BIN) $(WINDOWS_DIR)/
+	$(call win_sign,$(WINDOWS_DIR)/mercury.exe)
+	$(call win_sign,$(WINDOWS_DIR)/$(FYNE_UI_BIN))
 	cp mercury.ini.example $(WINDOWS_DIR)/
 	if ls $(HAMLIB_W64_DIR)/bin/*.dll >/dev/null 2>&1; then \
 		cp $(HAMLIB_W64_DIR)/bin/*.dll $(WINDOWS_DIR)/; \

--- a/Makefile
+++ b/Makefile
@@ -419,13 +419,13 @@ windows-installer: fyne-ui-windows
 	if ls $(HAMLIB_W64_DIR)/bin/*.dll >/dev/null 2>&1; then \
 		cp $(HAMLIB_W64_DIR)/bin/*.dll $(WINDOWS_INSTALLER_DIR)/; \
 	fi
-	@echo "windows-installer ready: run Inno Setup on $(WINDOWS_INSTALLER_DIR)/installer.iss"
+	@echo "windows-installer ready."
 	@echo ""
-	@echo "Full release pipeline:"
-	@echo "  1. make sign                     # sign mercury.exe on Linux (SimplySign cloud)"
-	@echo "  2. make windows-installer        # prepare Inno Setup files"
-	@echo "  3. On Windows VM with SimplySign Desktop running:"
-	@echo "     ISCC /DSIGN /Smercury=\"signtool sign /a /fd sha256 /tr http://time.certum.pl /td sha256 \044f\" installer.iss"
+	@echo "Build the installer (Windows or Wine):"
+	@echo "  ISCC $(WINDOWS_INSTALLER_DIR)/installer.iss"
+	@echo ""
+	@echo "Then sign the resulting .exe on Linux:"
+	@echo "  make sign-bin BIN=Mercury_\$$(VERSION)_Setup.exe"
 	@echo ""
 
 clean:

--- a/code-signing/.github-workflow-example/sign-windows.yml
+++ b/code-signing/.github-workflow-example/sign-windows.yml
@@ -1,0 +1,61 @@
+# Example GitHub Actions workflow: Authenticode-sign the Windows binaries with
+# the Certum SimplySign cloud certificate.
+#
+# TO USE: move this file to .github/workflows/sign-windows.yml and add two repo
+# secrets (Settings -> Secrets and variables -> Actions):
+#   CERTUM_EMAIL     the SimplySign account e-mail
+#   CERTUM_OTP_URI   the otpauth:// URI (TOTP seed)  <-- treat as a password
+# Nothing secret is committed; the job reads both from the encrypted secrets.
+#
+# The job runs inside reactiveui's prebuilt image, which already contains
+# SimplySign Desktop + jsign + Xvfb/fluxbox/xdotool + OpenSC — the same stack
+# code-signing/sign.sh expects, so no per-run install is needed.  (That image is
+# the maintained upstream of this whole approach:
+# https://github.com/reactiveui/actions-common/tree/main/.github/actions/certum-sign)
+
+name: sign-windows
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      CERTUM_EMAIL:   { required: true }
+      CERTUM_OTP_URI: { required: true }
+
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/reactiveui/certum-signer:latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Bring the unsigned Windows binaries into the workspace.  Either build
+      # them here (make windows fyne-ui-windows) or download them from an
+      # earlier build job:
+      - name: Fetch unsigned binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-unsigned
+          path: dist
+
+      - name: Sign (Certum SimplySign, one login for all binaries)
+        env:
+          CERTUM_EMAIL:   ${{ secrets.CERTUM_EMAIL }}
+          CERTUM_OTP_URI: ${{ secrets.CERTUM_OTP_URI }}   # sign.sh reads the URI directly
+          # The image ships jsign + SimplySign Desktop; point the lib at them if
+          # the paths differ from its defaults:
+          # JSIGN_JAR: /opt/jsign/jsign.jar
+          # SS_DIST:   /opt/SimplySignDesktop
+        run: |
+          set -e
+          code-signing/sign.sh dist/mercury.exe dist/mercury-ui.exe
+          code-signing/sign-logout.sh
+          # verify
+          for f in dist/*.exe; do osslsigncode verify "$f"; done
+
+      - name: Upload signed binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-signed
+          path: dist/*.exe

--- a/code-signing/README.md
+++ b/code-signing/README.md
@@ -1,0 +1,70 @@
+# Mercury Windows code signing (Certum SimplySign, headless Linux)
+
+Authenticode-sign the Windows binaries on Linux using a **Certum SimplySign**
+cloud certificate — no `.pfx` file, no Windows VM. Full background,
+troubleshooting and CI in [`../docs/WINDOWS-SIGNING.md`](../docs/WINDOWS-SIGNING.md).
+
+```
+sign-lib.sh      signing primitives (sourced): login-once, sign, logout
+sign.sh          sign one or more .exe IN PLACE (reuses one login)
+sign-logout.sh   tear the SimplySign session down
+```
+
+## Secrets — where they go (NEVER in the repo)
+
+The certificate's private key lives in Certum's cloud HSM; signing needs two
+account secrets. **Keep them OUTSIDE the git tree** and point env vars at them.
+The repo's `.gitignore` also blocks `*.pfx *.p12 *.otpauth *otpauth* pass.txt`
+as a backstop, but the real rule is: secrets live in your home, not here.
+
+| Secret | What it is | Suggested location | Env var |
+|---|---|---|---|
+| otpauth URI | TOTP seed (`otpauth://totp/...?secret=...`) — 2FA equivalent, **guard it** | `~/.config/mercury-signing/otpauth.txt` (mode 600) | `CERTUM_OTP_URI_FILE` (or `CERTUM_OTP_URI`) |
+| account e-mail | SimplySign login e-mail | env / your shell rc | `CERTUM_EMAIL` |
+
+Nothing else is secret: the public certificate, the PKCS#11 module and the
+SimplySign Desktop install are not sensitive.
+
+Get the otpauth URI once, when enrolling the SimplySign mobile token: Certum
+shows a QR code — decode it to the `otpauth://` URI and save that text to the
+file above. (The maintainer's copy lives at
+`~/files/documents/windows_certum/otpauthuri.txt`, outside the repo.)
+
+## One-time setup
+
+```bash
+# packages (Debian/Ubuntu): headless X + PKCS#11 + verify + Java for jsign
+sudo apt-get install -y xvfb fluxbox xdotool opensc osslsigncode default-jre-headless
+
+# jsign (the signer — see docs for WHY not osslsigncode): one jar
+curl -fsSLo ~/.local/share/jsign.jar \
+  https://repo1.maven.org/maven2/net/jsign/jsign/7.1/jsign-7.1.jar
+
+# SimplySign Desktop (Certum's bundle) -> /opt/SimplySignDesktop  (see docs)
+```
+
+## Sign
+
+```bash
+export CERTUM_EMAIL="you@example.org"
+export CERTUM_OTP_URI_FILE="$HOME/.config/mercury-signing/otpauth.txt"
+export JSIGN_JAR="$HOME/.local/share/jsign.jar"
+
+# via the Makefile (recommended — one login for the whole release):
+make windows-zip-signed
+
+# or directly:
+code-signing/sign.sh mercury.exe mercury-ui.exe
+code-signing/sign-logout.sh          # when done
+```
+
+## The three things that make this work (details in the doc)
+
+1. **jsign, not osslsigncode.** This SimplySign PKCS#11 module does not expose
+   its objects to OpenSC (`pkcs11-tool -O` / osslsigncode return an empty list),
+   but Java's SunPKCS11 enumerates the key by alias — so jsign signs where
+   osslsigncode cannot even find the key. osslsigncode is used only to *verify*.
+2. **`USER` must be set.** The module bundles an ancient OpenSSL that segfaults
+   (exit 139) when `$USER` is empty; `sign-lib.sh` exports it.
+3. **Login once, sign many.** The session and the per-file signing are separate
+   lifecycles, so a slow cloud round-trip can't be killed by a cleanup.

--- a/code-signing/sign-lib.sh
+++ b/code-signing/sign-lib.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# sign-lib.sh — Certum SimplySign Authenticode signing primitives for Mercury's
+# Windows binaries, run headlessly on Linux (sourced, not executed).
+#
+# WHY THIS EXISTS / KEY FACTS (learned the hard way — see docs/WINDOWS-SIGNING.md):
+#   * SimplySign has NO headless login: the cloud session is opened by logging
+#     into the SimplySign Desktop GUI.  We drive that GUI on a virtual X server
+#     (Xvfb + fluxbox + xdotool), typing the account e-mail + a TOTP derived
+#     from the otpauth:// URI.  This mirrors reactiveui/actions-common.
+#   * The signing tool is jsign (Java), NOT osslsigncode: the SimplySign PKCS#11
+#     module does not expose its objects to OpenSC's C_FindObjects
+#     (pkcs11-tool -O / osslsigncode return an EMPTY object list), but Java's
+#     SunPKCS11 provider enumerates the key by alias.  jsign therefore works
+#     where osslsigncode cannot even find the key.  osslsigncode is used only to
+#     VERIFY (nice human-readable summary).
+#   * The SimplySign module bundles an ancient OpenSSL that NULL-derefs (SIGSEGV,
+#     exit 139) when $USER is empty — so USER must be set for EVERY process that
+#     loads the module.  A non-login shell / CI runner often has it unset.
+#   * The authenticated session and the per-file signing are SEPARATE lifecycles
+#     (ss_login is idempotent + persistent; ss_sign_file only signs; ss_logout
+#     tears down).  Sign N binaries with ONE login; nothing in the signing path
+#     can race a cleanup that kills the daemon mid cloud round-trip.
+#
+# REQUIRED env (secrets — never committed; keep them OUTSIDE the repo):
+#   CERTUM_EMAIL          SimplySign account e-mail
+#   CERTUM_OTP_URI_FILE   path to a file containing the otpauth:// URI (TOTP seed)
+#     (or CERTUM_OTP_URI   the otpauth:// URI itself)
+# Optional env (have sensible defaults):
+#   SS_DIST      SimplySign Desktop dir            (/opt/SimplySignDesktop)
+#   SS_PKCS11    PKCS#11 module .so                (auto-found under SS_DIST)
+#   JSIGN_JAR    path to jsign CLI jar             (else `jsign` on PATH)
+#   CERTUM_TSA   RFC-3161 timestamp URL            (http://time.certum.pl)
+#   SS_DISPLAY   Xvfb display                      (:99)
+#   SS_ALG       digest algorithm                  (SHA-256)
+
+# CRITICAL: bundled-OpenSSL NULL-deref guard (see above).
+export USER="${USER:-$(id -un)}"
+
+SS_DIST="${SS_DIST:-/opt/SimplySignDesktop}"
+PKCS11="${SS_PKCS11:-$(find "$SS_DIST" -maxdepth 1 -iname 'SimplySignPKCS*.so' 2>/dev/null | head -1)}"
+CERTUM_TSA="${CERTUM_TSA:-http://time.certum.pl}"
+DISPLAY_NR="${SS_DISPLAY:-:99}"
+SS_ALG="${SS_ALG:-SHA-256}"
+SS_CONF="${SS_PKCS11_CONF:-/tmp/mercury-sunpkcs11.conf}"
+
+# jsign locator: explicit jar, else a `jsign` launcher on PATH.
+if [ -n "${JSIGN_JAR:-}" ]; then JSIGN=(java -jar "$JSIGN_JAR")
+elif command -v jsign >/dev/null 2>&1;   then JSIGN=(jsign)
+else JSIGN=(); fi
+
+ss_log() { echo "[ssign] $*" >&2; }
+
+ss_require() {
+    [ -n "$PKCS11" ] && [ -f "$PKCS11" ] || { ss_log "ERROR: SimplySign PKCS#11 module not found under $SS_DIST (set SS_PKCS11)"; return 1; }
+    [ "${#JSIGN[@]}" -gt 0 ] || { ss_log "ERROR: jsign not found — set JSIGN_JAR or put jsign on PATH (see docs/WINDOWS-SIGNING.md)"; return 1; }
+    [ -n "${CERTUM_EMAIL:-}" ] || { ss_log "ERROR: CERTUM_EMAIL is unset"; return 1; }
+    if [ -z "${CERTUM_OTP_URI:-}" ]; then
+        [ -n "${CERTUM_OTP_URI_FILE:-}" ] && [ -f "$CERTUM_OTP_URI_FILE" ] \
+            || { ss_log "ERROR: set CERTUM_OTP_URI or CERTUM_OTP_URI_FILE (the otpauth:// TOTP seed)"; return 1; }
+    fi
+    return 0
+}
+
+# --- fresh TOTP from the otpauth:// URI (algorithm/digits/period aware) ---
+ss_totp() {
+    local uri="${CERTUM_OTP_URI:-$(cat "$CERTUM_OTP_URI_FILE")}"
+    python3 - "$uri" <<'PY'
+import sys,hmac,hashlib,base64,struct,time
+from urllib.parse import urlparse,parse_qs
+q=parse_qs(urlparse(sys.argv[1].strip()).query)
+s=q['secret'][0]; d=int(q.get('digits',['6'])[0]); p=int(q.get('period',['30'])[0])
+a={'SHA1':hashlib.sha1,'SHA256':hashlib.sha256,'SHA512':hashlib.sha512}[q.get('algorithm',['SHA1'])[0].upper()]
+k=base64.b32decode(s+'='*((8-len(s)%8)%8))
+h=hmac.new(k,struct.pack('>Q',int(time.time())//p),a).digest(); o=h[-1]&0xF
+print(str((int.from_bytes(h[o:o+4],'big')&0x7fffffff)%(10**d)).zfill(d))
+PY
+}
+
+# --- is the token slot present (session live)?  Check -L, not -O. ---
+ss_token_live() {
+    timeout 15 pkcs11-tool --module "$PKCS11" -L 2>/dev/null | grep -qi 'token label'
+}
+
+# --- write the SunPKCS11 config jsign/keytool use to reach the module ---
+ss_write_conf() { printf 'name = SimplySign\nlibrary = %s\nslotListIndex = 0\n' "$PKCS11" > "$SS_CONF"; }
+
+# --- the signing key's alias (via SunPKCS11 — OpenSC can't enumerate it) ---
+ss_key_alias() {
+    ss_write_conf
+    timeout 40 keytool -list -keystore NONE -storetype PKCS11 \
+        -providerClass sun.security.pkcs11.SunPKCS11 -providerArg "$SS_CONF" \
+        -storepass "" 2>/dev/null \
+        | awk -F, '/PrivateKeyEntry/{gsub(/ /,"",$1); print $1; exit}'
+}
+
+# --- largest on-screen SimplySign window: sets WID BX BY BW BH ---
+ss_find_window() {
+    WID=""; local best=0
+    for w in $(DISPLAY=$DISPLAY_NR xdotool search --name '' 2>/dev/null); do
+        local nm; nm=$(DISPLAY=$DISPLAY_NR xdotool getwindowname "$w" 2>/dev/null || true)
+        case "$nm" in *implySign*) ;; *) continue ;; esac
+        eval "$(DISPLAY=$DISPLAY_NR xdotool getwindowgeometry --shell "$w" 2>/dev/null)"
+        local area=$(( ${WIDTH:-0} * ${HEIGHT:-0} ))
+        if [ "$area" -gt "$best" ]; then best=$area; WID=$w; BX=${X:-0}; BY=${Y:-0}; BW=${WIDTH:-0}; BH=${HEIGHT:-0}; fi
+    done
+    [ -n "$WID" ]
+}
+
+# --- bring up (or reuse) an authenticated session. Idempotent. No teardown. ---
+ss_login() {
+    ss_require || return 1
+    if ss_token_live; then ss_log "session already live — reusing"; return 0; fi
+
+    ss_log "starting headless SimplySign session on $DISPLAY_NR"
+    pkill -f SimplySignDesktop 2>/dev/null || true
+    pkill -f "Xvfb $DISPLAY_NR" 2>/dev/null || true
+    pkill -f fluxbox 2>/dev/null || true
+    sleep 1; rm -f "$HOME/SimplySignDesktop-Lock"
+
+    Xvfb $DISPLAY_NR -screen 0 1280x1024x24 -ac +extension GLX +render &>/dev/null &
+    sleep 2
+    mkdir -p ~/.fluxbox; echo 'session.screen0.rootCommand: /bin/true' > ~/.fluxbox/init
+    DISPLAY=$DISPLAY_NR fluxbox &>/dev/null & sleep 2
+    cp "$SS_DIST/SimplySignDesktop.xml" ~/ 2>/dev/null || true
+    mkdir -p ~/.config
+    printf '[General]\nCacheUserIdAtLogon=Yes\nShowLogonDialogAfterApplicationStartup=Yes\nShowLogonDialogWhenAnyAppRequestsAccess=Yes\n' > ~/.config/"Unknown Organization.conf"
+    DISPLAY=$DISPLAY_NR LD_LIBRARY_PATH=$SS_DIST QT_QPA_PLATFORM_PLUGIN_PATH=$SS_DIST/plugins \
+        "$SS_DIST/SimplySignDesktop_start" &>/dev/null &
+
+    ss_log "waiting for login window..."
+    local ok=""
+    for _ in $(seq 1 60); do
+        if ss_find_window && [ "${BW:-0}" -ge 300 ] && [ "${BH:-0}" -ge 200 ]; then ok=1; break; fi
+        sleep 2
+    done
+    [ -z "$ok" ] && { ss_log "ERROR: login window did not appear"; return 1; }
+
+    local totp; totp=$(ss_totp)
+    DISPLAY=$DISPLAY_NR xdotool windowactivate --sync "$WID" 2>/dev/null || true
+    DISPLAY=$DISPLAY_NR xdotool windowraise "$WID" 2>/dev/null || true; sleep 1
+    DISPLAY=$DISPLAY_NR xdotool mousemove $((BX + BW/2)) $((BY + BH*39/100)) click 1; sleep 1
+    DISPLAY=$DISPLAY_NR xdotool key --clearmodifiers ctrl+a
+    DISPLAY=$DISPLAY_NR xdotool type --clearmodifiers --delay 50 "$CERTUM_EMAIL"; sleep 1
+    DISPLAY=$DISPLAY_NR xdotool key Tab; sleep 1
+    DISPLAY=$DISPLAY_NR xdotool type --clearmodifiers --delay 50 "$totp"; sleep 1
+    DISPLAY=$DISPLAY_NR xdotool mousemove $((BX + BW/2)) $((BY + BH*76/100)) click 1; sleep 8
+    # dismiss the "Logon successful" dialog (Close button, bottom-centre)
+    if ss_find_window; then
+        DISPLAY=$DISPLAY_NR xdotool windowactivate --sync "$WID" 2>/dev/null || true
+        DISPLAY=$DISPLAY_NR xdotool mousemove $((BX + BW/2)) $((BY + BH*94/100)) click 1
+    fi
+
+    ss_log "waiting for PKCS#11 token to come online..."
+    for _ in $(seq 1 30); do ss_token_live && { ss_log "session live"; return 0; }; sleep 2; done
+    ss_log "ERROR: token did not come online (login likely failed)"; return 1
+}
+
+# --- sign ONE file IN PLACE (jsign adds the Authenticode signature); retries --
+ss_sign_file() {
+    local in="$1"
+    [ -f "$in" ] || { ss_log "ERROR: no such file: $in"; return 1; }
+    ss_login || return 1
+    local alias; alias=$(ss_key_alias)
+    [ -z "$alias" ] && { ss_log "ERROR: no signing key visible via SunPKCS11"; return 1; }
+
+    local attempt rc=1
+    for attempt in 1 2 3; do
+        ss_log "signing $in (alias $alias, attempt $attempt)"
+        if "${JSIGN[@]}" --storetype PKCS11 --keystore "$SS_CONF" --storepass "" \
+                --alias "$alias" --alg "$SS_ALG" --tsaurl "$CERTUM_TSA" "$in" \
+                2>&1 | grep -viE '^Warning|proprietary|will be removed' | sed 's/^/[jsign] /' >&2; then
+            rc=0; break
+        fi
+        ss_log "attempt $attempt failed (transient cloud/timestamp?) — retrying"; sleep 5
+    done
+    if [ "$rc" = 0 ]; then
+        ss_log "OK: signed $in"
+        command -v osslsigncode >/dev/null && \
+            osslsigncode verify "$in" 2>&1 | grep -iE 'Subject:|Issuer :|Serial :|Timestamp' | sed 's/^/[verify] /' >&2 || true
+    else
+        ss_log "ERROR: failed to sign $in after 3 attempts"
+    fi
+    return $rc
+}
+
+# --- tear the session down ---
+ss_logout() {
+    ss_log "tearing down SimplySign session"
+    pkill -f SimplySignDesktop 2>/dev/null || true
+    pkill -f "Xvfb $DISPLAY_NR" 2>/dev/null || true
+    pkill -f fluxbox 2>/dev/null || true
+    rm -f "$HOME/SimplySignDesktop-Lock"
+}

--- a/code-signing/sign-logout.sh
+++ b/code-signing/sign-logout.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# sign-logout.sh — tear down the persistent SimplySign session (SimplySign
+# Desktop + Xvfb + fluxbox) started by sign.sh.  Safe if nothing is running.
+set -uo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=sign-lib.sh
+source "$DIR/sign-lib.sh"
+ss_logout

--- a/code-signing/sign.sh
+++ b/code-signing/sign.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# sign.sh — Authenticode-sign one or more Windows binaries IN PLACE with the
+# Certum SimplySign cloud certificate.  Logs in once (idempotent) and reuses the
+# session across every argument and across repeated invocations, so the
+# Makefile's per-file calls cost a single cloud login.  Run sign-logout.sh when
+# the release is finished.  See docs/WINDOWS-SIGNING.md (secrets go OUTSIDE the
+# repo; point CERTUM_EMAIL / CERTUM_OTP_URI_FILE at them).
+#
+#   CERTUM_EMAIL=you@example.org CERTUM_OTP_URI_FILE=~/secrets/otpauth.txt \
+#     ./sign.sh mercury.exe mercury-ui.exe
+set -uo pipefail
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=sign-lib.sh
+source "$DIR/sign-lib.sh"
+[ "$#" -ge 1 ] || { echo "usage: $0 <file.exe> [more.exe ...]" >&2; exit 2; }
+rc=0
+for f in "$@"; do ss_sign_file "$f" || rc=1; done
+exit "$rc"

--- a/docs/WINDOWS-SIGNING.md
+++ b/docs/WINDOWS-SIGNING.md
@@ -1,48 +1,92 @@
 # Windows code signing (Authenticode)
 
-Mercury's Windows binaries and installer can be Authenticode-signed. This guide
-covers **self-signed signing for testing the pipeline**; the same steps apply to
-a real certificate — only the cert source changes.
+Mercury's Windows binaries and installer can be Authenticode-signed. Two
+approaches:
 
-> ⚠️ **A self-signed certificate proves the mechanics only.** It does *not*
-> clear the SmartScreen / "unknown publisher" warning on machines that don't
-> trust it. For public releases use an OV/EV code-signing certificate or a cloud
-> signing service (e.g. **Azure Trusted Signing**, ~$10/mo, CI-friendly).
+| Mode | Tool | When |
+|---|---|---|
+| **A) SimplySign cloud** | `sign.sh` (Xvfb + xdotool + PKCS#11) | Default for CI / developer workstations — no `.pfx` file needed |
+| **B) Local .pfx** | `osslsigncode -pkcs12` | Self-signed test cert or OV/EV hardware token |
+| **C) Inno Setup** | `signtool.exe` on Windows | Signing the installer (requires Windows VM or physical machine) |
+
+**Mode A (SimplySign cloud) is the production path.** The certificate lives in
+Certum's cloud HSM; there is no `.pfx` file. The `sign.sh` script automates the
+SimplySign Desktop GUI (Xvfb + xdotool), types the TOTP code into the login form,
+waits for the PKCS#11 token to activate, then signs with `osslsigncode -pkcs11`.
+
+## Prerequisites
+
+```bash
+# 6 packages (Debian 13):
+sudo apt-get install -y xvfb fluxbox xdotool opensc osslsigncode stalonetray
+```
+
+SimplySign Desktop must be installed at `/opt/SimplySignDesktop` (pre-built
+binary from Certum; bundles its own Qt 5.9.2 + OpenSSL 1.0.0 — no system Qt
+or OpenSSL packages needed).
+
+## Mode A: SimplySign cloud signing (default)
+
+The Makefile automatically uses this when `WIN_SIGN_PFX` is unset and the
+`sign.sh` script is available:
+
+```bash
+# Sign mercury.exe (already built)
+make sign
+
+# Sign an arbitrary binary
+make sign-bin BIN=mercury-ui.exe
+
+# Build + sign + zip in one step
+make windows-zip-signed
+```
+
+Under the hood this runs `~/files/MYSELF/code-signing/sign.sh`, which:
+1. Starts Xvfb :99 + fluxbox (virtual display for the GUI)
+2. Launches SimplySign Desktop with `USER=rafael2k` (prevents OpenSSL crash)
+3. Waits for the "SimplySign Desktop" login window to appear
+4. Generates a fresh TOTP code from `otpauthuri.txt`
+5. Uses xdotool to type email + TOTP + click Login
+6. Handles the "Logon successful" dialog
+7. Signs with `osslsigncode` via PKCS#11
+8. Verifies the signature
 
 ## What can be signed, and where
 
 | Artifact | Built on | Sign with |
 |---|---|---|
-| `mercury.exe`, `mercury-ui.exe` | Linux (mingw cross-build) | `osslsigncode` on Linux, **or** Inno (`signonce`) on Windows |
-| `Mercury_HF_Modem_Setup.exe` (installer) | Windows (Inno Setup) | Inno `SignTool` directive |
+| `mercury.exe`, `mercury-ui.exe` | Linux (mingw cross-build) | `make sign` (SimplySign cloud via PKCS#11), or `osslsigncode -pkcs12` (local .pfx) |
+| `Mercury_HF_Modem_Setup.exe` (installer) | Windows (Inno Setup) | `signtool.exe` on Windows VM with SimplySign Desktop installed (`/a` auto-selects cert) |
 
-Because the payload `.exe` files are cross-built on Linux, you can sign them
-there and let Inno sign only the installer — or let Inno sign everything on the
-Windows side. Both are wired up.
+For the payload `.exe` files: sign on Linux. The installer must be signed on
+Windows (Inno Setup's `SignTool` directive needs native `signtool.exe`).
 
-## 1. Make a self-signed test certificate
+## Setup: SimplySign Desktop + signing scripts
 
-**On Linux** (openssl):
-```bash
-cd windows-installer
-./gen-selfsigned-cert.sh                 # -> mercury-selfsign.pfx (password: mercury)
-```
+The SimplySign Desktop binary is bundled at `/opt/SimplySignDesktop`. The
+signing scripts live in `~/files/MYSELF/code-signing/`:
 
-**On Windows** (PowerShell) — equivalent:
-```powershell
-$c = New-SelfSignedCertificate -Type CodeSigningCert `
-       -Subject "CN=Rhizomatica Mercury (TEST)" `
-       -CertStoreLocation Cert:\CurrentUser\My
-Export-PfxCertificate -Cert $c -FilePath mercury-selfsign.pfx `
-       -Password (ConvertTo-SecureString -String "mercury" -Force -AsPlainText)
-```
+| File | Purpose |
+|---|---|
+| `sign.sh` | Main entry — Xvfb + xdotool + TOTP automation + `osslsigncode` |
+| `otpauthuri.txt` → `~/files/documents/windows_certum/otpauthuri.txt` | TOTP secret seed |
+| `219d71faf992d043051392dc77eb705b.pem` | Public certificate (in `~/files/documents/windows_certum/`) |
+| `SIGNING.md` | Full reference doc (in `~/files/MYSELF/code-signing/`) |
 
-`.pfx` / `.p12` files are git-ignored — never commit a signing key.
+## Parameters reference (Makefile)
 
-## 2a. Sign the binaries on Linux (osslsigncode)
+| Variable | Default | Meaning |
+|---|---|---|
+| `WIN_SIGN_PFX` | *(empty)* | Path to a local PKCS#12 (`.pfx`) cert+key. **When set**: uses `osslsigncode -pkcs12`. **When empty**: uses SimplySign cloud via `sign.sh` (default). |
+| `WIN_SIGN_PASS` | *(empty)* | Password for the `.pfx` (only used when `WIN_SIGN_PFX` is set). |
+| `WIN_SIGN_TS` | `http://timestamp.digicert.com` | RFC-3161 timestamp authority URL. Certum's timestamp server: `http://time.certum.pl` |
+| `WIN_SIGN_NAME` | `Mercury HF Modem` | Signature description (`-n`). |
+| `WIN_SIGN_URL` | `https://github.com/Rhizomatica/mercury` | Signature info URL (`-i`). |
+| `SIGN_SCRIPT` | `$(HOME)/files/MYSELF/code-signing/sign.sh` | Path to the SimplySign automation script. |
 
-The Makefile signs the cross-built `.exe` when `WIN_SIGN_PFX` is set (unset =
-unsigned build, the default — no behaviour change):
+## Mode B: Local .pfx (self-signed test or OV/EV token)
+
+Set `WIN_SIGN_PFX` and `WIN_SIGN_PASS` to use a local PKCS#12 file:
 
 ```bash
 make windows-zip \
@@ -50,7 +94,13 @@ make windows-zip \
      WIN_SIGN_PASS=mercury
 ```
 
-Manual single-file equivalent:
+To generate a self-signed test certificate:
+```bash
+cd windows-installer
+./gen-selfsigned-cert.sh    # -> mercury-selfsign.pfx (password: mercury)
+```
+
+Manual equivalent:
 ```bash
 osslsigncode sign -pkcs12 mercury-selfsign.pfx -pass mercury \
     -n "Mercury HF Modem" -i https://github.com/Rhizomatica/mercury \
@@ -58,65 +108,36 @@ osslsigncode sign -pkcs12 mercury-selfsign.pfx -pass mercury \
     -in mercury.exe -out mercury-signed.exe
 osslsigncode verify mercury-signed.exe
 ```
-`-ts` adds an RFC-3161 trusted timestamp so signatures stay valid after the cert
-expires. On a self-signed cert `verify` reports the chain as untrusted (expected)
-but confirms the embedded digest matches the file.
 
-## 2b. Sign via Inno Setup on Windows
+`.pfx` / `.p12` files are git-ignored — never commit a signing key.
 
-`installer.iss` gates signing behind the `SIGN` preprocessor define, so the
-default build is unchanged. Compile signed by registering a sign tool named
-`mercury` and passing `/DSIGN`:
+## Mode C: Sign the installer on Windows
+
+`installer.iss` gates signing behind the `SIGN` preprocessor define. On a
+Windows machine with SimplySign Desktop installed and authenticated:
 
 ```bat
 ISCC.exe /DSIGN ^
-  /Smercury="signtool sign /f mercury-selfsign.pfx /p mercury /fd sha256 /tr http://timestamp.digicert.com /td sha256 $f" ^
+  /Smercury="signtool sign /a /fd sha256 /tr http://time.certum.pl /td sha256 $f" ^
   windows-installer\installer.iss
 ```
+
+The `/a` flag auto-selects the SimplySign cert from the Windows cert store
+(SimplySign Desktop injects it there). No `.pfx` file or password needed.
 
 With `/DSIGN` Inno:
 - signs `mercury-ui.exe` inside the installer (`signonce` flag), and
 - signs the generated `Mercury_HF_Modem_Setup.exe` and its uninstaller
   (`SignTool` / `SignedUninstaller`).
 
-`osslsigncode` can substitute for `signtool` in the same command if you build the
-installer under Wine.
+## Certificate details
 
-## Parameters reference
-
-**Makefile (`osslsigncode` path)** — set on the `make windows-zip` command line
-or the environment. Signing is skipped entirely unless `WIN_SIGN_PFX` is set.
-
-| Variable | Default | Meaning |
-|---|---|---|
-| `WIN_SIGN_PFX` | *(empty)* | Path to the PKCS#12 (`.pfx`) cert+key. **Empty ⇒ no signing** (default). |
-| `WIN_SIGN_PASS` | *(empty)* | Password for the `.pfx`. |
-| `WIN_SIGN_TS` | `http://timestamp.digicert.com` | RFC-3161 timestamp authority URL. |
-| `WIN_SIGN_NAME` | `Mercury HF Modem` | Signature description (`-n`). |
-| `WIN_SIGN_URL` | `https://github.com/Rhizomatica/mercury` | Signature info URL (`-i`). |
-
-**Inno Setup (`installer.iss`)** — controlled by the ISPP preprocessor:
-
-| Define / directive | Effect |
+| Field | Value |
 |---|---|
-| `/DSIGN` | Enables signing: adds `SignTool=mercury`, `SignedUninstaller=yes`, and the `signonce` flag on `mercury-ui.exe`. Omit it ⇒ unsigned build (default). |
-| `/Smercury="<cmd> $f"` | Registers the sign tool named `mercury`; `$f` expands to each file to sign. |
-
-## 3. Trust the test cert locally (optional)
-
-To silence the warning *on your own test machine* only, import the cert into
-**Trusted Root Certification Authorities** and **Trusted Publishers**
-(`certmgr.msc`, LocalMachine). Do this only on throwaway/test systems.
-
-## Moving to a real certificate
-
-Swap the self-signed `.pfx` for the real credential — everything else (Makefile
-`WIN_SIGN_*`, Inno `/DSIGN`) is identical:
-- **Azure Trusted Signing** — cloud HSM, CI-native, immediate SmartScreen trust;
-  requires organization identity validation. Recommended.
-- **OV cert** on a hardware token — reputation builds over time.
-- **EV cert** — instant SmartScreen reputation; hardware token.
-
-For CI, store the cert (base64 `.pfx` + password) or the cloud-signing service
-credentials as repository secrets and set `WIN_SIGN_PFX`/`WIN_SIGN_PASS` (or the
-Inno `/DSIGN` sign-tool command) from them in the release workflow.
+| Type | Open Source Developer (Unqualified) |
+| Subject | Open Source Developer Rafael Diniz |
+| Issuer | Certum Code Signing 2021 CA |
+| Serial | `219d71faf992d0000000000000000000` |
+| Valid | 2026-07-24 to 2027-07-24 |
+| Account | `rafael@rhizomatica.org` |
+| Timestamp URL | `http://time.certum.pl` |

--- a/docs/WINDOWS-SIGNING.md
+++ b/docs/WINDOWS-SIGNING.md
@@ -32,10 +32,10 @@ The Makefile automatically uses this when `WIN_SIGN_PFX` is unset and the
 
 ```bash
 # Sign mercury.exe (already built)
-make sign
+make sign-windows
 
 # Sign an arbitrary binary
-make sign-bin BIN=mercury-ui.exe
+make sign-windows-bin BIN=mercury-ui.exe
 
 # Build + sign + zip in one step
 make windows-zip-signed
@@ -55,8 +55,8 @@ Under the hood this runs `~/files/MYSELF/code-signing/sign.sh`, which:
 
 | Artifact | Built on | Signed on | Tool |
 |---|---|---|---|
-| `mercury.exe`, `mercury-ui.exe` | Linux (mingw) | Linux | `osslsigncode` via PKCS#11 (`make sign`) |
-| `Mercury_*_Setup.exe` (installer) | Windows or Wine (Inno Setup ISCC) | Linux | `osslsigncode` via PKCS#11 (`make sign-bin BIN=Setup.exe`) |
+| `mercury.exe`, `mercury-ui.exe` | Linux (mingw) | Linux | `osslsigncode` via PKCS#11 (`make sign-windows`) |
+| `Mercury_*_Setup.exe` (installer) | Windows or Wine (Inno Setup ISCC) | Linux | `osslsigncode` via PKCS#11 (`make sign-windows-bin BIN=Setup.exe`) |
 
 Everything is signed on Linux with `osslsigncode` + PKCS#11. The Inno Setup
 compiler (ISCC) builds the installer unsigned — then the resulting `.exe` is
@@ -123,7 +123,7 @@ is then signed with the same `osslsigncode` PKCS#11 path as the payload binaries
 ISCC windows-installer/installer.iss          # builds Mercury_1.9.10_Setup.exe
 
 # Then sign it on Linux:
-make sign-bin BIN=Mercury_1.9.10_Setup.exe
+make sign-windows-bin BIN=Mercury_1.9.10_Setup.exe
 ```
 
 If you prefer Inno-side signing on Windows (with SimplySign Desktop installed):

--- a/docs/WINDOWS-SIGNING.md
+++ b/docs/WINDOWS-SIGNING.md
@@ -1,0 +1,122 @@
+# Windows code signing (Authenticode)
+
+Mercury's Windows binaries and installer can be Authenticode-signed. This guide
+covers **self-signed signing for testing the pipeline**; the same steps apply to
+a real certificate — only the cert source changes.
+
+> ⚠️ **A self-signed certificate proves the mechanics only.** It does *not*
+> clear the SmartScreen / "unknown publisher" warning on machines that don't
+> trust it. For public releases use an OV/EV code-signing certificate or a cloud
+> signing service (e.g. **Azure Trusted Signing**, ~$10/mo, CI-friendly).
+
+## What can be signed, and where
+
+| Artifact | Built on | Sign with |
+|---|---|---|
+| `mercury.exe`, `mercury-ui.exe` | Linux (mingw cross-build) | `osslsigncode` on Linux, **or** Inno (`signonce`) on Windows |
+| `Mercury_HF_Modem_Setup.exe` (installer) | Windows (Inno Setup) | Inno `SignTool` directive |
+
+Because the payload `.exe` files are cross-built on Linux, you can sign them
+there and let Inno sign only the installer — or let Inno sign everything on the
+Windows side. Both are wired up.
+
+## 1. Make a self-signed test certificate
+
+**On Linux** (openssl):
+```bash
+cd windows-installer
+./gen-selfsigned-cert.sh                 # -> mercury-selfsign.pfx (password: mercury)
+```
+
+**On Windows** (PowerShell) — equivalent:
+```powershell
+$c = New-SelfSignedCertificate -Type CodeSigningCert `
+       -Subject "CN=Rhizomatica Mercury (TEST)" `
+       -CertStoreLocation Cert:\CurrentUser\My
+Export-PfxCertificate -Cert $c -FilePath mercury-selfsign.pfx `
+       -Password (ConvertTo-SecureString -String "mercury" -Force -AsPlainText)
+```
+
+`.pfx` / `.p12` files are git-ignored — never commit a signing key.
+
+## 2a. Sign the binaries on Linux (osslsigncode)
+
+The Makefile signs the cross-built `.exe` when `WIN_SIGN_PFX` is set (unset =
+unsigned build, the default — no behaviour change):
+
+```bash
+make windows-zip \
+     WIN_SIGN_PFX=$PWD/windows-installer/mercury-selfsign.pfx \
+     WIN_SIGN_PASS=mercury
+```
+
+Manual single-file equivalent:
+```bash
+osslsigncode sign -pkcs12 mercury-selfsign.pfx -pass mercury \
+    -n "Mercury HF Modem" -i https://github.com/Rhizomatica/mercury \
+    -h sha256 -ts http://timestamp.digicert.com \
+    -in mercury.exe -out mercury-signed.exe
+osslsigncode verify mercury-signed.exe
+```
+`-ts` adds an RFC-3161 trusted timestamp so signatures stay valid after the cert
+expires. On a self-signed cert `verify` reports the chain as untrusted (expected)
+but confirms the embedded digest matches the file.
+
+## 2b. Sign via Inno Setup on Windows
+
+`installer.iss` gates signing behind the `SIGN` preprocessor define, so the
+default build is unchanged. Compile signed by registering a sign tool named
+`mercury` and passing `/DSIGN`:
+
+```bat
+ISCC.exe /DSIGN ^
+  /Smercury="signtool sign /f mercury-selfsign.pfx /p mercury /fd sha256 /tr http://timestamp.digicert.com /td sha256 $f" ^
+  windows-installer\installer.iss
+```
+
+With `/DSIGN` Inno:
+- signs `mercury-ui.exe` inside the installer (`signonce` flag), and
+- signs the generated `Mercury_HF_Modem_Setup.exe` and its uninstaller
+  (`SignTool` / `SignedUninstaller`).
+
+`osslsigncode` can substitute for `signtool` in the same command if you build the
+installer under Wine.
+
+## Parameters reference
+
+**Makefile (`osslsigncode` path)** — set on the `make windows-zip` command line
+or the environment. Signing is skipped entirely unless `WIN_SIGN_PFX` is set.
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `WIN_SIGN_PFX` | *(empty)* | Path to the PKCS#12 (`.pfx`) cert+key. **Empty ⇒ no signing** (default). |
+| `WIN_SIGN_PASS` | *(empty)* | Password for the `.pfx`. |
+| `WIN_SIGN_TS` | `http://timestamp.digicert.com` | RFC-3161 timestamp authority URL. |
+| `WIN_SIGN_NAME` | `Mercury HF Modem` | Signature description (`-n`). |
+| `WIN_SIGN_URL` | `https://github.com/Rhizomatica/mercury` | Signature info URL (`-i`). |
+
+**Inno Setup (`installer.iss`)** — controlled by the ISPP preprocessor:
+
+| Define / directive | Effect |
+|---|---|
+| `/DSIGN` | Enables signing: adds `SignTool=mercury`, `SignedUninstaller=yes`, and the `signonce` flag on `mercury-ui.exe`. Omit it ⇒ unsigned build (default). |
+| `/Smercury="<cmd> $f"` | Registers the sign tool named `mercury`; `$f` expands to each file to sign. |
+
+## 3. Trust the test cert locally (optional)
+
+To silence the warning *on your own test machine* only, import the cert into
+**Trusted Root Certification Authorities** and **Trusted Publishers**
+(`certmgr.msc`, LocalMachine). Do this only on throwaway/test systems.
+
+## Moving to a real certificate
+
+Swap the self-signed `.pfx` for the real credential — everything else (Makefile
+`WIN_SIGN_*`, Inno `/DSIGN`) is identical:
+- **Azure Trusted Signing** — cloud HSM, CI-native, immediate SmartScreen trust;
+  requires organization identity validation. Recommended.
+- **OV cert** on a hardware token — reputation builds over time.
+- **EV cert** — instant SmartScreen reputation; hardware token.
+
+For CI, store the cert (base64 `.pfx` + password) or the cloud-signing service
+credentials as repository secrets and set `WIN_SIGN_PFX`/`WIN_SIGN_PASS` (or the
+Inno `/DSIGN` sign-tool command) from them in the release workflow.

--- a/docs/WINDOWS-SIGNING.md
+++ b/docs/WINDOWS-SIGNING.md
@@ -53,13 +53,15 @@ Under the hood this runs `~/files/MYSELF/code-signing/sign.sh`, which:
 
 ## What can be signed, and where
 
-| Artifact | Built on | Sign with |
-|---|---|---|
-| `mercury.exe`, `mercury-ui.exe` | Linux (mingw cross-build) | `make sign` (SimplySign cloud via PKCS#11), or `osslsigncode -pkcs12` (local .pfx) |
-| `Mercury_HF_Modem_Setup.exe` (installer) | Windows (Inno Setup) | `signtool.exe` on Windows VM with SimplySign Desktop installed (`/a` auto-selects cert) |
+| Artifact | Built on | Signed on | Tool |
+|---|---|---|---|
+| `mercury.exe`, `mercury-ui.exe` | Linux (mingw) | Linux | `osslsigncode` via PKCS#11 (`make sign`) |
+| `Mercury_*_Setup.exe` (installer) | Windows or Wine (Inno Setup ISCC) | Linux | `osslsigncode` via PKCS#11 (`make sign-bin BIN=Setup.exe`) |
 
-For the payload `.exe` files: sign on Linux. The installer must be signed on
-Windows (Inno Setup's `SignTool` directive needs native `signtool.exe`).
+Everything is signed on Linux with `osslsigncode` + PKCS#11. The Inno Setup
+compiler (ISCC) builds the installer unsigned — then the resulting `.exe` is
+signed afterward, exactly like the payload binaries. The Inno `SignTool`
+directive is not used; post-build signing is simpler and works from CI.>
 
 ## Setup: SimplySign Desktop + signing scripts
 
@@ -111,24 +113,26 @@ osslsigncode verify mercury-signed.exe
 
 `.pfx` / `.p12` files are git-ignored — never commit a signing key.
 
-## Mode C: Sign the installer on Windows
+## Mode C: Sign the installer
 
-`installer.iss` gates signing behind the `SIGN` preprocessor define. On a
-Windows machine with SimplySign Desktop installed and authenticated:
+The Inno Setup compiler (ISCC) builds `Mercury_$(VERSION)_Setup.exe`. That `.exe`
+is then signed with the same `osslsigncode` PKCS#11 path as the payload binaries:
 
-```bat
-ISCC.exe /DSIGN ^
-  /Smercury="signtool sign /a /fd sha256 /tr http://time.certum.pl /td sha256 $f" ^
-  windows-installer\installer.iss
+```bash
+# On Linux (or Windows with Inno):
+ISCC windows-installer/installer.iss          # builds Mercury_1.9.10_Setup.exe
+
+# Then sign it on Linux:
+make sign-bin BIN=Mercury_1.9.10_Setup.exe
 ```
 
-The `/a` flag auto-selects the SimplySign cert from the Windows cert store
-(SimplySign Desktop injects it there). No `.pfx` file or password needed.
+If you prefer Inno-side signing on Windows (with SimplySign Desktop installed):
+```bat
+ISCC /DSIGN /Smercury="signtool sign /a /fd sha256 /tr http://time.certum.pl /td sha256 $f" installer.iss
+```
 
-With `/DSIGN` Inno:
-- signs `mercury-ui.exe` inside the installer (`signonce` flag), and
-- signs the generated `Mercury_HF_Modem_Setup.exe` and its uninstaller
-  (`SignTool` / `SignedUninstaller`).
+The `/a` flag auto-selects the cert from the Windows cert store. But the
+recommended path is post-build signing on Linux — same tooling, same CI.
 
 ## Certificate details
 

--- a/docs/WINDOWS-SIGNING.md
+++ b/docs/WINDOWS-SIGNING.md
@@ -1,55 +1,110 @@
 # Windows code signing (Authenticode)
 
-Mercury's Windows binaries and installer can be Authenticode-signed. Two
+Mercury's Windows binaries and installer can be Authenticode-signed. Three
 approaches:
 
 | Mode | Tool | When |
 |---|---|---|
-| **A) SimplySign cloud** | `sign.sh` (Xvfb + xdotool + PKCS#11) | Default for CI / developer workstations — no `.pfx` file needed |
-| **B) Local .pfx** | `osslsigncode -pkcs12` | Self-signed test cert or OV/EV hardware token |
-| **C) Inno Setup** | `signtool.exe` on Windows | Signing the installer (requires Windows VM or physical machine) |
+| **A) SimplySign cloud** | `code-signing/sign.sh` (Xvfb + xdotool login; **jsign** over PKCS#11) | **Production path** — the real Certum cert, no `.pfx` file |
+| **B) Local .pfx** | `osslsigncode -pkcs12` | Self-signed test cert only (see below) |
+| **C) Inno Setup** | `signtool.exe` on Windows | Signing the installer (Windows VM / physical machine) |
 
-**Mode A (SimplySign cloud) is the production path.** The certificate lives in
-Certum's cloud HSM; there is no `.pfx` file. The `sign.sh` script automates the
-SimplySign Desktop GUI (Xvfb + xdotool), types the TOTP code into the login form,
-waits for the PKCS#11 token to activate, then signs with `osslsigncode -pkcs11`.
+**Mode A (SimplySign cloud) is the production path.** The certificate is a
+*Certum Open Source Developer* cert whose private key lives in Certum's cloud
+HSM — there is no `.pfx` to export. The in-repo scripts under `code-signing/`
+open a SimplySign session by automating the SimplySign Desktop GUI on a virtual
+X server, then sign with **jsign**. See `code-signing/README.md` for the
+quickstart; this document is the full reference.
+
+### Three facts that make (or break) this — learned the hard way
+
+1. **The signer is `jsign` (Java), not `osslsigncode`.** This SimplySign PKCS#11
+   module (`SimplySignPKCS_64-MS-1.0.20.so`, shipped with SimplySign Desktop
+   2.9.14) does **not** expose its objects to OpenSC's `C_FindObjects`:
+   `pkcs11-tool -O`, `p11tool`, and therefore `osslsigncode -pkcs11module`
+   all see an **empty** object list, so osslsigncode cannot even find the key
+   (and crashes if pushed via the OpenSSL `pkcs11` engine — see below). Java's
+   **SunPKCS11** provider *does* enumerate the key by alias, so `jsign`
+   (and `keytool`) work where osslsigncode cannot. osslsigncode is kept **only
+   to verify** the result (nice human-readable summary). This matches the
+   upstream reactiveui `certum-sign` action, which also uses jsign.
+2. **`USER` must be set.** The SimplySign module bundles an ancient OpenSSL that
+   NULL-derefs (SIGSEGV, exit 139) when `$USER` is empty — so **every** process
+   that loads the module (SimplySign Desktop, `keytool`, `jsign`) needs `USER`
+   set. Non-login shells and CI runners often have it empty. `sign-lib.sh`
+   exports it (`export USER="${USER:-$(id -un)}"`).
+3. **Login once, sign many.** The authenticated session and the per-file signing
+   are separate lifecycles: `ss_login` is idempotent + persistent, `ss_sign_file`
+   only signs, `ss_logout` tears down. A slow cloud round-trip therefore can
+   never be killed by a cleanup — the failure the old monolithic script hit.
+
+> Do **not** install `libengine-pkcs11-openssl` / use the OpenSSL `pkcs11`
+> engine for this cert — loading the OpenSSL-1.0.0-based module into an
+> OpenSSL-3.x process segfaults. jsign (separate JVM) avoids the ABI clash.
+
+## Secrets — where they live (NEVER in the repo)
+
+Signing needs two account secrets. **Keep them OUTSIDE the git tree** and point
+env vars at them. `.gitignore` also blocks `*otpauth* pass.txt *.pfx *.p12
+*sunpkcs11*.conf jsign*.jar` as a backstop, but the rule is: secrets live in
+your home, not in the repo.
+
+| Secret | What it is | Suggested location (mode 600) | Env var |
+|---|---|---|---|
+| otpauth URI | TOTP seed `otpauth://totp/...?secret=...` — 2FA-equivalent | `~/.config/mercury-signing/otpauth.txt` | `CERTUM_OTP_URI_FILE` (or `CERTUM_OTP_URI`) |
+| account e-mail | SimplySign login e-mail | shell env | `CERTUM_EMAIL` |
+
+The public certificate, the PKCS#11 module and the SimplySign Desktop install
+are **not** secret. The maintainer's copies live under
+`~/files/documents/windows_certum/` (outside the repo).
 
 ## Prerequisites
 
 ```bash
-# 6 packages (Debian 13):
-sudo apt-get install -y xvfb fluxbox xdotool opensc osslsigncode stalonetray
+# headless X + PKCS#11 + verify + Java (for jsign)
+sudo apt-get install -y xvfb fluxbox xdotool opensc osslsigncode default-jre-headless
+
+# jsign — the signer (single jar); point JSIGN_JAR at it (or put `jsign` on PATH)
+curl -fsSLo ~/.local/share/jsign.jar \
+  https://repo1.maven.org/maven2/net/jsign/jsign/7.1/jsign-7.1.jar
 ```
 
-SimplySign Desktop must be installed at `/opt/SimplySignDesktop` (pre-built
-binary from Certum; bundles its own Qt 5.9.2 + OpenSSL 1.0.0 — no system Qt
-or OpenSSL packages needed).
+SimplySign Desktop must be installed at `/opt/SimplySignDesktop` (Certum's
+bundle; ships its own Qt 5.9.2 + OpenSSL 1.0.0 — no system Qt/OpenSSL needed).
+It runs fine on Xvfb (software GL); on a real GPU display its old Qt hangs.
 
-## Mode A: SimplySign cloud signing (default)
-
-The Makefile automatically uses this when `WIN_SIGN_PFX` is unset and the
-`sign.sh` script is available:
+## Mode A: SimplySign cloud signing (production)
 
 ```bash
-# Sign mercury.exe (already built)
-make sign-windows
+export CERTUM_EMAIL="you@example.org"
+export CERTUM_OTP_URI_FILE="$HOME/.config/mercury-signing/otpauth.txt"
+export JSIGN_JAR="$HOME/.local/share/jsign.jar"
 
-# Sign an arbitrary binary
+make sign-windows                       # sign mercury.exe
 make sign-windows-bin BIN=mercury-ui.exe
-
-# Build + sign + zip in one step
-make windows-zip-signed
+make windows-zip-signed                 # build + sign both + zip (one login)
 ```
 
-Under the hood this runs `~/files/MYSELF/code-signing/sign.sh`, which:
-1. Starts Xvfb :99 + fluxbox (virtual display for the GUI)
-2. Launches SimplySign Desktop with `USER=rafael2k` (prevents OpenSSL crash)
-3. Waits for the "SimplySign Desktop" login window to appear
-4. Generates a fresh TOTP code from `otpauthuri.txt`
-5. Uses xdotool to type email + TOTP + click Login
-6. Handles the "Logon successful" dialog
-7. Signs with `osslsigncode` via PKCS#11
-8. Verifies the signature
+The Makefile calls `code-signing/sign.sh`, which:
+1. Starts Xvfb `:99` + fluxbox (virtual display) with `USER` set
+2. Launches SimplySign Desktop, waits for the login window
+3. Generates a fresh TOTP from the otpauth URI, types e-mail + TOTP, clicks Login
+4. Dismisses the "Logon successful" dialog; waits for the PKCS#11 token
+5. Signs each file **in place** with `jsign` via SunPKCS11 (alias auto-detected)
+6. Verifies with `osslsigncode`
+7. `sign-logout.sh` tears the session down at the end of `windows-zip-signed`
+
+Signing is **opt-in**: `make windows-zip` (and the whole flow) stays *unsigned*
+unless `CERTUM_EMAIL` is set in the environment, so ordinary builds never touch
+the cloud.
+
+## CI
+
+A ready-to-adapt GitHub Actions workflow is in
+`code-signing/.github-workflow-example/sign-windows.yml`. It runs inside
+reactiveui's prebuilt `ghcr.io/reactiveui/certum-signer` image (SimplySign +
+jsign + X11 already installed) and reads `CERTUM_EMAIL` / `CERTUM_OTP_URI` from
+GitHub Actions secrets. Move it to `.github/workflows/` and add the two secrets.
 
 ## What can be signed, and where
 

--- a/windows-installer/gen-selfsigned-cert.sh
+++ b/windows-installer/gen-selfsigned-cert.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Generate a SELF-SIGNED code-signing certificate for TESTING the Windows
+# Authenticode signing pipeline (osslsigncode on Linux, or signtool / Inno on
+# Windows).
+#
+# IMPORTANT: a self-signed certificate only proves the sign/verify *mechanics*.
+# It does NOT clear the SmartScreen "unknown publisher" warning on machines that
+# do not explicitly trust it — for that you need a real OV/EV cert or a cloud
+# signing service (e.g. Azure Trusted Signing).  See docs/WINDOWS-SIGNING.md.
+#
+# Usage:
+#   ./gen-selfsigned-cert.sh ["CN string"] [pfx-password] [output-basename]
+# Defaults: CN="Rhizomatica Mercury (TEST)"  pass="mercury"  out="mercury-selfsign"
+# Produces: <out>.pfx   (PKCS#12: private key + cert, for signtool/osslsigncode)
+#
+set -euo pipefail
+
+CN="${1:-Rhizomatica Mercury (TEST)}"
+PASS="${2:-mercury}"
+OUT="${3:-mercury-selfsign}"
+
+command -v openssl >/dev/null || { echo "error: openssl not found" >&2; exit 1; }
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+cat > "$tmp/ext.cnf" <<CNF
+[req]
+distinguished_name = dn
+x509_extensions    = v3
+prompt             = no
+[dn]
+CN = $CN
+[v3]
+basicConstraints   = critical,CA:FALSE
+keyUsage           = critical,digitalSignature
+extendedKeyUsage   = critical,codeSigning
+CNF
+
+# 3072-bit RSA, SHA-256, ~27 months validity (Authenticode leaf max is 39mo).
+openssl req -x509 -newkey rsa:3072 -sha256 -days 825 -nodes \
+    -keyout "$tmp/key.pem" -out "$tmp/cert.pem" -config "$tmp/ext.cnf"
+
+# PKCS#12 bundle.  If a *very* old Windows signtool refuses to import it, add
+# -legacy (older RC2/3DES encryption).
+openssl pkcs12 -export -out "$OUT.pfx" \
+    -inkey "$tmp/key.pem" -in "$tmp/cert.pem" \
+    -name "$CN" -passout "pass:$PASS"
+
+echo "Wrote $OUT.pfx  (password: $PASS)"
+echo "Sign on Linux:   osslsigncode sign -pkcs12 $OUT.pfx -pass $PASS -n 'Mercury HF Modem' \\"
+echo "                   -i https://github.com/Rhizomatica/mercury -h sha256 \\"
+echo "                   -ts http://timestamp.digicert.com -in app.exe -out app-signed.exe"
+echo "Or drive the Makefile: make windows-zip WIN_SIGN_PFX=\$PWD/$OUT.pfx WIN_SIGN_PASS=$PASS"

--- a/windows-installer/installer.iss
+++ b/windows-installer/installer.iss
@@ -15,7 +15,7 @@
 ;
 ; Build unsigned, then sign afterward:
 ;   1. ISCC installer.iss                         (builds Mercury_*.exe)
-;   2. make sign BIN=Mercury_$(VERSION)_Setup.exe  (signs it on Linux)
+;   2. make sign-windows-bin BIN=Mercury_$(VERSION)_Setup.exe  (signs it on Linux)
 ;
 ; If you prefer Inno-side signing on Windows (requires SimplySign Desktop):
 ;   ISCC /DSIGN /Smercury="signtool sign /a /fd sha256 \

--- a/windows-installer/installer.iss
+++ b/windows-installer/installer.iss
@@ -8,6 +8,19 @@
 #define MyAppURL "https://github.com/Rhizomatica/mercury"
 #define MyAppExeName "mercury-ui.exe"
 
+; --- Optional Authenticode signing --------------------------------------
+; Compile signed with:
+;   ISCC /DSIGN /Smercury="signtool sign /f cert.pfx /p PW /fd sha256 \
+;         /tr http://timestamp.digicert.com /td sha256 $f" installer.iss
+; (register a sign tool named "mercury"; $f is the file to sign).  Without
+; /DSIGN the installer builds unsigned exactly as before.  A self-signed cert
+; only proves the mechanics — see docs/WINDOWS-SIGNING.md.
+#ifdef SIGN
+  #define ExeFlags "ignoreversion signonce"
+#else
+  #define ExeFlags "ignoreversion"
+#endif
+
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
 AppId={{D3B073A1-C8A5-42E1-BC9B-5A3445C555DF}
@@ -29,6 +42,10 @@ WizardStyle=modern
 PrivilegesRequired=admin
 ChangesEnvironment=yes
 ArchitecturesInstallIn64BitMode=x64
+#ifdef SIGN
+SignTool=mercury
+SignedUninstaller=yes
+#endif
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -49,7 +66,7 @@ Source: "libgcc_s_seh-1.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "libhamlib-4.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "libusb-1.0.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "libwinpthread-1.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "mercury-ui.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "mercury-ui.exe"; DestDir: "{app}"; Flags: {#ExeFlags}
 
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\mercury.ico"; Comment: "Launch Mercury HF Modem (GUI)"

--- a/windows-installer/installer.iss
+++ b/windows-installer/installer.iss
@@ -9,12 +9,21 @@
 #define MyAppExeName "mercury-ui.exe"
 
 ; --- Optional Authenticode signing --------------------------------------
-; Compile signed with:
+; The SimplySign cert lives in Certum's cloud HSM — no .pfx file exists.
+; The SimplySign Desktop app injects the cert into the Windows cert store.
+; Once SimplySign Desktop is running and authenticated, sign with:
+;
+;   ISCC /DSIGN /Smercury="signtool sign /a /fd sha256 \
+;         /tr http://time.certum.pl /td sha256 $f" installer.iss
+;
+; The /a flag auto-selects the cert from the Windows cert store.
+; Without /DSIGN the installer builds unsigned exactly as before.
+;
+; For a local .pfx (self-signed test or OV/EV token), use:
 ;   ISCC /DSIGN /Smercury="signtool sign /f cert.pfx /p PW /fd sha256 \
 ;         /tr http://timestamp.digicert.com /td sha256 $f" installer.iss
-; (register a sign tool named "mercury"; $f is the file to sign).  Without
-; /DSIGN the installer builds unsigned exactly as before.  A self-signed cert
-; only proves the mechanics — see docs/WINDOWS-SIGNING.md.
+;
+; See docs/WINDOWS-SIGNING.md for the full signing workflow.
 #ifdef SIGN
   #define ExeFlags "ignoreversion signonce"
 #else

--- a/windows-installer/installer.iss
+++ b/windows-installer/installer.iss
@@ -8,27 +8,24 @@
 #define MyAppURL "https://github.com/Rhizomatica/mercury"
 #define MyAppExeName "mercury-ui.exe"
 
-; --- Optional Authenticode signing --------------------------------------
-; The SimplySign cert lives in Certum's cloud HSM — no .pfx file exists.
-; The SimplySign Desktop app injects the cert into the Windows cert store.
-; Once SimplySign Desktop is running and authenticated, sign with:
+; --- Authenticode signing ----------------------------------------------
+; The EXE files (payload + installer) are signed with osslsigncode on Linux,
+; not with Inno's SignTool. The SimplySign cert has no .pfx — signing uses
+; the cloud HSM via PKCS#11. See docs/WINDOWS-SIGNING.md.
 ;
+; Build unsigned, then sign afterward:
+;   1. ISCC installer.iss                         (builds Mercury_*.exe)
+;   2. make sign BIN=Mercury_$(VERSION)_Setup.exe  (signs it on Linux)
+;
+; If you prefer Inno-side signing on Windows (requires SimplySign Desktop):
 ;   ISCC /DSIGN /Smercury="signtool sign /a /fd sha256 \
 ;         /tr http://time.certum.pl /td sha256 $f" installer.iss
 ;
-; The /a flag auto-selects the cert from the Windows cert store.
-; Without /DSIGN the installer builds unsigned exactly as before.
-;
-; For a local .pfx (self-signed test or OV/EV token), use:
+; Old local-.pfx path (self-signed test / OV/EV token):
 ;   ISCC /DSIGN /Smercury="signtool sign /f cert.pfx /p PW /fd sha256 \
 ;         /tr http://timestamp.digicert.com /td sha256 $f" installer.iss
-;
-; See docs/WINDOWS-SIGNING.md for the full signing workflow.
-#ifdef SIGN
-  #define ExeFlags "ignoreversion signonce"
-#else
-  #define ExeFlags "ignoreversion"
-#endif
+#undef SIGN
+#define ExeFlags "ignoreversion"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.
@@ -51,10 +48,6 @@ WizardStyle=modern
 PrivilegesRequired=admin
 ChangesEnvironment=yes
 ArchitecturesInstallIn64BitMode=x64
-#ifdef SIGN
-SignTool=mercury
-SignedUninstaller=yes
-#endif
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"


### PR DESCRIPTION
## What

Windows Authenticode code signing for Mercury's binaries, driven by the
**Certum SimplySign** cloud certificate (cloud HSM — no `.pfx` file), runnable
headlessly on Linux and in CI. Off by default; unsigned builds are byte-for-byte
unchanged.

**Validated end-to-end** against the real *Open Source Developer Rafael Diniz*
cert: signed + RFC-3161-timestamped a Windows PE, `osslsigncode verify` confirms
`Issuer: Certum Code Signing 2021 CA`, serial `219D71FAF992D043051392DC77EB705B`,
timestamp OK.

## The load-bearing finding: sign with jsign, not osslsigncode

The SimplySign PKCS#11 module (`SimplySignPKCS_64-MS-1.0.20.so`, Desktop 2.9.14)
does **not** expose its objects to OpenSC's `C_FindObjects` — `pkcs11-tool -O`,
`p11tool` and `osslsigncode -pkcs11module` all see an **empty** object list
(the token is present in `-L`, but no enumerable objects, under any PIN incl.
empty), so osslsigncode cannot find the key. Java's **SunPKCS11** provider *does*
enumerate the key by alias, so **jsign** signs where osslsigncode can't.
osslsigncode is kept only to *verify*. This mirrors the upstream reactiveui
`certum-sign` action, which also uses jsign.

Two more gotchas baked into the scripts:
- **`USER` must be exported** — the module bundles an ancient OpenSSL that
  NULL-derefs (SIGSEGV, exit 139) when `$USER` is empty (non-login shells / CI).
- **Login once, sign many** — the authenticated session and per-file signing are
  separate lifecycles, so a slow cloud round-trip can't be raced by a cleanup.

## Changes

- **`code-signing/`** (new): `sign-lib.sh` (login-once/sign/logout primitives),
  `sign.sh` (sign N binaries in place with one login), `sign-logout.sh`,
  `README.md` (quickstart + where secrets go), and
  `.github-workflow-example/sign-windows.yml` (CI).
- **`Makefile`**: `SIGN_SCRIPT` → in-repo `code-signing/sign.sh`; SimplySign
  signing is **opt-in** (runs only when `CERTUM_EMAIL` is set), so plain
  `windows-zip` stays unsigned; `windows-zip-signed` tears the session down via
  `SIGN_LOGOUT`. `windows-installer/installer.iss` keeps its `SIGN`-gated Inno
  path; the local self-signed `.pfx` path (`WIN_SIGN_PFX`, osslsigncode) remains
  for pipeline testing.
- **`docs/WINDOWS-SIGNING.md`**: full reference — the jsign vs osslsigncode
  finding, the `USER` gotcha, prerequisites (jsign/java), secret locations,
  Makefile params, and CI.
- **`.gitignore`**: blocks `*otpauth* pass.txt *sunpkcs11*.conf jsign*.jar`
  alongside `*.pfx *.p12 *.signed`.

## Secrets (never committed — kept OUTSIDE the repo)

Two GitHub **Actions secrets** are required for CI (Settings → Secrets and
variables → Actions):

| Secret | What it is |
|---|---|
| `CERTUM_EMAIL` | SimplySign account e-mail |
| `CERTUM_OTP_URI` | the `otpauth://` URI (TOTP seed) — treat as a password |

Locally, point `CERTUM_EMAIL` + `CERTUM_OTP_URI_FILE` (+ `JSIGN_JAR`) at files
under your home; `make windows-zip-signed` does the rest.

## CI

`code-signing/.github-workflow-example/sign-windows.yml` runs inside reactiveui's
prebuilt `ghcr.io/reactiveui/certum-signer` image (SimplySign + jsign + X11
preinstalled) and reads the two secrets above. Move it to `.github/workflows/`
to enable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
