### PR TITLE
installer: shortcut name cannot contain "/" — it aborts Setup on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ FYNE_UI_DIR   = gui_interface/fyne-ui
 FYNE_UI_BIN   = mercury-ui.exe
 MINGW_GO_CC   = x86_64-w64-mingw32-gcc
 
-.PHONY: all install internal_deps utils clean doxygen doxygen-clean windows windows-zip windows-installer-signed windows-installer-stage fyne-ui fyne-ui-macos fyne-ui-macos-dmg macos-universal fyne-ui-macos-universal fyne-ui-macos-universal-dmg fyne-ui-windows windows-installer test integration-test FORCE
+.PHONY: all install internal_deps utils clean doxygen doxygen-clean windows windows-zip windows-installer-signed windows-installer-stage check-installer-names fyne-ui fyne-ui-macos fyne-ui-macos-dmg macos-universal fyne-ui-macos-universal fyne-ui-macos-universal-dmg fyne-ui-windows windows-installer test integration-test FORCE
 
 prefix ?= /usr
 bindir ?= $(prefix)/bin
@@ -483,7 +483,19 @@ fyne-ui-windows: libmercury_core_w64.a
 # the release pipeline signs in a container that has the certificate but no
 # mingw/Go toolchain, so it must be able to pack without triggering a rebuild
 # (which would also discard the signatures it just applied).
-windows-installer-stage:
+# Windows rejects \ / : * ? " < > | in file names, and Inno Setup only finds
+# out at INSTALL time — ISCC compiles a bad shortcut name happily and the user
+# gets "IPersistFile::Save failed; code 0x80070003" halfway through Setup.
+# Nothing in CI installs the installer, so check the names statically.
+check-installer-names:
+	@awk -F'"' '/^Name: "\{(group|autodesktop|commondesktop|userdesktop)\}/ { \
+		n = $$2; sub(/.*\\/, "", n); \
+		if (n ~ /[\/:*?<>|]/) { \
+			printf("%s:%d: illegal character in shortcut name: %s\n", FILENAME, NR, n); \
+			rc = 1 } } \
+	    END { exit rc }' $(WINDOWS_INSTALLER_DIR)/installer.iss
+
+windows-installer-stage: check-installer-names
 	cp mercury.exe $(WINDOWS_INSTALLER_DIR)/
 	cp mercury.ini.example $(WINDOWS_INSTALLER_DIR)/mercury.ini
 	sed -i 's/ui_enabled = false/ui_enabled = true/g' $(WINDOWS_INSTALLER_DIR)/mercury.ini

--- a/windows-installer/installer.iss
+++ b/windows-installer/installer.iss
@@ -91,7 +91,7 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilen
 ; running the modem: a bare double-click would flash a window and vanish, which
 ; looks broken.  This lands an advanced user (or someone being talked through a
 ; problem) at a prompt with mercury.exe on hand.
-Name: "{group}\Advanced\Mercury Console (headless / TNC)"; Filename: "{cmd}"; Parameters: "/K mercury.exe -h"; WorkingDir: "{app}"; IconFilename: "{app}\mercury.ico"; Comment: "Command-line modem for headless, TNC and scripted use - advanced users"
+Name: "{group}\Advanced\Mercury Console (headless, TNC)"; Filename: "{cmd}"; Parameters: "/K mercury.exe -h"; WorkingDir: "{app}"; IconFilename: "{app}\mercury.ico"; Comment: "Command-line modem for headless, TNC and scripted use - advanced users"
 
 
 [Run]


### PR DESCRIPTION
A 1.9.11 install fails partway through with:

> IPersistFile::Save failed; code 0x80070003.
> The system cannot find the path specified.

The Advanced Start Menu entry was named `Mercury Console (headless / TNC)`. Windows does not allow `/` in a file name, so writing the `.lnk` fails and Setup stops while creating shortcuts.

ISCC compiles the bad name without complaint — it is only rejected when the shortcut is actually written, at install time. Nothing in CI installs the installer, so it reached a user.

## Fix

Renamed to `Mercury Console (headless, TNC)`, and added a static check of every `{group}`/desktop shortcut name for characters Windows will not accept (`\ / : * ? " < > |`). It is wired into `windows-installer-stage`, so both the local and CI installer paths run it. Verified it fails on the old name and passes on the new one.

## Note on 1.9.11

The published v1.9.11 release contains only the zip, so no shipped installer is affected. Any installer built from the 1.9.11 tag locally does have the bug and should be rebuilt after this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
