### PR TITLE
modem: 8 MB stacks for TX/RX threads — fixes macOS crash on wide OFDM modes

### DIFF
--- a/modem/modem.c
+++ b/modem/modem.c
@@ -559,9 +559,19 @@ try_shm_connect2:
         run_tests_rx(g_modem);
     }
 
-    // Create TX and RX threads
-    pthread_create(&tx_thread_tid, NULL, tx_thread, (void *)g_modem);
-    pthread_create(&rx_thread_tid, NULL, rx_thread, (void *)g_modem);
+    // Create TX and RX threads.  Explicit 8 MB stacks: the codec2 OFDM
+    // mod/demod paths allocate large VLA buffers for the wide modes (e.g.
+    // DATAC16's LDPC interleaver), which overflows the macOS default pthread
+    // stack of 512 KB (SIGBUS in ofdm_ldpc_interleave_tx); glibc's default is
+    // 8 MB, so match it everywhere.
+    {
+        pthread_attr_t modem_thread_attr;
+        pthread_attr_init(&modem_thread_attr);
+        pthread_attr_setstacksize(&modem_thread_attr, 8 * 1024 * 1024);
+        pthread_create(&tx_thread_tid, &modem_thread_attr, tx_thread, (void *)g_modem);
+        pthread_create(&rx_thread_tid, &modem_thread_attr, rx_thread, (void *)g_modem);
+        pthread_attr_destroy(&modem_thread_attr);
+    }
 
     return 0;
 }


### PR DESCRIPTION
## Problem

On macOS, mercury crashes the first time the mode ladder reaches a wide OFDM mode (observed with DATAC16) and keys a burst. The TX thread dies with:

```
EXC_BAD_ACCESS (SIGBUS), Thread stack size exceeded
KERN_PROTECTION_FAILURE

Thread 4 (tx_thread):
  ___chkstk_darwin
  ofdm_ldpc_interleave_tx
  freedv_comptx_ofdm
  freedv_rawdatacomptx
  freedv_rawdatatx
  send_modulated_data
  tx_thread
```

## Cause

The codec2 OFDM mod/demod paths allocate their working buffers as variable-length arrays on the stack, sized by the mode's frame geometry. For the wide modes this exceeds the macOS default pthread stack of **512 KB**. Linux never sees it because glibc's default thread stack is **8 MB**.

## Fix

Create the modem TX/RX threads with an explicit 8 MB stack (`pthread_attr_setstacksize`), so every platform gets the stack size the code was effectively developed against. One hunk in `init_modem`; no behavior change beyond not crashing. All backends are affected on macOS (this reproduces against a plain audio device too), so the fix is not specific to any transport.

Found while running two mercury instances through a channel simulator on an Apple Silicon MacBook Air (macOS 26.5): connect + mode negotiation up to DATAC16 completed, then the sender vanished mid-burst with the crash report above. With this fix the same scenario completes 4096/4096 B transfers repeatedly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Az9HBCH2P8e5f2A4G5LPTn