### PR TITLE
modem: TUNE command — a 1 kHz ATU tuning carrier with a hard unkey timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ over HF radio links in rural and emergency scenarios.
 - **Adaptive payload "gear-shifting"** (DATAC4/DATAC3/DATAC1) driven by link quality and backlog, with DATAC13 used for control signaling.
 - **Per-direction mode selection**: each path (A→B and B→A) negotiates its mode independently based on local SNR.
 - **Broadcast data mode** in parallel to ARQ, with dedicated broadcast framing and TCP ingress port.
-- **VARA-style TCP TNC interface** with separate control and data sockets (base port and base+1), including commands/status like `MYCALL`, `LISTEN`, `CONNECT`, `BUFFER`, `SN`, and `BITRATE`.
+- **VARA-style TCP TNC interface** with separate control and data sockets (base port and base+1), including commands/status like `MYCALL`, `LISTEN`, `CONNECT`, `BUFFER`, `SN`, `BITRATE`, and `TUNE` (a 1 kHz ATU tuning carrier at a requested dBFS level, with a hard 60 s unkey timer).
 - **Audio modem operation over multiple backends** (`alsa`, `pulse`, `oss`, `coreaudio`, `aaudio`, `dsound`, `wasapi`, `shm`, `null`, `fifo`) with split RX/TX modem orchestration.
 - **Direct radio control** via HAMLIB or HERMES shared-memory interface for direct PTT keying.
 

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -50,6 +50,7 @@
 #include "framer.h"
 #include "hermes_log.h"
 #include "radio_io.h"
+#include "modem.h"
 
 static pthread_t tid[7];
 static bool tid_started[7];
@@ -403,6 +404,48 @@ static void execute_control_command(char *buffer)
 
     if (!strncmp(buffer, "P2P", strlen("P2P")))
     {
+        tcp_write(CTL_TCP_PORT, (uint8_t *)"OK\r", 3);
+        return;
+    }
+
+    if (!strncmp(buffer, "TUNE", strlen("TUNE")))
+    {
+        /* VARA-compatible tuning carrier, so an ATU can find a match:
+         *   TUNE -<dB>   key TX and hold a ~1 kHz tone at that drive level
+         *   TUNE ?       report the current drive level
+         *   TUNE OFF     unkey
+         * The carrier also stops on its own after modem.c's hard safety
+         * deadline — a keyed tone has no protocol underneath it, so a host
+         * that dies or forgets TUNE OFF must not leave the radio keyed. */
+        char arg[16] = {0};
+        if (sscanf(buffer, "TUNE %15s", arg) != 1)
+        {
+            tcp_write(CTL_TCP_PORT, (uint8_t *)"WRONG\r", 6);
+            return;
+        }
+
+        if (!strncasecmp(arg, "OFF", strlen("OFF")))
+        {
+            modem_tune_stop();
+            tcp_write(CTL_TCP_PORT, (uint8_t *)"OK\r", 3);
+            return;
+        }
+
+        if (arg[0] == '?')
+        {
+            char reply[32];
+            int n = snprintf(reply, sizeof(reply), "TUNE %g\r",
+                             (double)modem_tune_level_dbfs());
+            tcp_write(CTL_TCP_PORT, (uint8_t *)reply, (size_t)n);
+            return;
+        }
+
+        float dbfs = 0.0f;
+        if (sscanf(arg, "%f", &dbfs) != 1 || modem_tune_start(dbfs) != 0)
+        {
+            tcp_write(CTL_TCP_PORT, (uint8_t *)"WRONG\r", 6);
+            return;
+        }
         tcp_write(CTL_TCP_PORT, (uint8_t *)"OK\r", 3);
         return;
     }

--- a/mercury.1
+++ b/mercury.1
@@ -322,6 +322,30 @@ Query the current signal-to-noise ratio.
 .B BITRATE
 Query the current bitrate.
 .TP
+.BI "TUNE " -dB
+Key the transmitter and hold a steady 1000 Hz tone at the given level in dBFS,
+so an antenna tuner can find a match (for example
+.BR "TUNE -15" ).
+Accepted levels are \-60 to 0 dBFS.
+The level is absolute at the sound card: the modulator TX gain is deliberately
+not applied, so
+.B TUNE -15
+really is \-15 dBFS.
+Re-issuing while tuning changes the level and restarts the safety timer.
+Refused while a link is connected or a burst is in flight.
+.IP
+The carrier
+.B always
+stops by itself after 60 seconds, even if the host never sends
+.BR "TUNE OFF" ,
+crashes, or drops the control socket \(em nothing else bounds a keyed carrier.
+.TP
+.B TUNE ?
+Query the current tuning drive level.
+.TP
+.B TUNE OFF
+Stop the tuning carrier and unkey.
+.TP
 .BI "CQFRAME " "callsign " bandwidth
 Transmit a CQ broadcast frame.
 .I bandwidth

--- a/modem/modem.c
+++ b/modem/modem.c
@@ -104,6 +104,175 @@ float modem_get_tx_peak_dbfs(void)
     return atomic_load(&g_tx_peak_dbfs);
 }
 
+/* --- ATU tuning carrier (host "TUNE" command) ------------------------
+ *
+ * A steady single tone with the transmitter keyed, so an antenna tuner can
+ * find a match.  VARA HF drives its TUNE button the same way (~1 kHz), and
+ * the host syntax mirrors VARA's: TUNE -<dB> / TUNE ? / TUNE OFF.
+ *
+ * SAFETY IS THE WHOLE DESIGN HERE.  Unlike every other transmission Mercury
+ * makes, this one has no protocol underneath it: nothing bounds it except us.
+ * A carrier left keyed cooks a finals stage and jams the channel, so:
+ *   * a hard deadline (MODEM_TUNE_MAX_S) unkeys even if the host never sends
+ *     TUNE OFF, dies, or drops the control socket;
+ *   * the loop tops the playback ring up in short chunks and never blocks on
+ *     a full ring, so a stalled audio consumer cannot pin PTT on;
+ *   * send_modulated_data() refuses while tuning, and tuning refuses while a
+ *     link is up or a burst is in flight — the two can never key together.
+ *
+ * The requested level is absolute dBFS at the sound card and deliberately
+ * does NOT go through g_tx_gain: "TUNE -15" must mean -15 dBFS, not -15 dBFS
+ * times whatever the modulator gain happens to be.
+ */
+#define MODEM_TUNE_TONE_HZ       1000.0   /* VARA-compatible tuning tone      */
+#define MODEM_TUNE_MAX_S         60       /* hard unkey deadline (seconds)    */
+#define MODEM_TUNE_MIN_DBFS      (-60.0f)
+#define MODEM_TUNE_MAX_DBFS      (0.0f)   /* above 0 dBFS would just clip     */
+#define MODEM_TUNE_CHUNK_SAMPLES 800      /* 100 ms @ 8 kHz                   */
+/* Keep at most this much audio queued, so TUNE OFF and the deadline both take
+ * effect within ~one chunk instead of after the whole ring drains. */
+#define MODEM_TUNE_RING_HIGH_BYTES (4800 * (int)sizeof(int32_t))   /* 600 ms */
+
+static _Atomic bool     g_tune_active      = false;
+static _Atomic bool     g_tune_stop        = false;
+static _Atomic int      g_tune_dbfs_milli  = -15000;  /* dBFS * 1000 */
+static _Atomic uint64_t g_tune_deadline_ms = 0;
+static pthread_t        g_tune_tid;
+static pthread_mutex_t  g_tune_lock = PTHREAD_MUTEX_INITIALIZER;
+static bool             g_tune_running = false;   /* guarded by g_tune_lock */
+
+bool modem_tune_active(void)
+{
+    return atomic_load(&g_tune_active);
+}
+
+float modem_tune_level_dbfs(void)
+{
+    return (float)atomic_load(&g_tune_dbfs_milli) / 1000.0f;
+}
+
+static void *tune_thread(void *unused)
+{
+    (void)unused;
+    static const double TWO_PI = 6.283185307179586476925286766559;
+    const double dphi = TWO_PI * MODEM_TUNE_TONE_HZ / (double)FREEDV_FS_8000;
+    int32_t chunk[MODEM_TUNE_CHUNK_SAMPLES];
+    double phase = 0.0;
+    bool timed_out = false;
+
+    ptt_on();
+
+    while (!shutdown_ && !atomic_load(&g_tune_stop))
+    {
+        if (time_now_ms() >= atomic_load(&g_tune_deadline_ms))
+        {
+            timed_out = true;
+            break;
+        }
+
+        /* Never block on a full ring while keyed — poll instead, so the
+         * deadline above is always reachable. */
+        if ((int)size_buffer(playback_buffer) >= MODEM_TUNE_RING_HIGH_BYTES)
+        {
+            usleep(10000);
+            continue;
+        }
+
+        float dbfs = modem_tune_level_dbfs();
+        double amp = pow(10.0, (double)dbfs / 20.0) * 2147483648.0;
+        for (int i = 0; i < MODEM_TUNE_CHUNK_SAMPLES; i++)
+        {
+            double v = sin(phase) * amp;
+            phase += dphi;
+            if (phase >= TWO_PI) phase -= TWO_PI;
+            if (v >=  2147483647.0)      chunk[i] = INT32_MAX;
+            else if (v <= -2147483648.0) chunk[i] = INT32_MIN;
+            else                         chunk[i] = (int32_t)v;
+        }
+        write_buffer(playback_buffer, (uint8_t *)chunk, sizeof(chunk));
+        atomic_store(&g_tx_peak_dbfs, dbfs);
+    }
+
+    /* Let what is already queued play out before unkeying, but bound the
+     * wait: a wedged consumer must not hold the transmitter up. */
+    uint64_t tail_deadline = time_now_ms() + 2000;
+    while (!shutdown_ && size_buffer(playback_buffer) > 0 &&
+           time_now_ms() < tail_deadline)
+        usleep(1000);
+    usleep(TAIL_TIME_US);
+
+    ptt_off();
+    atomic_store(&g_tune_active, false);
+
+    if (timed_out)
+        HLOGW("tune", "tuning carrier stopped: %d s safety limit reached",
+              MODEM_TUNE_MAX_S);
+    else
+        HLOGI("tune", "tuning carrier stopped");
+    return NULL;
+}
+
+int modem_tune_start(float dbfs)
+{
+    if (!isfinite(dbfs) || dbfs < MODEM_TUNE_MIN_DBFS || dbfs > MODEM_TUNE_MAX_DBFS)
+    {
+        HLOGW("tune", "refused: level %.1f dBFS outside [%.0f, %.0f]",
+              (double)dbfs, (double)MODEM_TUNE_MIN_DBFS, (double)MODEM_TUNE_MAX_DBFS);
+        return -1;
+    }
+
+    pthread_mutex_lock(&g_tune_lock);
+
+    /* A tuning carrier on top of a live link would key over the session and
+     * trash it; an in-flight burst already owns the transmitter. */
+    if (arq_is_link_connected() || arq_get_trx() == TX)
+    {
+        pthread_mutex_unlock(&g_tune_lock);
+        HLOGW("tune", "refused: link connected or transmit in progress");
+        return -2;
+    }
+
+    atomic_store(&g_tune_dbfs_milli, (int)lrintf(dbfs * 1000.0f));
+    atomic_store(&g_tune_deadline_ms, time_now_ms() + MODEM_TUNE_MAX_S * 1000ULL);
+
+    if (g_tune_running)
+    {
+        /* Re-issuing TUNE while tuning retunes the level and restarts the
+         * safety timer — what an operator adjusting drive expects. */
+        pthread_mutex_unlock(&g_tune_lock);
+        HLOGI("tune", "tuning carrier level set to %.1f dBFS", (double)dbfs);
+        return 0;
+    }
+
+    atomic_store(&g_tune_stop, false);
+    atomic_store(&g_tune_active, true);
+    if (pthread_create(&g_tune_tid, NULL, tune_thread, NULL) != 0)
+    {
+        atomic_store(&g_tune_active, false);
+        pthread_mutex_unlock(&g_tune_lock);
+        HLOGE("tune", "could not start tuning thread");
+        return -3;
+    }
+    g_tune_running = true;
+    pthread_mutex_unlock(&g_tune_lock);
+
+    HLOGI("tune", "tuning carrier ON: %.0f Hz at %.1f dBFS, max %d s",
+          MODEM_TUNE_TONE_HZ, (double)dbfs, MODEM_TUNE_MAX_S);
+    return 0;
+}
+
+void modem_tune_stop(void)
+{
+    pthread_mutex_lock(&g_tune_lock);
+    if (g_tune_running)
+    {
+        atomic_store(&g_tune_stop, true);
+        pthread_join(g_tune_tid, NULL);
+        g_tune_running = false;
+    }
+    pthread_mutex_unlock(&g_tune_lock);
+}
+
 /* Convert a 16-bit modulator sample to a 32-bit playback sample with gain
  * and saturation.  At gain == 1.0 this matches the historical behavior of
  * mapping int16 into the upper bits of int32 — but via a multiply by 65536,
@@ -690,6 +859,11 @@ int run_tests_rx(generic_modem_t *g_modem)
 
 int shutdown_modem(generic_modem_t *g_modem)
 {
+    /* Unkey and join the tuning thread first: it owns PTT and writes into the
+     * playback ring, so tearing the rings down under it would both leave the
+     * transmitter keyed and use freed memory. */
+    modem_tune_stop();
+
     /* rx_thread reads the capture ring with a BLOCKING read_buffer() sized to
      * the decoder chunk.  By the time we get here the audio capture thread
      * has already exited, so if rx_thread parked on an empty ring after its
@@ -791,6 +965,17 @@ int send_modulated_data(generic_modem_t *g_modem, uint8_t *bytes_in, int frames_
     size_t total_samples = 0;
     float tx_gain = atomic_load(&g_tx_gain);
     float peak_fs = 0.0f;  /* pre-saturation peak magnitude across this burst */
+
+    /* Never modulate on top of a tuning carrier: the tune thread owns PTT and
+     * the playback ring until TUNE OFF or its safety deadline. */
+    if (atomic_load(&g_tune_active))
+    {
+        HLOGW("modem", "TX suppressed: tuning carrier active (send TUNE OFF)");
+        free(tx_buffer);
+        free(mod_out_short);
+        pthread_mutex_unlock(&modem_freedv_lock);
+        return -1;
+    }
 
 
     /* === STEP 1: Generate all modulated audio into temp buffer === */

--- a/modem/modem.h
+++ b/modem/modem.h
@@ -87,4 +87,26 @@ float modem_get_tx_gain(void);
 // silent.
 float modem_get_tx_peak_dbfs(void);
 
+// --- ATU tuning carrier (host "TUNE" command) ---
+// Key the transmitter and emit a steady ~1 kHz tone so an antenna tuner can
+// find a match, VARA-style. `dbfs` is the absolute level at the sound card in
+// dBFS and must be in [-60, 0]; the modulator TX gain is deliberately NOT
+// applied, so "TUNE -15" really is -15 dBFS.
+//
+// The carrier ALWAYS stops on its own after a hard safety deadline (see
+// MODEM_TUNE_MAX_S in modem.c) even if the host never sends TUNE OFF, dies, or
+// drops the control socket — nothing else bounds a keyed carrier. Re-issuing
+// while tuning retunes the level and restarts that deadline.
+//
+// Returns 0 on success, -1 if the level is out of range, -2 if a link is up or
+// a burst is in flight (the two never key together), -3 if the thread failed.
+int   modem_tune_start(float dbfs);
+// Stop the carrier and unkey. Safe to call when not tuning; blocks until the
+// tuning thread has unkeyed.
+void  modem_tune_stop(void);
+// True while the carrier is keyed.
+bool  modem_tune_active(void);
+// Most recently requested tuning level in dBFS (what "TUNE ?" reports).
+float modem_tune_level_dbfs(void);
+
 #endif // MODEM_H

--- a/tests/data_interfaces/test_tcp_interfaces.c
+++ b/tests/data_interfaces/test_tcp_interfaces.c
@@ -135,6 +135,24 @@ bool radio_io_enabled(void) { return false; }
 void radio_io_key_on(void) { }
 void radio_io_key_off(void) { }
 
+/* ---- modem tuning-carrier stubs ---- */
+
+static float mock_tune_start_dbfs  = 0.0f;
+static int   mock_tune_start_calls = 0;
+static int   mock_tune_start_rc    = 0;     /* what modem_tune_start returns */
+static int   mock_tune_stop_calls  = 0;
+static float mock_tune_level_dbfs  = -15.0f;
+
+int modem_tune_start(float dbfs)
+{
+    mock_tune_start_dbfs = dbfs;
+    mock_tune_start_calls++;
+    return mock_tune_start_rc;
+}
+void  modem_tune_stop(void)        { mock_tune_stop_calls++; }
+bool  modem_tune_active(void)      { return false; }
+float modem_tune_level_dbfs(void)  { return mock_tune_level_dbfs; }
+
 /* ---- ring_buffer stubs ---- */
 
 size_t size_buffer(cbuf_handle_t cbuf) { (void)cbuf; return 0; }
@@ -251,6 +269,13 @@ void setUp(void)
 
     /* Reset dedup */
     atomic_store_explicit(&tnc_last_buffer_sent, -1, memory_order_relaxed);
+
+    /* Tuning carrier */
+    mock_tune_start_dbfs  = 0.0f;
+    mock_tune_start_calls = 0;
+    mock_tune_start_rc    = 0;
+    mock_tune_stop_calls  = 0;
+    mock_tune_level_dbfs  = -15.0f;
 }
 
 void tearDown(void) { }
@@ -316,6 +341,83 @@ void test_cmd_compression(void)
 
     assert_ok_response();
     TEST_ASSERT_EQUAL(0, captured_cmd_count);
+}
+
+/* ---- TUNE: the ATU tuning carrier (VARA syntax) ----
+ * This command keys the transmitter with no protocol underneath it, so the
+ * parser boundary is safety-relevant: a level must reach the modem verbatim,
+ * a refusal must NOT be reported as success, and OFF must always stop. */
+
+void test_cmd_tune_on(void)
+{
+    char cmd[] = "TUNE -15";
+    execute_control_command(cmd);
+
+    assert_ok_response();
+    TEST_ASSERT_EQUAL_INT(1, mock_tune_start_calls);
+    TEST_ASSERT_EQUAL_FLOAT(-15.0f, mock_tune_start_dbfs);
+}
+
+void test_cmd_tune_on_fractional_level(void)
+{
+    char cmd[] = "TUNE -12.5";
+    execute_control_command(cmd);
+
+    assert_ok_response();
+    TEST_ASSERT_EQUAL_FLOAT(-12.5f, mock_tune_start_dbfs);
+}
+
+void test_cmd_tune_off(void)
+{
+    char cmd[] = "TUNE OFF";
+    execute_control_command(cmd);
+
+    assert_ok_response();
+    TEST_ASSERT_EQUAL_INT(1, mock_tune_stop_calls);
+    TEST_ASSERT_EQUAL_INT(0, mock_tune_start_calls);
+}
+
+void test_cmd_tune_query_reports_level(void)
+{
+    mock_tune_level_dbfs = -15.0f;
+    char cmd[] = "TUNE ?";
+    execute_control_command(cmd);
+
+    TEST_ASSERT_EQUAL(1, tcp_write_call_count);
+    TEST_ASSERT_EQUAL_STRING("TUNE -15\r", (char *)last_tcp_write_buf);
+    /* A query must not key anything. */
+    TEST_ASSERT_EQUAL_INT(0, mock_tune_start_calls);
+    TEST_ASSERT_EQUAL_INT(0, mock_tune_stop_calls);
+}
+
+void test_cmd_tune_refusal_is_not_ok(void)
+{
+    /* modem_tune_start rejects out-of-range levels and refuses while a link
+     * is up; the host must see WRONG, never OK. */
+    mock_tune_start_rc = -2;
+    char cmd[] = "TUNE -15";
+    execute_control_command(cmd);
+
+    assert_wrong_response();
+    TEST_ASSERT_EQUAL_INT(1, mock_tune_start_calls);
+}
+
+void test_cmd_tune_missing_argument(void)
+{
+    char cmd[] = "TUNE";
+    execute_control_command(cmd);
+
+    assert_wrong_response();
+    TEST_ASSERT_EQUAL_INT(0, mock_tune_start_calls);
+}
+
+void test_cmd_tune_garbage_argument(void)
+{
+    char cmd[] = "TUNE loud";
+    execute_control_command(cmd);
+
+    assert_wrong_response();
+    TEST_ASSERT_EQUAL_INT(0, mock_tune_start_calls);
 }
 
 void test_cmd_chat_on(void)
@@ -888,6 +990,13 @@ int main(void)
     RUN_TEST(test_cmd_listen_off);
     RUN_TEST(test_cmd_public_on);
     RUN_TEST(test_cmd_compression);
+    RUN_TEST(test_cmd_tune_on);
+    RUN_TEST(test_cmd_tune_on_fractional_level);
+    RUN_TEST(test_cmd_tune_off);
+    RUN_TEST(test_cmd_tune_query_reports_level);
+    RUN_TEST(test_cmd_tune_refusal_is_not_ok);
+    RUN_TEST(test_cmd_tune_missing_argument);
+    RUN_TEST(test_cmd_tune_garbage_argument);
     RUN_TEST(test_cmd_chat_on);
     RUN_TEST(test_cmd_bw500);
     RUN_TEST(test_cmd_bw2300);


### PR DESCRIPTION
Adds a **TUNE** host command so an operator can key a steady carrier and let an antenna tuner find a match — and, as the user put it, use it as the reference for setting `tx_gain`.

## Host syntax — VARA's, exactly

```
TUNE -15\r   →  OK        key TX, hold a 1 kHz tone at -15 dBFS
TUNE ?\r     →  TUNE -15  report the drive level
TUNE OFF\r   →  OK        unkey
```

Matches the official VARA HF/SAT command set, so existing clients work unmodified. There is deliberately **no duration argument** — VARA has none, so the safety timer below is internal rather than part of the wire syntax.

The level is **absolute dBFS at the sound card** and deliberately does *not* go through `g_tx_gain`: `TUNE -15` has to mean −15 dBFS, not −15 dBFS scaled by whatever the modulator gain happens to be, since the whole point is a known reference to set drive against. Accepted range `[-60, 0]`.

## Safety is the design

Unlike every other transmission Mercury makes, a tuning carrier has no protocol underneath it — nothing bounds it but us. A carrier left keyed cooks a finals stage and jams the channel.

- A hard **`MODEM_TUNE_MAX_S` (60 s) deadline** unkeys even if the host never sends `TUNE OFF`, crashes, or drops the control socket.
- The write loop polls the ring and **never blocks while keyed**, so a stalled playback consumer cannot pin PTT on.
- `send_modulated_data()` refuses while tuning, and `modem_tune_start()` refuses when a link is up or a burst is in flight — **the two can never key together**.
- `shutdown_modem()` stops the tuning thread **first**, before the rings it writes into are torn down.

Re-issuing `TUNE` while tuning retunes the level and restarts the deadline, which is what an operator adjusting drive expects.

## Validated by measurement, not inspection

The tone was captured off the wire — via the `-x fifo` backend and over a **real `snd-aloop` ALSA device** — and analysed:

| | measured | requested |
|---|---|---|
| peak | **−15.02 dBFS** | −15.00 |
| rms | −18.01 dBFS | peak−3.01 (pure sine) ✓ |
| dominant tone | **1000.0 Hz** | 1000.0 |
| in-band energy | **1.00000** | — |

That last row matters: a phase discontinuity at the 100 ms chunk boundaries would show up as sidebands. The phase accumulator stays continuous.

Verified across **every playback layout the audioio layer negotiates**:

| format | channels | result |
|---|---|---|
| int16 | 1, 2 | ✅ 1000.0 Hz @ −15.02 dBFS |
| int32 | 1, 2 | ✅ 1000.0 Hz @ −15.02 dBFS |
| float32 | 1 | ✅ 1000.0 Hz @ −15.02 dBFS |

The int16/mono case is the one that matters most — that is the Yaesu FT-710 `hw:` profile where the old int32-into-int16 garbage-TX bug lived (fixed in d5f062c). It is clean.

**Safety timer proven the hard way**: started a carrier, then closed the control socket without ever sending `TUNE OFF`.

```
[INF] [tune]  tuning carrier ON: 1000 Hz at -20.0 dBFS, max 60 s
[INF] [radio] TX enabled (PTT ON)
        ... host gone ...
[INF] [radio] TX disabled (PTT OFF)
[WRN] [tune]  tuning carrier stopped: 60 s safety limit reached
```

## Tests

7 new unit tests on the parser boundary — in particular that a refusal is **never** reported as `OK`. Full suite **184 tests, 0 failures**, 0 build warnings.

## Two pre-existing audio findings (NOT fixed here, filed for follow-up)

Found while testing this on real ALSA devices; both predate this branch and affect all transmitted audio, not just the tuning tone:

1. **The negotiated sample rate is never checked.** `audioio.c` requests `sample_rate = 48000` for playback (~:726) and capture (~:1040) and hardcodes `resample_ratio = 6` (~:807 / ~:1107), then resamples unconditionally. Nothing compares the rate ALSA actually negotiated against that assumption (`grep -cE "sample_rate *[!=]= *48000"` = 0). Forcing an `snd-aloop` playback end to 8 kHz turned the 1 kHz tone into **166.8 Hz = 1000/6** — correct level, spectrally pure, just wrong frequency. Same code shape on capture. Normally masked because real cards do 48 kHz and Mercury asks for it; it bites when another client has already locked the device to a different rate.

2. **A 24-bit device cannot be opened.** With the loopback pinned to `S24_LE`, `audio->open()` fails outright, so the `FFAUDIO_F_INT24_4` branch in the emit loop is unreachable on ALSA. Fails safe (no corrupt audio) but a 24-bit-only card is unusable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
