### PR TITLE
Store config, logs in install dir on Windows and fix audio device persistence on restart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ fyne-ui-windows: libmercury_core_w64.a
 windows-installer: fyne-ui-windows
 	cp mercury.ini.example $(WINDOWS_INSTALLER_DIR)/mercury.ini
 	sed -i 's/ui_enabled = false/ui_enabled = true/g' $(WINDOWS_INSTALLER_DIR)/mercury.ini
-	sed -i 's/sound_system = auto/sound_system = dsound/g' $(WINDOWS_INSTALLER_DIR)/mercury.ini
+	sed -i 's/sound_system = auto/sound_system = wasapi/g' $(WINDOWS_INSTALLER_DIR)/mercury.ini
 	if ls $(HAMLIB_W64_DIR)/bin/*.dll >/dev/null 2>&1; then \
 		cp $(HAMLIB_W64_DIR)/bin/*.dll $(WINDOWS_INSTALLER_DIR)/; \
 	fi

--- a/common/mercury_engine.c
+++ b/common/mercury_engine.c
@@ -55,8 +55,6 @@ static int apply_audio_defaults(int audio_system, char *input_dev, size_t in_siz
     case AUDIO_SUBSYSTEM_PULSE:
     case AUDIO_SUBSYSTEM_WASAPI:
     case AUDIO_SUBSYSTEM_DSOUND:
-        input_dev[0] = '\0';
-        output_dev[0] = '\0';
         break;
     case AUDIO_SUBSYSTEM_OSS:
         if (input_dev[0] == 0)  snprintf(input_dev, in_size, "/dev/dsp");

--- a/gui_interface/fyne-ui/main.go
+++ b/gui_interface/fyne-ui/main.go
@@ -959,15 +959,7 @@ func main() {
 	go func() {
 		time.Sleep(200 * time.Millisecond)
 
-		// Per-user writable config used when no -C is passed (seeded from the
-		// bundled default the first time).  The C parser picks -C over this.
-		defaultConfig := filepath.Join(getLogDir(), "mercury.ini")
-		if _, err := os.Stat(defaultConfig); os.IsNotExist(err) {
-			bundled := filepath.Join(getBaseDir(), "mercury.ini")
-			if data, rerr := os.ReadFile(bundled); rerr == nil {
-				os.WriteFile(defaultConfig, data, 0644)
-			}
-		}
+		defaultConfig := filepath.Join(getBaseDir(), "mercury.ini")
 
 		logPath := filepath.Join(getLogDir(), "mercury_engine.log")
 		appendLog("Starting Mercury engine...\n")
@@ -1249,9 +1241,7 @@ func getBaseDir() string {
 
 func getLogDir() string {
 	if runtime.GOOS == "windows" {
-		dir := filepath.Join(os.Getenv("LOCALAPPDATA"), "MercuryHF")
-		os.MkdirAll(dir, 0755)
-		return dir
+		return getBaseDir()
 	}
 	return "."
 }

--- a/windows-installer/installer.iss
+++ b/windows-installer/installer.iss
@@ -37,9 +37,12 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
 
 
+[Dirs]
+Name: "{app}"; Permissions: users-modify
+
 [Files]
 Source: "run_mercury.bat"; DestDir: "{app}"; Flags: ignoreversion
-Source: "mercury.ini"; DestDir: "{app}"; Flags: ignoreversion
+Source: "mercury.ini"; DestDir: "{app}"; Flags: ignoreversion; Permissions: users-modify
 Source: "../LICENSE"; DestDir: "{app}"; Flags: ignoreversion
 Source: "../assets/mercury.ico"; DestDir: "{app}"; Flags: ignoreversion
 Source: "libgcc_s_seh-1.dll"; DestDir: "{app}"; Flags: ignoreversion


### PR DESCRIPTION
1. **Consolidate config and log paths to the installation directory**
On Windows, the GUI now stores `mercury.ini`, `mercury_engine.log`, and `ui.log` all in the same folder as the program executable (`C:\Program Files\MercuryHF\`), instead of scattering config to `%LOCALAPPDATA%\MercuryHF\.` The first-run copy-to-per-user-dir logic is removed.
2. **Grant write permissions in the installer**
Added `[Dirs]` with `Permissions: users-modify` on `{app}` and `Permissions: users-modify` on `mercury.ini` in the Inno Setup script, so non-admin users can write config changes and create log files in the install directory.
3. **Fix audio device selection not persisting across restarts**
`apply_audio_defaults()` was unconditionally zeroing the device ID strings for DirectSound, WASAPI, and PulseAudio backends after loading them from `mercury.ini`. This caused saved soundcard selections to be lost on every restart — the UI showed defaults and no audio was received until devices were manually re-selected. Removed the destructive clearing; empty string already means "default device" for these backends.
4. **Switch Windows default audio system to WASAPI**
Changed the installer's default sound_system from dsound to wasapi.