### PR TITLE
ci(release): build and sign the Windows installer from a prepared Inno tree

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,16 @@ jobs:
         uses: actions/download-artifact@v4
         with: { name: windows-unsigned }
 
+      # The SimplySign login is driven through a headless GUI, so when it fails
+      # the only useful evidence is a screenshot of the dialog — that is how the
+      # last field failure (a TOTP typed into the e-mail field) was diagnosed.
+      # The signer image has no screenshot tool, and without one the scripts fall
+      # back to a bare window list.
+      - name: Install screenshot tool for login diagnostics
+        run: |
+          command -v import >/dev/null || \
+            { apt-get update && apt-get install -y --no-install-recommends imagemagick; }
+
       - name: Sign binaries
         env:
           CERTUM_EMAIL:   ${{ secrets.CERTUM_EMAIL }}
@@ -227,6 +237,16 @@ jobs:
           name: windows-signed
           path: mercury-${{ inputs.version }}-w64-*.zip
 
+      # Screenshots and window lists live on the runner; without this they are
+      # thrown away with the container, which is exactly when they are wanted.
+      - name: Upload signing diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: signing-diagnostics
+          path: /tmp/mercury-signing-diag
+          if-no-files-found: ignore
+
   # ---- Create GitHub release ----
   release:
     name: Create GitHub release
@@ -253,7 +273,9 @@ jobs:
           # The installer is opt-in (build_installer); attach it only if present,
           # so a release without it still publishes cleanly.
           SETUP=$(ls Mercury_*_Setup.exe 2>/dev/null | head -1 || true)
-          [ -n "$SETUP" ] && ASSETS="$ASSETS ./${SETUP}"
+          # Not `[ -n ... ] && ASSETS=...`: the runner shell has -e, so the
+          # false test would end the step and no release would be created.
+          if [ -n "$SETUP" ]; then ASSETS="$ASSETS ./${SETUP}"; fi
           gh release create "v${{ inputs.version }}" $ASSETS \
             --repo Rhizomatica/mercury --target mercuryv2 --generate-notes \
             --title "Mercury ${{ inputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,18 +172,12 @@ jobs:
           # half-succeed, and the exact same compiler every time.  ISCC is a
           # console program and needs no registry state — the tree alone is
           # enough (verified by compiling from a virgin WINEPREFIX).
-          # -k: the host currently serves only its leaf certificate, no
-          # intermediate, so verification fails ("unable to get local issuer
-          # certificate"). TEMPORARY — drop the -k once the server sends its
-          # full chain.
-          #
-          # What is and is not covered meanwhile: the sha256 below pins the
-          # exact bytes, so a tampered or swapped tarball cannot build a
-          # release. What -k gives up is authentication of the HOST, i.e. an
-          # attacker who can intercept the connection could serve a different
-          # file — and the checksum would reject it. So the failure mode is a
-          # failed build, not a poisoned installer.
-          curl -fsSLko /tmp/inno.tar.gz "$INNO_URL"
+          # TLS is verified (the host serves its full chain) and the sha256
+          # pins the exact bytes: the transport says where the tarball came
+          # from, the checksum says it is the one this workflow was built
+          # against. A mismatch fails the build rather than signing whatever
+          # turned up.
+          curl -fsSLo /tmp/inno.tar.gz "$INNO_URL"
           echo "${INNO_SHA256}  /tmp/inno.tar.gz" | sha256sum -c -
           wineboot -i
           PF="$HOME/.wine/drive_c/Program Files (x86)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ on:
         description: 'Release version (e.g. 1.9.9)'
         required: true
         type: string
+      build_installer:
+        description: 'Also build+sign the Windows installer (needs Wine+Inno in the signer container)'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   # ---- Version bump + commit ----
@@ -120,8 +125,10 @@ jobs:
       image: ghcr.io/reactiveui/certum-signer:latest
     timeout-minutes: 15
     steps:
+      # Full checkout, not sparse: building the installer needs installer.iss,
+      # LICENSE, the icon, mercury.ini.example and the vendored hamlib DLLs.
       - uses: actions/checkout@v4
-        with: { ref: mercuryv2, sparse-checkout: code-signing }
+        with: { ref: mercuryv2 }
 
       - name: Download unsigned binaries
         uses: actions/download-artifact@v4
@@ -144,6 +151,71 @@ jobs:
           for f in mercury.exe windows-installer/mercury-ui.exe; do
             osslsigncode verify "$f" || { echo "::error::Signature verification failed for $f"; exit 1; }
           done
+
+      # ---- Installer: pack the SIGNED payloads, then sign the installer ----
+      # Order matters. ISCC packs whatever is staged, so signing only the
+      # finished Setup.exe would ship a signed installer that installs unsigned
+      # programs. The payloads above are already signed; stage them without
+      # rebuilding (windows-installer-stage has no toolchain dependency, and a
+      # rebuild here would discard those signatures anyway).
+      - name: Install Inno Setup (Wine)
+        if: ${{ inputs.build_installer }}
+        env:
+          INNO_URL:    https://wiki.hermes.radio/reports/inno-setup-6.7.3-wine.tar.gz
+          INNO_SHA256: 4c9c92249663f201a33bf194c0cd37e01c60540e299c771f3626411ef463c884
+        run: |
+          set -eu
+          apt-get update
+          apt-get install -y --no-install-recommends wine ca-certificates curl
+          # A prepared Inno Setup tree rather than running its GUI installer under
+          # Wine on every release: no display needed, no silent-install that can
+          # half-succeed, and the exact same compiler every time.  ISCC is a
+          # console program and needs no registry state — the tree alone is
+          # enough (verified by compiling from a virgin WINEPREFIX).
+          # -k: the host currently serves only its leaf certificate, no
+          # intermediate, so verification fails ("unable to get local issuer
+          # certificate"). TEMPORARY — drop the -k once the server sends its
+          # full chain.
+          #
+          # What is and is not covered meanwhile: the sha256 below pins the
+          # exact bytes, so a tampered or swapped tarball cannot build a
+          # release. What -k gives up is authentication of the HOST, i.e. an
+          # attacker who can intercept the connection could serve a different
+          # file — and the checksum would reject it. So the failure mode is a
+          # failed build, not a poisoned installer.
+          curl -fsSLko /tmp/inno.tar.gz "$INNO_URL"
+          echo "${INNO_SHA256}  /tmp/inno.tar.gz" | sha256sum -c -
+          wineboot -i
+          PF="$HOME/.wine/drive_c/Program Files (x86)"
+          mkdir -p "$PF"
+          tar xzf /tmp/inno.tar.gz -C "$PF/"
+          ISCC_PATH="$PF/Inno Setup 6/ISCC.exe"
+          [ -f "$ISCC_PATH" ] || { echo "::error::Inno Setup tree missing ISCC.exe"; exit 1; }
+          echo "ISCC_PATH=$ISCC_PATH" >> "$GITHUB_ENV"
+
+      - name: Build and sign the installer
+        if: ${{ inputs.build_installer }}
+        env:
+          CERTUM_EMAIL:   ${{ secrets.CERTUM_EMAIL }}
+          CERTUM_OTP_URI: ${{ secrets.CERTUM_OTP_URI }}
+        run: |
+          set -eu
+          make windows-installer-stage
+          wine "$ISCC_PATH" windows-installer/installer.iss
+          SETUP=$(ls Mercury_*_Setup.exe | head -1)
+          [ -n "$SETUP" ] || { echo "::error::ISCC produced no installer"; exit 1; }
+          code-signing/sign.sh "$SETUP"
+          code-signing/sign-logout.sh
+          osslsigncode verify "$SETUP" || {
+            echo "::error::Installer signature verification failed"; exit 1; }
+          echo "SETUP_EXE=$SETUP" >> "$GITHUB_ENV"
+
+      - name: Upload signed installer
+        if: ${{ inputs.build_installer }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-installer-signed
+          path: Mercury_*_Setup.exe
 
       - name: Re-pack signed zip
         run: |
@@ -174,10 +246,20 @@ jobs:
         uses: actions/download-artifact@v4
         with: { name: windows-signed }
 
+      - name: Download signed installer
+        if: ${{ inputs.build_installer }}
+        uses: actions/download-artifact@v4
+        with: { name: windows-installer-signed }
+
       - name: Create release
         env: { GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
         run: |
           ZIP=$(ls mercury-${{ inputs.version }}-w64-*.zip)
-          gh release create "v${{ inputs.version }}" "./${ZIP}" \
+          ASSETS="./${ZIP}"
+          # The installer is opt-in (build_installer); attach it only if present,
+          # so a release without it still publishes cleanly.
+          SETUP=$(ls Mercury_*_Setup.exe 2>/dev/null | head -1 || true)
+          [ -n "$SETUP" ] && ASSETS="$ASSETS ./${SETUP}"
+          gh release create "v${{ inputs.version }}" $ASSETS \
             --repo Rhizomatica/mercury --target mercuryv2 --generate-notes \
             --title "Mercury ${{ inputs.version }}"

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ FYNE_UI_DIR   = gui_interface/fyne-ui
 FYNE_UI_BIN   = mercury-ui.exe
 MINGW_GO_CC   = x86_64-w64-mingw32-gcc
 
-.PHONY: all install internal_deps utils clean doxygen doxygen-clean windows windows-zip windows-installer-signed fyne-ui fyne-ui-macos fyne-ui-macos-dmg macos-universal fyne-ui-macos-universal fyne-ui-macos-universal-dmg fyne-ui-windows windows-installer test integration-test FORCE
+.PHONY: all install internal_deps utils clean doxygen doxygen-clean windows windows-zip windows-installer-signed windows-installer-stage fyne-ui fyne-ui-macos fyne-ui-macos-dmg macos-universal fyne-ui-macos-universal fyne-ui-macos-universal-dmg fyne-ui-windows windows-installer test integration-test FORCE
 
 prefix ?= /usr
 bindir ?= $(prefix)/bin
@@ -478,7 +478,12 @@ fyne-ui-windows: libmercury_core_w64.a
 		go build -tags mercury_embedded -ldflags="-s -w -H windowsgui -X main.coreBuildID=$$(cksum $(abspath libmercury_core_w64.a) | cut -d' ' -f1)" -o $(abspath $(WINDOWS_INSTALLER_DIR)/$(FYNE_UI_BIN)) .
 	@echo "  -> $(WINDOWS_INSTALLER_DIR)/$(FYNE_UI_BIN)"
 
-windows-installer: windows fyne-ui-windows
+# Stage everything the installer packs, WITHOUT rebuilding the binaries.
+# Split out so a signing environment can reuse payloads it has just signed:
+# the release pipeline signs in a container that has the certificate but no
+# mingw/Go toolchain, so it must be able to pack without triggering a rebuild
+# (which would also discard the signatures it just applied).
+windows-installer-stage:
 	cp mercury.exe $(WINDOWS_INSTALLER_DIR)/
 	cp mercury.ini.example $(WINDOWS_INSTALLER_DIR)/mercury.ini
 	sed -i 's/ui_enabled = false/ui_enabled = true/g' $(WINDOWS_INSTALLER_DIR)/mercury.ini
@@ -486,6 +491,9 @@ windows-installer: windows fyne-ui-windows
 	if ls $(HAMLIB_W64_DIR)/bin/*.dll >/dev/null 2>&1; then \
 		cp $(HAMLIB_W64_DIR)/bin/*.dll $(WINDOWS_INSTALLER_DIR)/; \
 	fi
+	@echo "windows-installer staged."
+
+windows-installer: windows fyne-ui-windows windows-installer-stage
 	@echo "windows-installer ready."
 	@echo ""
 	@echo "Build the installer (Windows or Wine):"


### PR DESCRIPTION
Builds and signs the Windows installer as part of the release, instead of leaving it a manual step.

**Opt-in and off by default** (`build_installer` input, default `false`), so the normal release path is unchanged.

## How

The release previously published only the ZIP. This adds, to the existing signing job:

1. fetch a **prepared Inno Setup tree** and unpack it into a Wine prefix;
2. stage the payloads that job has **just signed** (`windows-installer-stage`);
3. run ISCC;
4. sign the resulting installer.

All in the same job, so it stays one signing session, and in that order, so nothing inside the installer is unsigned.

A prepared tree rather than running Inno's GUI installer under Wine on every release: no display needed, no silent-install that can half-succeed, and the exact same compiler every time, pinned by checksum. ISCC turns out to need no registry state — verified by unpacking into a virgin `WINEPREFIX` and compiling. Only `wine` comes from apt, and `xvfb` is gone (ISCC is a console program; the display was only for the GUI installer this replaces).

`Makefile`: `windows-installer-stage` is split out of `windows-installer` so the signing environment can pack without a rebuild — it has no mingw/Go toolchain, and rebuilding there would discard the signatures just applied.

## Verification

Rehearsed locally with the same commands the job runs, against the tarball as actually served: download → `sha256sum -c` → `wineboot` → unpack → stage → ISCC. Result: **Successful compile**, 13.9 MB installer with both payloads packed.

Two things testing caught that inspection would not have:
- trimming the `*.issig` files breaks Inno 6.7.3 — it verifies its own DLLs (`Could not load ISCmplr.dll`), so they are kept;
- `xvfb` is unnecessary for ISCC.

## Notes

- Both controls are in place on the fetch: TLS says where the tarball came from, the sha256 says it is the one this workflow was built against. A mismatch fails the build instead of signing whatever turned up.
- Left disabled by default deliberately: the signing job this extends has never executed (secrets added after both previous releases), and the first release to exercise signing should not also be the first to exercise this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
