### PR TITLE
fix: race condition in WebSocket connect callback on aarch64

### DIFF
--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -505,15 +505,17 @@ int ui_comm_init(ui_ctx_t *ctx, uint16_t ws_port, bool tls_enabled,
     }
 
     // Initialize WebSocket server (bidirectional: status TX + command RX)
-    // Serve static test page from websocket/web/ directory
+    // Serve static test page from websocket/web/ directory.
+    // connect callback is registered before the server thread starts to avoid
+    // a race on aarch64 where the callback ptr and data could be seen
+    // out-of-order by the server thread.
     if (ws_init(&ctx->ws, ws_port, "gui_interface/websocket/web",
-                ws_command_handler, ctx, tls_enabled) != 0) {
+                ws_command_handler, ctx,
+                ws_connect_handler, ctx,
+                tls_enabled) != 0) {
         HLOGE(UI_LOG_TAG, "Failed to init WebSocket server on port %u", ws_port);
         return -1;
     }
-    // Register connect callback - sends all device lists and radio list on each new UI connection
-    ctx->ws.connect_callback = ws_connect_handler;
-    ctx->ws.connect_callback_data = ctx;
     HLOGI(UI_LOG_TAG, "WebSocket server ready on port %u", ws_port);
 
     // Start publisher thread - periodic status broadcaster (via WebSocket)

--- a/gui_interface/websocket/mercury_websocket.c
+++ b/gui_interface/websocket/mercury_websocket.c
@@ -411,6 +411,8 @@ int ws_init(ws_ctx_t *ctx,
             const char *web_root,
             ws_command_callback_t cmd_callback,
             void *cb_data,
+            ws_connect_callback_t connect_callback,
+            void *connect_cb_data,
             bool tls_enabled)
 {
     if (!ctx)
@@ -421,6 +423,8 @@ int ws_init(ws_ctx_t *ctx,
     ctx->tls_enabled = tls_enabled;
     ctx->cmd_callback = cmd_callback;
     ctx->cmd_callback_data = cb_data;
+    ctx->connect_callback = connect_callback;
+    ctx->connect_callback_data = connect_cb_data;
 
     snprintf(ctx->listen_url, sizeof(ctx->listen_url),
              "%s://0.0.0.0:%u", tls_enabled ? "wss" : "ws", port);

--- a/gui_interface/websocket/mercury_websocket.h
+++ b/gui_interface/websocket/mercury_websocket.h
@@ -100,6 +100,8 @@ int ws_init(ws_ctx_t *ctx,
             const char *web_root,
             ws_command_callback_t cmd_callback,
             void *cb_data,
+            ws_connect_callback_t connect_callback,
+            void *connect_cb_data,
             bool tls_enabled);
 
 /**


### PR DESCRIPTION
## Problem

Reported by PD0ART — on aarch64 (Raspberry Pi 4, Ubuntu 24.04 LTS, glibc 2.39), Mercury 1.9.10 segfaults in `__strlen_generic` the moment a browser opens the waterfall page. Works fine on Ubuntu 25.04. Running under gdb prevents the crash (race condition).

## Root Cause

`ws_init()` starts the WebSocket server thread via `pthread_create`, but `connect_callback` and `connect_callback_data` were set in `ui_comm_init()` **after** `ws_init()` returned. On aarch64's relaxed memory model, the server thread could observe `connect_callback` as valid while `connect_callback_data` was still NULL, leading to a bad pointer dereference inside mongoose's internal string handling.

## Fix

Accept `connect_callback` and its user data as parameters to `ws_init()` and store both **before** `pthread_create` fires. This moves the initialization into the same happens-before scope as the thread start.

## Changes

- `mercury_websocket.h`: added `connect_callback` and `connect_cb_data` params to `ws_init()`
- `mercury_websocket.c`: store callbacks before `pthread_create`
- `ui_communication.c`: pass callbacks directly to `ws_init()`, removed post-init assignment

## Testing

- Compiles cleanly on x86_64 (no warnings)
- Needs on-device testing: build on RPi4 aarch64, connect browser to port 10000