### PR TITLE
audioio: support 24-bit packed (S24_3LE) cards on Linux

### DIFF
--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -27,6 +27,7 @@
 #include "audioio.h"
 #include "hermes_log.h"
 #include "resampler.h"
+#include "pcm24.h"
 
 extern volatile bool shutdown_;
 
@@ -907,8 +908,14 @@ void *radio_playback_thread(void *device_ptr)
      * garbage and only part of each period is written. */
     bool playback_is_float = (cfg->format == FFAUDIO_F_FLOAT32);
     bool playback_is_int16 = (cfg->format == FFAUDIO_F_INT16);
+    /* FFAUDIO_F_INT24 is 24 bits PACKED into 3 bytes — the 24-bit format ALSA
+     * and PulseAudio expose (SND_PCM_FORMAT_S24_3LE).  It is not the same as
+     * FFAUDIO_F_INT24_4, which carries a 24-bit sample in a 4-byte container
+     * and is what WASAPI negotiates on Windows.  Handling only the latter left
+     * 24-bit playback working on Windows but rejected on Linux. */
+    bool playback_is_int24 = (cfg->format == FFAUDIO_F_INT24);
 
-    if (!playback_is_float && !playback_is_int16 &&
+    if (!playback_is_float && !playback_is_int16 && !playback_is_int24 &&
         cfg->format != FFAUDIO_F_INT32 && cfg->format != FFAUDIO_F_INT24_4)
     {
         HLOGE("audio-play", "Unsupported playback format %d, aborting", cfg->format);
@@ -978,6 +985,20 @@ void *radio_playback_thread(void *device_ptr)
                 o[idx] = (int16_t)(left >> 16);
                 if (cfg->channels > 1)
                     o[idx + 1] = (int16_t)(right >> 16);
+            }
+            else if (playback_is_int24)
+            {
+                /* 3 bytes per sample, little-endian, sample value scaled from
+                 * int32 full scale down to 24-bit (/256 — the exact inverse of
+                 * the capture side's *256).  Division, not >>8: it is defined
+                 * for negatives, and the byte extraction goes through an
+                 * unsigned copy because right-shifting a negative int is
+                 * implementation-defined. */
+                uint8_t *o = (uint8_t *) buffer_output_stereo;
+                size_t off = (size_t) idx * PCM24_BYTES;
+                pcm24_wr_le(o + off, left);
+                if (cfg->channels > 1)
+                    pcm24_wr_le(o + off + PCM24_BYTES, right);
             }
             else if (playback_is_float)
             {
@@ -1186,9 +1207,11 @@ void *radio_capture_thread(void *device_ptr)
 
     bool capture_is_float = (cfg->format == FFAUDIO_F_FLOAT32);
     bool capture_is_int16 = (cfg->format == FFAUDIO_F_INT16);
+    /* 24-bit packed in 3 bytes — see the matching note in the playback path. */
+    bool capture_is_int24 = (cfg->format == FFAUDIO_F_INT24);
     int  capture_channels = cfg->channels;
 
-    if (!capture_is_float && !capture_is_int16 &&
+    if (!capture_is_float && !capture_is_int16 && !capture_is_int24 &&
         cfg->format != FFAUDIO_F_INT32 && cfg->format != FFAUDIO_F_INT24_4)
     {
         HLOGE("audio-cap", "Unsupported capture format %d, aborting", cfg->format);
@@ -1347,6 +1370,10 @@ void *radio_capture_thread(void *device_ptr)
                 {
                     sample = (int32_t)((int16_t *)buffer)[i] * 65536;
                 }
+                else if (capture_is_int24)
+                {
+                    sample = pcm24_rd_le((const uint8_t *)buffer + (size_t)i * PCM24_BYTES);
+                }
                 else
                 {
                     sample = buffer[i];
@@ -1380,6 +1407,20 @@ void *radio_capture_thread(void *device_ptr)
                         sample = (int32_t)i16buf[i*2 + 1] * 65536;
                     else
                         sample = ((int32_t)i16buf[i*2] + (int32_t)i16buf[i*2 + 1]) * 32768;
+                }
+                else if (capture_is_int24)
+                {
+                    /* 6 bytes per stereo frame: L then R, 3 bytes each. */
+                    const uint8_t *p = (const uint8_t *)buffer + (size_t)i * 2u * PCM24_BYTES;
+                    if (ch_layout == LEFT)
+                        sample = pcm24_rd_le(p);
+                    else if (ch_layout == RIGHT)
+                        sample = pcm24_rd_le(p + PCM24_BYTES);
+                    else
+                        /* Widen before adding, as in the int32 branch below:
+                         * two full-scale int32 values sum past INT32_MAX. */
+                        sample = (int32_t)(((int64_t)pcm24_rd_le(p) +
+                                            (int64_t)pcm24_rd_le(p + PCM24_BYTES)) / 2);
                 }
                 else
                 {

--- a/audioio/pcm24.h
+++ b/audioio/pcm24.h
@@ -1,0 +1,54 @@
+/* 24-bit packed PCM conversion (FFAUDIO_F_INT24 / SND_PCM_FORMAT_S24_3LE).
+ *
+ * Three bytes per sample, little-endian on the wire regardless of host order,
+ * carrying a signed 24-bit value.  This is the 24-bit format ALSA and
+ * PulseAudio expose; it is NOT FFAUDIO_F_INT24_4, which puts a 24-bit sample
+ * in a 4-byte container and is what WASAPI negotiates on Windows.  Mercury
+ * handled only the latter, so 24-bit cards worked on Windows and were
+ * rejected on Linux.
+ *
+ * The modem rings hold int32 full scale, so the pair is a scale by 256:
+ * reading multiplies, writing divides.  They are exact inverses apart from
+ * the low 8 bits, which a 24-bit device cannot represent anyway.
+ *
+ * Kept in a header (like sock_wire.h) so the conversion is unit-testable
+ * without a sound card — see tests/audioio/test_pcm24.c, which pins the byte
+ * layout and the round trip.
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef AUDIOIO_PCM24_H
+#define AUDIOIO_PCM24_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#define PCM24_BYTES 3
+
+/* One packed 24-bit LE sample -> int32 full scale.
+ * Assembled through an unsigned value and sign-extended explicitly: shifting
+ * a negative int is implementation-defined, and the byte order must not
+ * depend on the host's. */
+static inline int32_t pcm24_rd_le(const uint8_t *p)
+{
+    uint32_t u = (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16);
+    if (u & 0x800000u)
+        u |= 0xFF000000u;              /* sign-extend bit 23 */
+    return (int32_t)u * 256;           /* 24-bit -> int32 full scale */
+}
+
+/* int32 full scale -> one packed 24-bit LE sample.
+ * Division, not >>8: it is defined for negative values (truncates toward
+ * zero), and the byte extraction goes through an unsigned copy so no
+ * implementation-defined right shift of a negative is involved. */
+static inline void pcm24_wr_le(uint8_t *p, int32_t s)
+{
+    uint32_t v = (uint32_t)(s / 256);
+    p[0] = (uint8_t)(v & 0xffu);
+    p[1] = (uint8_t)((v >> 8) & 0xffu);
+    p[2] = (uint8_t)((v >> 16) & 0xffu);
+}
+
+#endif /* AUDIOIO_PCM24_H */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -43,7 +43,7 @@ ARQ_STUBS = datalink_arq/arq_test_stubs.c
 
 # Test executables
 TEST_BINS = test_ring_buffer test_arq_protocol test_arq_timing test_arq_fsm \
-            test_tcp_interfaces test_resampler test_arq_olla test_arq_sim \
+            test_tcp_interfaces test_resampler test_pcm24 test_arq_olla test_arq_sim \
             test_arq_conn test_cfg_utils test_arq_tnc test_channel_busy \
             test_freedv_harq test_sock_wire test_virtual_clock
 
@@ -67,6 +67,10 @@ test_ring_buffer: common/test_ring_buffer.c $(UNITY_SRC) ../common/ring_buffer_p
 
 # Audio resampler test (offline, no sound card)
 test_resampler: audioio/test_resampler.c $(UNITY_SRC) ../audioio/resampler.c
+	$(CC) $(CFLAGS) -I../audioio -o $@ $^ $(LDFLAGS) -lm
+
+# 24-bit packed PCM conversion test (offline, no sound card)
+test_pcm24: audioio/test_pcm24.c $(UNITY_SRC)
 	$(CC) $(CFLAGS) -I../audioio -o $@ $^ $(LDFLAGS) -lm
 
 # ARQ protocol tests (frame encode/decode, utilities)

--- a/tests/audioio/test_pcm24.c
+++ b/tests/audioio/test_pcm24.c
@@ -1,0 +1,137 @@
+/*
+ * 24-bit packed PCM conversion tests — pins the byte layout and the scaling
+ * of audioio/pcm24.h without a sound card.
+ *
+ * This is the format ALSA/PulseAudio expose for 24-bit cards
+ * (SND_PCM_FORMAT_S24_3LE).  Getting the sign extension or the byte order
+ * wrong does not crash: it puts distorted or inverted audio on the air, which
+ * is exactly the failure mode that has bitten this file before.
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "unity.h"
+#include "pcm24.h"
+
+#include <stdint.h>
+#include <math.h>
+
+void setUp(void)    { }
+void tearDown(void) { }
+
+/* ---- byte layout is little-endian on every host ---- */
+
+void test_read_is_little_endian(void)
+{
+    const uint8_t p[3] = {0x78, 0x56, 0x34};        /* 0x345678 */
+    TEST_ASSERT_EQUAL_INT32(0x345678 * 256, pcm24_rd_le(p));
+}
+
+void test_write_is_little_endian(void)
+{
+    uint8_t p[3] = {0, 0, 0};
+    pcm24_wr_le(p, 0x345678 * 256);
+    TEST_ASSERT_EQUAL_UINT8(0x78, p[0]);
+    TEST_ASSERT_EQUAL_UINT8(0x56, p[1]);
+    TEST_ASSERT_EQUAL_UINT8(0x34, p[2]);
+}
+
+/* ---- sign handling: bit 23 is the sign, not a magnitude bit ---- */
+
+void test_read_negative_sign_extends(void)
+{
+    const uint8_t minus_one[3] = {0xFF, 0xFF, 0xFF};   /* 24-bit -1 */
+    TEST_ASSERT_EQUAL_INT32(-256, pcm24_rd_le(minus_one));
+
+    const uint8_t most_negative[3] = {0x00, 0x00, 0x80}; /* -2^23 */
+    TEST_ASSERT_EQUAL_INT32(INT32_MIN, pcm24_rd_le(most_negative));
+}
+
+void test_read_largest_positive(void)
+{
+    const uint8_t p[3] = {0xFF, 0xFF, 0x7F};          /* +2^23 - 1 */
+    TEST_ASSERT_EQUAL_INT32(2147483392, pcm24_rd_le(p));   /* (2^23-1)*256 */
+}
+
+void test_write_negative(void)
+{
+    uint8_t p[3];
+    pcm24_wr_le(p, -256);                              /* -> 24-bit -1 */
+    TEST_ASSERT_EQUAL_UINT8(0xFF, p[0]);
+    TEST_ASSERT_EQUAL_UINT8(0xFF, p[1]);
+    TEST_ASSERT_EQUAL_UINT8(0xFF, p[2]);
+
+    pcm24_wr_le(p, INT32_MIN);                         /* -> -2^23 */
+    TEST_ASSERT_EQUAL_UINT8(0x00, p[0]);
+    TEST_ASSERT_EQUAL_UINT8(0x00, p[1]);
+    TEST_ASSERT_EQUAL_UINT8(0x80, p[2]);
+}
+
+/* ---- round trip: write then read must return the value, to 24-bit
+ *      resolution (the low 8 bits cannot survive a 24-bit device) ---- */
+
+void test_round_trip_preserves_value(void)
+{
+    const int32_t cases[] = {
+        0, 256, -256, 65536, -65536,
+        1073741824, -1073741824,          /* +/- half scale */
+        2147483392, INT32_MIN,            /* extremes representable in 24 bit */
+        123456 * 256, -123456 * 256,
+    };
+    for (unsigned i = 0; i < sizeof cases / sizeof *cases; i++) {
+        uint8_t p[3];
+        pcm24_wr_le(p, cases[i]);
+        TEST_ASSERT_EQUAL_INT32(cases[i], pcm24_rd_le(p));
+    }
+}
+
+/* Values that are not multiples of 256 lose only their low 8 bits, and the
+ * error must stay under one 24-bit LSB — never wrap or flip sign. */
+void test_round_trip_truncates_within_one_lsb(void)
+{
+    for (int32_t base = -2100000000; base < 2100000000; base += 37129151) {
+        for (int k = 0; k < 256; k += 37) {
+            int64_t vin = (int64_t)base + k;
+            if (vin > INT32_MAX) break;
+            uint8_t p[3];
+            pcm24_wr_le(p, (int32_t)vin);
+            int64_t out = pcm24_rd_le(p);
+            TEST_ASSERT_TRUE_MESSAGE(out <= vin ? (vin - out) < 256 : (out - vin) < 256,
+                                     "24-bit round trip error exceeded 1 LSB");
+            /* sign must never invert */
+            if (vin > 255)  TEST_ASSERT_TRUE(out >= 0);
+            if (vin < -255) TEST_ASSERT_TRUE(out <= 0);
+        }
+    }
+}
+
+/* A full-scale sine must survive the round trip with its shape intact — the
+ * property that actually matters on the air. */
+void test_round_trip_sine_is_undistorted(void)
+{
+    for (int i = 0; i < 4096; i++) {
+        double phase = 2.0 * M_PI * 1000.0 * i / 8000.0;
+        int32_t in = (int32_t)(2000000000.0 * sin(phase));
+        uint8_t p[3];
+        pcm24_wr_le(p, in);
+        int32_t out = pcm24_rd_le(p);
+        int64_t err = (int64_t)in - out;
+        if (err < 0) err = -err;
+        TEST_ASSERT_TRUE_MESSAGE(err < 256, "sine sample distorted beyond 1 LSB");
+    }
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_read_is_little_endian);
+    RUN_TEST(test_write_is_little_endian);
+    RUN_TEST(test_read_negative_sign_extends);
+    RUN_TEST(test_read_largest_positive);
+    RUN_TEST(test_write_negative);
+    RUN_TEST(test_round_trip_preserves_value);
+    RUN_TEST(test_round_trip_truncates_within_one_lsb);
+    RUN_TEST(test_round_trip_sine_is_undistorted);
+    return UNITY_END();
+}


### PR DESCRIPTION
Mercury's 24-bit support was Windows-only, by accident.

The emit and extract loops accepted `FFAUDIO_F_INT24_4` — a 24-bit sample in a 4-byte container, which is what **WASAPI** negotiates — and rejected `FFAUDIO_F_INT24`, the 3-byte packed form that **ALSA and PulseAudio** actually expose (`SND_PCM_FORMAT_S24_3LE`). So a 24-bit card worked on Windows and aborted on Linux with `Unsupported playback format`.

```
FFAUDIO_F_INT24   = 24            3 bytes packed   ALSA, PulseAudio
FFAUDIO_F_INT24_4 = 32 | 0x0200   24-bit in 4      WASAPI
```

(ALSA's other 4-byte form, `S24_LE`, has no entry in ffaudio's format table at all, so such a device still fails at `open()` — untouched here.)

## The change

Adds the packed path to **both** directions. The conversion lives in a new `audioio/pcm24.h` rather than inline, following the `sock_wire.h` precedent: a byte-layout codec that is wrong in a way that *does not crash* — it just puts distorted or sign-inverted audio on the air — belongs somewhere a unit test can reach it.

Both helpers assemble through an unsigned value and sign-extend explicitly (shifting a negative int is implementation-defined, and byte order must not depend on the host's); the write side divides by 256 rather than `>>8` for the same reason. Scaling is an exact inverse pair, so a round trip is lossless to 24-bit resolution. The stereo MIX branch widens to `int64` before averaging, like the int32 branch fixed in `5192529`.

## Validation — measured, not inspected

Captured what Mercury actually transmits through a real `snd-aloop` device pinned to `S24_3LE`:

| format | ch | tone | peak | in-band |
|---|---|---|---|---|
| **int24** | 1 | **1000.0 Hz** | −15.02 dBFS | 1.00000 |
| **int24** | 2 | **999.9 Hz** | −15.02 dBFS | 1.00000 |
| int16 | 1 | 1000.0 Hz | −15.02 dBFS | 1.00000 |
| int32 | 2 | 1000.0 Hz | −15.02 dBFS | 1.00000 |

Capture verified separately: a 24-bit device negotiates `int24` and the capture thread stays alive instead of aborting.

**8 new unit tests** pin the byte layout, sign extension at both extremes (−2²³ and +2²³−1), the lossless round trip, that truncation never exceeds one 24-bit LSB or inverts a sign, and that a full-scale sine survives undistorted.

Full suite **201 tests, 0 failures**, 0 build warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
