### PR TITLE
arq+tnc: honour LISTEN OFF in every state; make host state notifications reliable

### DIFF
--- a/common/os_interop.h
+++ b/common/os_interop.h
@@ -175,6 +175,13 @@ static inline int sock_errno(void) { return errno; }
 
 #endif
 
+/* Cross-platform microsecond sleep. mingw has no usleep(). */
+#if defined(_WIN32)
+#define hermes_usleep(us) Sleep((DWORD)((us) / 1000))
+#else
+#define hermes_usleep(us) usleep(us)
+#endif
+
 #ifdef __cplusplus
 };
 #endif

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -183,7 +183,7 @@ static int tnc_queue_line_critical(const char *line)
     {
         if (tnc_queue_line(line) == 0)
             return 0;
-        usleep(TNC_CRITICAL_SLEEP_US);
+        hermes_usleep(TNC_CRITICAL_SLEEP_US);
     }
     HLOGE("tcp-ctl", "DROPPED host state notification '%s' — the TNC channel "
           "stayed full for %d ms; a host relying on this for interlock or "

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -159,6 +159,39 @@ static int tnc_queue_line(const char *line)
     return 0;
 }
 
+/* Queue a line that the HOST NEEDS FOR CORRECTNESS, not just for display.
+ *
+ * tnc_queue_line() is deliberately lossy: it drops rather than block a modem
+ * thread when the channel backs up.  That is right for telemetry (BUFFER, SN,
+ * BITRATE arrive continuously — a lost one is replaced a moment later), and
+ * wrong for state changes.  A host driving a transmitter interlock or a
+ * frequency scanner (BPQ32 INTERLOCK, VARA-style scanning) decides whether the
+ * radio is busy from PENDING / PTT ON / PTT OFF; a dropped PTT ON leaves it
+ * believing we are receiving while we are keyed, and it will hand the antenna
+ * to another port on top of us.
+ *
+ * So retry briefly before giving up, and if it still fails say so loudly
+ * instead of incrementing a counter nobody reads.  The bound is small: a full
+ * channel means the consumer is already stalled, and delaying a modem thread
+ * further helps nobody. */
+#define TNC_CRITICAL_RETRIES   10
+#define TNC_CRITICAL_SLEEP_US  5000   /* 10 x 5 ms = 50 ms worst case */
+
+static int tnc_queue_line_critical(const char *line)
+{
+    for (int i = 0; i < TNC_CRITICAL_RETRIES; i++)
+    {
+        if (tnc_queue_line(line) == 0)
+            return 0;
+        usleep(TNC_CRITICAL_SLEEP_US);
+    }
+    HLOGE("tcp-ctl", "DROPPED host state notification '%s' — the TNC channel "
+          "stayed full for %d ms; a host relying on this for interlock or "
+          "scanning is now out of sync",
+          line, (TNC_CRITICAL_RETRIES * TNC_CRITICAL_SLEEP_US) / 1000);
+    return -1;
+}
+
 static uint64_t monotonic_ms(void)
 {
     struct timespec ts;
@@ -1243,7 +1276,7 @@ void ptt_on()
      * The PTT state change (arq_set_trx(TX)) is already synchronous and
      * is what the modem RX thread actually polls; the TCP notification to
      * uucpd is informational only. */
-    (void)tnc_queue_line("PTT ON\r");
+    (void)tnc_queue_line_critical("PTT ON\r");
     HLOGI("radio", "TX enabled (PTT ON)");
 }
 
@@ -1253,7 +1286,7 @@ void ptt_off()
     if (radio_io_enabled())
         radio_io_key_off();
     /* Same reasoning as ptt_on(): queue asynchronously. */
-    (void)tnc_queue_line("PTT OFF\r");
+    (void)tnc_queue_line_critical("PTT OFF\r");
     HLOGI("radio", "TX disabled (PTT OFF)");
 }
 
@@ -1267,7 +1300,7 @@ void tnc_send_connected()
     int bw = arq_reported_bandwidth_hz();   /* separate locked call, AFTER the getter returns */
     snprintf(buffer, sizeof(buffer), "CONNECTED %s %s %d\r",
              source_call, dest_call, bw);
-    if (tnc_queue_line(buffer) < 0)
+    if (tnc_queue_line_critical(buffer) < 0)
         HLOGW("tcp-ctl", "Error queuing connected message");
 }
 
@@ -1285,13 +1318,13 @@ void tnc_send_cqframe(const char *source_call, int bw_hz)
 
 void tnc_send_pending()
 {
-    if (tnc_queue_line("PENDING\r") < 0)
+    if (tnc_queue_line_critical("PENDING\r") < 0)
         HLOGW("tcp-ctl", "Error queuing pending message");
 }
 
 void tnc_send_cancelpending()
 {
-    if (tnc_queue_line("CANCELPENDING\r") < 0)
+    if (tnc_queue_line_critical("CANCELPENDING\r") < 0)
         HLOGW("tcp-ctl", "Error queuing cancelpending message");
 }
 
@@ -1299,7 +1332,7 @@ void tnc_send_disconnected()
 {
     char buffer[128];
     snprintf(buffer, sizeof(buffer), "DISCONNECTED\r");
-    if (tnc_queue_line(buffer) < 0)
+    if (tnc_queue_line_critical(buffer) < 0)
         HLOGW("tcp-ctl", "Error queuing disconnected message");
 }
 

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -1188,6 +1188,12 @@ static void fsm_calling(arq_session_t *sess, const arq_event_t *ev)
         }
         break;
 
+    /* VARA-compatible: LISTEN OFF drops the link, it does not merely stop
+     * accepting new ones.  A host asserting a transmitter interlock (BPQ32
+     * INTERLOCK, frequency scanners) sends LISTEN OFF to mean "release the
+     * radio now" — honouring it only in LISTENING left us retrying CALL/ACCEPT
+     * over another port that had already taken the channel. */
+    case ARQ_EV_APP_STOP_LISTEN:
     case ARQ_EV_APP_DISCONNECT:
         if (g_cbs.notify_disconnected) g_cbs.notify_disconnected(false);
         enter_idle_after_call(sess);
@@ -1278,6 +1284,10 @@ static void fsm_accepting(arq_session_t *sess, const arq_event_t *ev)
         fsm_disconnected(sess, ev);
         break;
 
+    /* See fsm_calling: LISTEN OFF releases the radio.  This is the state the
+     * BPQ32 interlock report lands in — an inbound CALL we are answering with
+     * ACCEPT retries. */
+    case ARQ_EV_APP_STOP_LISTEN:
     case ARQ_EV_APP_DISCONNECT:
         if (g_cbs.notify_cancelpending)
             g_cbs.notify_cancelpending();
@@ -1296,6 +1306,12 @@ static void fsm_disconnecting(arq_session_t *sess, const arq_event_t *ev)
 
     switch (ev->id)
     {
+    case ARQ_EV_APP_STOP_LISTEN:
+        /* Stop retransmitting DISCONNECT frames: the host wants the radio
+         * free, and the peer will time out without them. */
+        enter_idle_after_call(sess);
+        return;
+
     case ARQ_EV_TIMER_ACK:
         /* Initial DISCONNECT send after channel guard. */
         send_ctrl_frame(sess, ARQ_SUBTYPE_DISCONNECT);
@@ -1362,6 +1378,21 @@ static void fsm_connected(arq_session_t *sess, const arq_event_t *ev)
 
     switch (ev->id)
     {
+    case ARQ_EV_APP_STOP_LISTEN:
+        /* LISTEN OFF on a live link means "release the radio", so unlike
+         * APP_DISCONNECT below we do NOT drain the TX backlog: the host is
+         * telling us another port needs the channel, and queued bytes must not
+         * buy more airtime.  No air-side DISCONNECT frame either — that is one
+         * more keydown on a channel we were just told to give up, and the peer
+         * times out on its own (same reasoning as a dirty ABORT).  A frame
+         * already in the air finishes; truncating a keydown mid-frame only
+         * leaves the peer decoding garbage, since the transmitter is keyed
+         * either way. */
+        sess->pending_disconnect = false;
+        if (g_cbs.notify_disconnected) g_cbs.notify_disconnected(false);
+        enter_idle_after_call(sess);
+        return;
+
     case ARQ_EV_APP_DISCONNECT:
         /* Defer DISCONNECT while a frame is physically being transmitted
          * (PTT on, DATA_TX), still awaiting its ACK (WAIT_ACK), or the TX

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -33,12 +33,6 @@
 
 #include "../common/os_interop.h"
 
-/* Cross-platform microsecond sleep */
-#ifdef _WIN32
-#define hermes_usleep(us) Sleep((DWORD)((us) / 1000))
-#else
-#define hermes_usleep(us) usleep(us)
-#endif
 
 #include "ui_communication.h"
 

--- a/tests/datalink_arq/test_arq_fsm.c
+++ b/tests/datalink_arq/test_arq_fsm.c
@@ -665,6 +665,83 @@ void test_timeout_ms_idle(void)
     TEST_ASSERT_GREATER_THAN(60000, ms);
 }
 
+
+/* ---- LISTEN OFF releases the radio (VARA semantics, host interlock) ----
+ *
+ * A host asserting a transmitter interlock or stopping a frequency scan sends
+ * LISTEN OFF meaning "release the radio now". Honouring it only in LISTENING
+ * left Mercury retrying CALL/ACCEPT on a channel another port had taken —
+ * reported from the field as BPQ32 INTERLOCK being ignored, and as a scanner
+ * that kept stepping frequencies while Mercury answered a connect request.
+ */
+
+void test_listen_off_drops_pending_accept(void)
+{
+    arq_event_t ev = make_event(ARQ_EV_APP_LISTEN);
+    arq_fsm_dispatch(&sess, &ev);
+
+    ev = make_event(ARQ_EV_RX_CALL);
+    ev.session_id = 0x42;
+    strncpy(ev.remote_call, "REMOTE1", CALLSIGN_MAX_SIZE);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_ACCEPTING, sess.conn_state);
+
+    RESET_FAKE(fake_send_tx_frame);
+    RESET_FAKE(fake_notify_cancelpending);
+
+    ev = make_event(ARQ_EV_APP_STOP_LISTEN);
+    arq_fsm_dispatch(&sess, &ev);
+
+    /* Must leave ACCEPTING: staying there keeps retrying ACCEPT on the air. */
+    TEST_ASSERT_NOT_EQUAL_INT(ARQ_CONN_ACCEPTING, sess.conn_state);
+    /* The host must learn the pending connection is gone. */
+    TEST_ASSERT_GREATER_THAN(0, fake_notify_cancelpending_fake.call_count);
+    /* And listen intent is cleared, so we do not fall back into LISTENING. */
+    TEST_ASSERT_FALSE(sess.listen_enabled);
+}
+
+void test_listen_off_drops_outgoing_call(void)
+{
+    arq_event_t ev = make_event(ARQ_EV_APP_LISTEN);
+    arq_fsm_dispatch(&sess, &ev);
+    ev = make_event(ARQ_EV_APP_CONNECT);
+    strncpy(ev.remote_call, "DST1", CALLSIGN_MAX_SIZE);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CALLING, sess.conn_state);
+
+    ev = make_event(ARQ_EV_APP_STOP_LISTEN);
+    arq_fsm_dispatch(&sess, &ev);
+
+    TEST_ASSERT_NOT_EQUAL_INT(ARQ_CONN_CALLING, sess.conn_state);
+}
+
+void test_listen_off_drops_live_link_without_draining(void)
+{
+    arq_event_t ev = make_event(ARQ_EV_APP_LISTEN);
+    arq_fsm_dispatch(&sess, &ev);
+    ev = make_event(ARQ_EV_APP_CONNECT);
+    strncpy(ev.remote_call, "DST1", CALLSIGN_MAX_SIZE);
+    arq_fsm_dispatch(&sess, &ev);
+    ev = make_event(ARQ_EV_RX_ACCEPT);
+    ev.session_id = sess.session_id;
+    strncpy(ev.remote_call, "DST1", CALLSIGN_MAX_SIZE);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
+
+    RESET_FAKE(fake_send_tx_frame);
+
+    ev = make_event(ARQ_EV_APP_STOP_LISTEN);
+    arq_fsm_dispatch(&sess, &ev);
+
+    /* Unlike APP_DISCONNECT this must NOT linger in a draining teardown:
+     * the radio was requested back, so queued bytes buy no more airtime. */
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_DISCONNECTED, sess.conn_state);
+    TEST_ASSERT_FALSE(sess.pending_disconnect);
+    /* No air-side DISCONNECT frame — that is one more keydown on a channel we
+     * were just told to give up; the peer times out instead. */
+    TEST_ASSERT_EQUAL_INT(0, fake_send_tx_frame_fake.call_count);
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -677,6 +754,9 @@ int main(void)
     RUN_TEST(test_incoming_call_records_dialed_secondary);
     RUN_TEST(test_accept_transitions_to_connected);
     RUN_TEST(test_disconnect_from_connected);
+    RUN_TEST(test_listen_off_drops_pending_accept);
+    RUN_TEST(test_listen_off_drops_outgoing_call);
+    RUN_TEST(test_listen_off_drops_live_link_without_draining);
     RUN_TEST(test_rx_disconnect_from_connected);
     RUN_TEST(test_connected_seeds_no_progress_clock);
     RUN_TEST(test_app_disconnect_defers_with_backlog);


### PR DESCRIPTION
Two field reports about Mercury transmitting when the host expected it not to: a BPQ32 transmitter interlock that appeared to be ignored, and a frequency scanner that kept stepping while Mercury was mid-handshake. Both point at the same gap.

## LISTEN OFF was only honoured while idle

`LISTEN OFF` was handled in `LISTENING` and dropped everywhere else. In `CALLING`, `ACCEPTING`, `CONNECTED` or `DISCONNECTING` the event fell through silently, so Mercury kept keying a channel the host had just asked it to release — an ACCEPT retry cycle is up to four keydowns of a few seconds each.

Per the VARA specification `LISTEN OFF` drops the connection. It is now handled in every state:

- **CALLING / ACCEPTING** — fall through to the existing `APP_DISCONNECT` teardown; the host gets `CANCELPENDING` / `DISCONNECTED`, and listen intent is cleared so Mercury does not immediately answer the next call.
- **CONNECTED** — abort semantics: no TX backlog drain and no air-side DISCONNECT frame. The radio was asked for back, so queued bytes buy no more airtime and the peer times out normally. This is deliberately *unlike* `APP_DISCONNECT`, which defers in order to drain.
- **DISCONNECTING** — stop retransmitting DISCONNECT.

An in-flight frame is allowed to finish; nothing new is keyed after that.

## Host state notifications no longer silently dropped

`PTT ON/OFF`, `PENDING`, `CANCELPENDING`, `CONNECTED` and `DISCONNECTED` were best-effort: if the control queue was momentarily full they were discarded. A lost `PTT ON` leaves the host believing the radio is free — exactly what an interlock exists to prevent — and a lost `CONNECTED`/`DISCONNECTED` desynchronises the host's link state.

These now retry briefly (10 × 5 ms) and log an error if they still cannot be delivered. Telemetry (`BUFFER`, `SN`, `BUSY`, `BITRATE`, `CQFRAME`) stays best-effort, since it is refreshed continuously and a dropped sample is harmless.

## Not a regression

Checked against the released versions: `LISTEN OFF` has never dropped a live connection in any of them. This is a long-standing deviation from the spec rather than something recently broken.

## Tests

Three FSM tests, each failing against the old code by construction (the event was previously dropped, so state, notification and frame count are precisely what changed):

- `LISTEN OFF` from `ACCEPTING` — leaves the state, notifies `CANCELPENDING`, clears listen intent.
- `LISTEN OFF` from `CALLING` — abandons the outgoing call.
- `LISTEN OFF` from `CONNECTED` — reaches `DISCONNECTED` without draining and without emitting a DISCONNECT frame, contrasting with the existing "defers with backlog" test for `APP_DISCONNECT`.

Full suite green, clean build, no warnings.

## Open question for the reporters

Whether the host asserts its interlock by sending `LISTEN OFF`, or only observes `PTT`. This change is correct either way, but if it is the latter then the notification-reliability half of this PR is the part that matters for their symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
