### PR TITLE
channel: enable the busy detector by default, deliver BUSY like other state

### DIFF
--- a/common/cfg_utils.c
+++ b/common/cfg_utils.c
@@ -64,7 +64,7 @@ void cfg_set_defaults(mercury_config *cfg)
     cfg->keepalive_miss_limit        = ARQ_KEEPALIVE_MISS_LIMIT_DEFAULT;
     cfg->peer_payload_hold_s         = ARQ_PEER_PAYLOAD_HOLD_S_DEFAULT;
     cfg->startup_max_s               = ARQ_STARTUP_MAX_S_DEFAULT;
-    cfg->busy_detect                 = false;
+    cfg->busy_detect                 = true;
     cfg->busy_threshold_db           = 10;
     cfg->busy_hysteresis_db          = 3;
     cfg->busy_on_debounce_ms         = 300;

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -1375,8 +1375,11 @@ void tnc_send_busy(bool busy)
     /* VARA-compatible channel-occupancy notification: hosts (VarAC, BPQ32,
      * Winlink) already understand "BUSY ON" / "BUSY OFF".  Edge-triggered by
      * the caller (the channel-busy detector), so this only fires on a real
-     * CLEAR<->BUSY transition. */
-    (void)tnc_queue_line(busy ? "BUSY ON\r" : "BUSY OFF\r");
+     * CLEAR<->BUSY transition — which is why it goes out on the critical path
+     * with the other state notifications.  There is no periodic refresh: a
+     * dropped "BUSY ON" leaves a scanning host stepping over an occupied
+     * channel until the next transition, which may be a whole QSO away. */
+    (void)tnc_queue_line_critical(busy ? "BUSY ON\r" : "BUSY OFF\r");
 }
 
 void tnc_send_bitrate(uint32_t speed_level, uint32_t bps)

--- a/docs/TNC.md
+++ b/docs/TNC.md
@@ -429,11 +429,17 @@ HF channel transition between clear and occupied, using VARA's exact wording so
 existing VARA-compatible hosts (VarAC, BPQ32, Winlink) act on them unchanged.
 Edge-triggered: `BUSY ON\r` on clear→busy, `BUSY OFF\r` on busy→clear.
 
-The detector is **disabled by default** and enabled via the `[channel]` section
-of `mercury.ini` (`busy_detect = true`); its sensitivity/timing knobs
+The detector is **enabled by default** and can be turned off via the `[channel]`
+section of `mercury.ini` (`busy_detect = false`); its sensitivity/timing knobs
 (`busy_threshold_db`, `busy_hysteresis_db`, `busy_on_debounce_ms`,
 `busy_hang_ms`) typically need on-air tuning per band/noise environment. When
 disabled, these notifications are never sent. See `mercury.ini.example`.
+
+`BUSY ON` is the earliest notification a host can act on: it follows the carrier
+by roughly the debounce time (~0.3 s by default), whereas `PENDING` cannot be
+sent until a whole connect request has decoded — 3.74 s in the DATAC16 control
+mode. A host that scans channels needs the former to hold its dwell long enough
+to receive the latter.
 
 ### DISCONNECTED
 

--- a/mercury.ini.example
+++ b/mercury.ini.example
@@ -143,11 +143,15 @@ peer_payload_hold_s = 15
 startup_max_s = 10
 
 [channel]
-; Channel-busy (occupancy) detector.  When enabled, Mercury classifies the HF
-; channel as busy/clear from the RX spectrum and reports transitions to the host
-; with VARA-compatible "BUSY ON" / "BUSY OFF" notifications on the control port.
-; Disabled by default (opt-in); thresholds typically need on-air tuning.
-busy_detect = false
+; Channel-busy (occupancy) detector.  Mercury classifies the HF channel as
+; busy/clear from the RX spectrum and reports transitions to the host with
+; VARA-compatible "BUSY ON" / "BUSY OFF" notifications on the control port.
+; Enabled by default: it is report-only (it never gates transmission), and it is
+; the ONLY early warning a host gets — everything else waits for a full frame to
+; decode, which is 3.7 s for a connect request.  A scanning host cannot hold its
+; dwell that long, so with the detector off it steps over incoming calls.
+; Thresholds below typically need on-air tuning per band/noise environment.
+busy_detect = true
 
 ; Passband peak level, in dB above the tracked noise floor, required to call the
 ; channel BUSY (default 10, range 3..40).  Lower = more sensitive.

--- a/tests/common/test_cfg_utils.c
+++ b/tests/common/test_cfg_utils.c
@@ -45,7 +45,7 @@ void test_defaults_match_constants(void)
     TEST_ASSERT_EQUAL_INT(5,   c.keepalive_miss_limit);
     TEST_ASSERT_EQUAL_INT(15,  c.peer_payload_hold_s);
     TEST_ASSERT_EQUAL_INT(10,  c.startup_max_s);
-    TEST_ASSERT_FALSE(c.busy_detect);
+    TEST_ASSERT_TRUE(c.busy_detect);   /* report-only, and the only early warning a host gets */
     TEST_ASSERT_EQUAL_INT(10,   c.busy_threshold_db);
     TEST_ASSERT_EQUAL_INT(3,    c.busy_hysteresis_db);
     TEST_ASSERT_EQUAL_INT(300,  c.busy_on_debounce_ms);
@@ -67,7 +67,7 @@ void test_arq_tunables_roundtrip(void)
     w.keepalive_miss_limit        = 8;
     w.peer_payload_hold_s         = 25;
     w.startup_max_s               = 20;
-    w.busy_detect                 = true;
+    w.busy_detect                 = false;  /* non-default: proves it round-trips */
     w.busy_threshold_db           = 14;
     w.busy_hysteresis_db          = 5;
     w.busy_on_debounce_ms         = 500;
@@ -87,7 +87,7 @@ void test_arq_tunables_roundtrip(void)
     TEST_ASSERT_EQUAL_INT(8,    r.keepalive_miss_limit);
     TEST_ASSERT_EQUAL_INT(25,   r.peer_payload_hold_s);
     TEST_ASSERT_EQUAL_INT(20,   r.startup_max_s);
-    TEST_ASSERT_TRUE(r.busy_detect);
+    TEST_ASSERT_FALSE(r.busy_detect);
     TEST_ASSERT_EQUAL_INT(14,   r.busy_threshold_db);
     TEST_ASSERT_EQUAL_INT(5,    r.busy_hysteresis_db);
     TEST_ASSERT_EQUAL_INT(500,  r.busy_on_debounce_ms);


### PR DESCRIPTION
A scanning gateway reported stepping over incoming calls: it only stopped scanning once the whole connect request had decoded, and when it missed one it stopped on the *next* channel in the scan table — where a reply would have gone out on the wrong frequency.

## Why

With the busy detector off, the first thing a host hears about an incoming call is `PENDING`, and that cannot be sent until the entire CALL burst has decoded — **3.74 s** in the DATAC16 control mode (`arq_protocol.c:89`). The reported setup has a 7 s dwell and the call arrived 5 s in, leaving 2 s. The scanner had already moved on before Mercury could say anything.

`BUSY ON` follows the carrier by the debounce time instead (~0.3 s by default, evaluated on every spectrum frame), which fits comfortably. Mercury already had the detector — it was simply opt-in and off.

## Changes

**`busy_detect` now defaults to true.** This is report-only: `modem_channel_busy()` has no callers outside the tests, so it gates nothing and the change is in what Mercury *tells* the host, not in what it puts on the air. Hosts that do not understand `BUSY` ignore the line. It can still be turned off in `[channel]`.

**`BUSY ON`/`BUSY OFF` now go out on the critical path** with the other state notifications. They are edge-triggered with no periodic refresh, exactly like `PTT` — a dropped `BUSY ON` leaves a scanning host stepping over an occupied channel until the next transition, possibly a whole QSO later. Same reasoning as #141.

Docs and `mercury.ini.example` updated, including the 0.3 s vs 3.74 s comparison so the reason for the default is on the page.

## Tests

The config round-trip test now writes the **non-default** value, so it proves the setting survives a save/load instead of accidentally matching the new default. Full suite green, clean build.

## Still to confirm on the host side

Whether BPQ32 pauses its scan on `BUSY ON` — that is what makes this land end to end, and only the reporting operator can verify it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
