### PR TITLE
ci: install the tools the signer image lacks; honour Integration's branch input

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,6 +46,11 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Honour the dispatch input; it was advertised but ignored, so a manual
+          # run against another branch silently tested mercuryv2. github.ref keeps
+          # the automatic behaviour unchanged (PR merge ref / pushed branch).
+          ref: ${{ github.event.inputs.branch || github.ref }}
 
       - name: Git Safe Directory
         run: git config --global --add safe.directory /__w/mercury/mercury

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,15 +134,23 @@ jobs:
         uses: actions/download-artifact@v4
         with: { name: windows-unsigned }
 
-      # The SimplySign login is driven through a headless GUI, so when it fails
-      # the only useful evidence is a screenshot of the dialog — that is how the
-      # last field failure (a TOTP typed into the e-mail field) was diagnosed.
-      # The signer image has no screenshot tool, and without one the scripts fall
-      # back to a bare window list.
-      - name: Install screenshot tool for login diagnostics
+      # The signer image (Ubuntu 24.04 + SimplySign + jsign) ships unzip but not
+      # zip, and no make or screenshot tool. Every one of those is used AFTER a
+      # successful signing session — re-packing the zip, staging the installer,
+      # photographing a failed login — so a missing one would burn the session
+      # and fail the release at the last step. Install them before signing.
+      - name: Install tools the signer image lacks
         run: |
-          command -v import >/dev/null || \
-            { apt-get update && apt-get install -y --no-install-recommends imagemagick; }
+          set -eu
+          PKGS=""
+          command -v zip    >/dev/null || PKGS="$PKGS zip"
+          command -v make   >/dev/null || PKGS="$PKGS make"
+          command -v import >/dev/null || PKGS="$PKGS imagemagick"
+          if [ -n "$PKGS" ]; then
+            apt-get update
+            # shellcheck disable=SC2086
+            apt-get install -y --no-install-recommends $PKGS
+          fi
 
       - name: Sign binaries
         env:


### PR DESCRIPTION
Two bugs found auditing the release path before cutting 1.9.11.

## The signer image has no `zip` and no `make`

The signing container is Ubuntu 24.04 + SimplySign + jsign; its image config shows `unzip` but **not** `zip`, and no `make`.

Both are used *after* a successful signing session — "Re-pack signed zip" runs `zip`, and the installer path runs `make windows-installer-stage`. Either missing tool would have burned the SimplySign session and failed the release at its final step, with the binaries signed and nothing published.

Neither has ever run: the signing job was added after 1.9.10 shipped, so 1.9.11 is its first outing. `zip`, `make` and `imagemagick` are now installed before signing starts (the last for login screenshots, which is how the previous field login failure was diagnosed).

## Integration ignored its own `branch` input

The workflow advertises a `branch` dispatch input, but its checkout had no `ref:` — a manual run against another branch quietly tested `mercuryv2` and reported green for code it never compiled. Now uses the input, falling back to `github.ref` so automatic PR and push runs behave exactly as before.

Also audited and found clean: `build.yml`, `ut.yml`, `sanitizers.yml` (the TSan suppressions path is already container-absolute), and the rest of `release.yml` — the version bump covers all five files, and the signed-zip re-pack updates the existing archive rather than replacing it, so the vendored hamlib DLLs survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
