### PR TITLE
gui: drive the embedded UI through CGo, behind a transport-agnostic Link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ MERCURY_LINK_INPUTS = \
 	datalink_broadcast/broadcast.o datalink_broadcast/kiss.o modem/modem.o modem/framer.o modem/channel_busy.o modem/freedv/libfreedvdata.a \
 	audioio/audioio.a common/os_interop.o common/ring_buffer_posix.o common/shm_posix.o common/crc6.o common/hermes_log.o common/virtual_clock.o \
 	common/chan.o common/queue.o common/mercury_engine.o common/mercury_cli.o data_interfaces/tcp_interfaces.o data_interfaces/net.o \
-	gui_interface/ui_communication.o \
+	gui_interface/ui_communication.o gui_interface/ui_status.o \
 	gui_interface/websocket/mongoose.o gui_interface/websocket/mercury_websocket.o \
 	radio_io/radio_io.o
 
@@ -200,7 +200,7 @@ MERCURY_CORE_OBJS = \
 	common/os_interop.o common/ring_buffer_posix.o common/shm_posix.o common/crc6.o common/hermes_log.o common/virtual_clock.o \
 	common/chan.o common/queue.o common/mercury_engine.o common/mercury_cli.o \
 	data_interfaces/tcp_interfaces.o data_interfaces/net.o \
-	gui_interface/ui_communication.o \
+	gui_interface/ui_communication.o gui_interface/ui_status.o \
 	gui_interface/websocket/mongoose.o gui_interface/websocket/mercury_websocket.o \
 	radio_io/radio_io.o
 

--- a/gui_interface/Makefile
+++ b/gui_interface/Makefile
@@ -28,13 +28,16 @@ CFLAGS_COMMON = $(COMMON_CFLAGS) -Wno-stringop-truncation -I../datalink_arq -I..
 WS_CFLAGS = $(COMMON_CFLAGS) -Iwebsocket -DMG_TLS=MG_TLS_BUILTIN
 
 # Objects
-OBJS = ui_communication.o
+OBJS = ui_communication.o ui_status.o
 WS_OBJS = websocket/mongoose.o websocket/mercury_websocket.o
 
 all: $(OBJS) $(WS_OBJS)
 
-ui_communication.o: ui_communication.c ui_communication.h
+ui_communication.o: ui_communication.c ui_communication.h ui_status.h
 	$(CC) $(CFLAGS_COMMON) -c ui_communication.c -o ui_communication.o
+
+ui_status.o: ui_status.c ui_status.h
+	$(CC) $(CFLAGS_COMMON) -c ui_status.c -o ui_status.o
 
 websocket/mongoose.o: websocket/mongoose.c websocket/mongoose.h
 	$(CC) $(WS_CFLAGS) -Wno-maybe-uninitialized -c websocket/mongoose.c -o websocket/mongoose.o

--- a/gui_interface/fyne-ui/engine/mercury_bridge.c
+++ b/gui_interface/fyne-ui/engine/mercury_bridge.c
@@ -105,6 +105,18 @@ void mercury_shutdown(void)
 }
 
 /* ------------------------------------------------------------------ */
+/*  mercury_ui_preload_device_lists()                                  */
+/*                                                                     */
+/*  Trigger radio-enumeration during engine init, on the main thread,   */
+/*  so the Go goroutine that later reads the list never enters hamlib's */
+/*  backend-loading path inside a CGo context.                          */
+/* ------------------------------------------------------------------ */
+void mercury_ui_preload_device_lists(void)
+{
+    ui_comm_preload_radio_list();
+}
+
+/* ------------------------------------------------------------------ */
 /*  In-process UI link                                                 */
 /*                                                                     */
 /*  Thin forwarders: the engine owns the state and the command          */

--- a/gui_interface/fyne-ui/engine/mercury_bridge.c
+++ b/gui_interface/fyne-ui/engine/mercury_bridge.c
@@ -16,6 +16,9 @@
 #include "mercury_engine.h"
 #include "mercury_cli.h"
 #include "mercury_version.h"
+#include "ui_communication.h"
+#include "modem.h"
+#include "modem_stats.h"   /* MODEM_STATS_NSPEC */
 
 /* Print the startup version banner (same text the daemon prints), so the UI
  * announces its version on the terminal too.  Resolved here, in a unit the
@@ -99,4 +102,35 @@ void mercury_request_shutdown(void)
 void mercury_shutdown(void)
 {
     mercury_engine_shutdown();
+}
+
+/* ------------------------------------------------------------------ */
+/*  In-process UI link                                                 */
+/*                                                                     */
+/*  Thin forwarders: the engine owns the state and the command          */
+/*  handling, so local and remote clients cannot drift apart.           */
+/* ------------------------------------------------------------------ */
+int mercury_ui_get_status(ui_status_t *out)
+{
+    return ui_comm_get_status(out) ? 1 : 0;
+}
+
+int mercury_ui_get_spectrum(float *out, int max_bins, int *sample_rate_hz)
+{
+    if (!out || max_bins <= 0)
+        return 0;
+
+    int nbins = (max_bins < MODEM_STATS_NSPEC) ? max_bins : MODEM_STATS_NSPEC;
+    int sr = modem_get_rx_spectrum(out, nbins);
+    if (sr <= 0)
+        return 0;
+    if (sample_rate_hz)
+        *sample_rate_hz = sr;
+    return nbins;
+}
+
+int mercury_ui_command(const char *command, const char *value,
+                       const char *value2, const char *value3)
+{
+    return ui_comm_command(command, value, value2, value3);
 }

--- a/gui_interface/fyne-ui/engine/mercury_bridge.c
+++ b/gui_interface/fyne-ui/engine/mercury_bridge.c
@@ -115,17 +115,21 @@ int mercury_ui_get_status(ui_status_t *out)
     return ui_comm_get_status(out) ? 1 : 0;
 }
 
-int mercury_ui_get_spectrum(float *out, int max_bins, int *sample_rate_hz)
+int mercury_ui_get_spectrum(float *out, int max_bins, int *sample_rate_hz,
+                            unsigned long long *seq)
 {
     if (!out || max_bins <= 0)
         return 0;
 
     int nbins = (max_bins < MODEM_STATS_NSPEC) ? max_bins : MODEM_STATS_NSPEC;
-    int sr = modem_get_rx_spectrum(out, nbins);
+    uint64_t s = 0;
+    int sr = modem_get_rx_spectrum_seq(out, nbins, &s);
     if (sr <= 0)
         return 0;
     if (sample_rate_hz)
         *sample_rate_hz = sr;
+    if (seq)
+        *seq = (unsigned long long)s;
     return nbins;
 }
 

--- a/gui_interface/fyne-ui/engine/mercury_bridge.c
+++ b/gui_interface/fyne-ui/engine/mercury_bridge.c
@@ -134,3 +134,25 @@ int mercury_ui_command(const char *command, const char *value,
 {
     return ui_comm_command(command, value, value2, value3);
 }
+
+int mercury_ui_get_audio_devices(int kind, ui_device_t *out, int max,
+                                 char *selected, int selected_len)
+{
+    return ui_comm_get_audio_devices((ui_device_kind_t)kind, out, max,
+                                     selected, (size_t)selected_len);
+}
+
+int mercury_ui_get_radio_list(ui_device_t *out, int max,
+                              char *selected, int selected_len,
+                              char *device_path, int device_path_len,
+                              int *serial_speed)
+{
+    return ui_comm_get_radio_list(out, max, selected, (size_t)selected_len,
+                                  device_path, (size_t)device_path_len,
+                                  serial_speed);
+}
+
+int mercury_ui_get_input_channel(void)
+{
+    return ui_comm_get_input_channel();
+}

--- a/gui_interface/fyne-ui/engine/mercury_bridge.h
+++ b/gui_interface/fyne-ui/engine/mercury_bridge.h
@@ -46,8 +46,12 @@ void mercury_request_shutdown(void);
 int mercury_ui_get_status(ui_status_t *out);
 
 /* Copy the current RX power spectrum (dB).  Returns the number of bins written
- * (0 if none available yet) and sets *sample_rate_hz when non-NULL. */
-int mercury_ui_get_spectrum(float *out, int max_bins, int *sample_rate_hz);
+ * (0 if none available yet), and sets *sample_rate_hz and *seq when non-NULL.
+ * `seq` counts FFT frames: poll faster than they are produced and skip the
+ * ones already seen, and the waterfall gets each frame exactly once instead of
+ * aliasing two independent ~20 Hz clocks against each other. */
+int mercury_ui_get_spectrum(float *out, int max_bins, int *sample_rate_hz,
+                            unsigned long long *seq);
 
 /* Run a UI command through the same handler the websocket path uses.
  * Unused values may be NULL.  Returns 0 on success. */

--- a/gui_interface/fyne-ui/engine/mercury_bridge.h
+++ b/gui_interface/fyne-ui/engine/mercury_bridge.h
@@ -58,6 +58,13 @@ int mercury_ui_get_spectrum(float *out, int max_bins, int *sample_rate_hz,
 int mercury_ui_command(const char *command, const char *value,
                        const char *value2, const char *value3);
 
+/* Pre-load device enumerations from the main thread during engine init.
+ * hamlib backend loading uses a global registry that must be initialised
+ * on a "normal" POSIX thread (not a CGo goroutine which has a different
+ * signal mask and TLS setup).  Calling this from mercury_init() ensures
+ * the radio list is ready before any UI goroutine asks for it. */
+void mercury_ui_preload_device_lists(void);
+
 /* Device pickers.  The websocket path pushes these to a client when it
  * connects; a local UI asks for them instead.  Both read the same enumerators,
  * so the two see the same devices and the same selection. */

--- a/gui_interface/fyne-ui/engine/mercury_bridge.h
+++ b/gui_interface/fyne-ui/engine/mercury_bridge.h
@@ -12,6 +12,10 @@
 
 #include <stdbool.h>
 
+/* The UI status struct is defined once, in the engine — the bridge hands out
+ * that same type rather than declaring a parallel copy. */
+#include "ui_status.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -27,6 +31,28 @@ int  mercury_precheck(int argc, char **argv, const char *default_config);
 int  mercury_init(int argc, char **argv, const char *default_config, const char *log_path);
 void mercury_shutdown(void);
 void mercury_request_shutdown(void);
+
+/* ---- In-process UI link ----------------------------------------------------
+ * The embedded UI pulls state and pushes commands through these calls instead
+ * of opening a websocket back to its own process.  The websocket server keeps
+ * running for remote clients (HERMES web UI, a desktop UI on another machine).
+ *
+ * Pull, not callbacks: the engine's publisher threads never call into Go, so a
+ * busy or stopped UI can never stall the modem, and there is no cgocallback on
+ * the audio-adjacent threads. */
+
+/* Copy the latest status snapshot.  Returns 1 on success, 0 before the engine
+ * has published its first one. */
+int mercury_ui_get_status(ui_status_t *out);
+
+/* Copy the current RX power spectrum (dB).  Returns the number of bins written
+ * (0 if none available yet) and sets *sample_rate_hz when non-NULL. */
+int mercury_ui_get_spectrum(float *out, int max_bins, int *sample_rate_hz);
+
+/* Run a UI command through the same handler the websocket path uses.
+ * Unused values may be NULL.  Returns 0 on success. */
+int mercury_ui_command(const char *command, const char *value,
+                       const char *value2, const char *value3);
 
 #ifdef __cplusplus
 }

--- a/gui_interface/fyne-ui/engine/mercury_bridge.h
+++ b/gui_interface/fyne-ui/engine/mercury_bridge.h
@@ -54,6 +54,17 @@ int mercury_ui_get_spectrum(float *out, int max_bins, int *sample_rate_hz);
 int mercury_ui_command(const char *command, const char *value,
                        const char *value2, const char *value3);
 
+/* Device pickers.  The websocket path pushes these to a client when it
+ * connects; a local UI asks for them instead.  Both read the same enumerators,
+ * so the two see the same devices and the same selection. */
+int mercury_ui_get_audio_devices(int kind, ui_device_t *out, int max,
+                                 char *selected, int selected_len);
+int mercury_ui_get_radio_list(ui_device_t *out, int max,
+                              char *selected, int selected_len,
+                              char *device_path, int device_path_len,
+                              int *serial_speed);
+int mercury_ui_get_input_channel(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/gui_interface/fyne-ui/link.go
+++ b/gui_interface/fyne-ui/link.go
@@ -1,0 +1,141 @@
+package main
+
+import "context"
+
+// A Link is where the UI gets engine state and where it sends commands. It
+// exists so the rest of the UI never knows, or cares, whether Mercury is
+// running inside this process or on a Pi at the far end of the shack.
+//
+// Two implementations:
+//
+//	engineLink — the engine linked into this binary, read through CGo. No
+//	             socket, no serialization; the default for the desktop app.
+//	wsLink     — a Mercury elsewhere, over the websocket the web UI uses.
+//
+// Both deliver the same events, so the UI code below is written once. Adding a
+// third transport means implementing this interface, nothing else.
+type Link interface {
+	// Name is shown in the status line, e.g. "embedded engine" or
+	// "ws://192.168.1.50:10000".
+	Name() string
+
+	// Start begins producing events and returns the channel they arrive on.
+	// The channel is closed when the link goes down or ctx is cancelled.
+	// Events must be consumed promptly; a Link may drop stale telemetry
+	// rather than block the engine.
+	Start(ctx context.Context) (<-chan Event, error)
+
+	// Send delivers a command to the engine. Safe for concurrent use.
+	Send(cmd Command) error
+
+	// Close releases the transport. Idempotent.
+	Close()
+}
+
+// Command is a UI action on its way to the engine — the same four fields the
+// websocket protocol carries, so neither transport has to translate.
+type Command struct {
+	Name   string
+	Value  string
+	Value2 string
+	Value3 string
+}
+
+// DeviceKind identifies which selector a device list belongs to.
+type DeviceKind int
+
+const (
+	DeviceCapture DeviceKind = iota
+	DevicePlayback
+	DeviceInputChannel
+)
+
+// Event is anything a Link can report. The set is closed: a type switch in the
+// UI handles every case, so a new event type will not be silently ignored.
+type Event interface{ isLinkEvent() }
+
+// StatusEvent carries a full telemetry snapshot (bitrate, SNR, callsigns,
+// byte counters, PTT direction). Sent about twice a second.
+type StatusEvent struct{ Status telemetryState }
+
+// SpectrumEvent carries one FFT frame for the waterfall, about 20 times a
+// second. Bins are dB magnitudes; the UI owns the slice once delivered.
+type SpectrumEvent struct {
+	Bins       []float32
+	SampleRate int
+}
+
+// DeviceListEvent repopulates one of the audio selectors.
+type DeviceListEvent struct {
+	Kind     DeviceKind
+	Items    []optionItem
+	Selected string
+}
+
+// RadioListEvent repopulates the radio selector and its companion fields.
+type RadioListEvent struct {
+	Items       []optionItem
+	Selected    string
+	DevicePath  string
+	SerialSpeed string
+}
+
+// LinkStateEvent reports the transport coming up or going down, with a
+// human-readable detail for the log pane.
+type LinkStateEvent struct {
+	Up     bool
+	Detail string
+}
+
+// LogEvent is a line for the UI log pane — anything the transport wants to
+// say that is not state.
+type LogEvent struct{ Text string }
+
+func (StatusEvent) isLinkEvent()     {}
+func (SpectrumEvent) isLinkEvent()   {}
+func (DeviceListEvent) isLinkEvent() {}
+func (RadioListEvent) isLinkEvent()  {}
+func (LinkStateEvent) isLinkEvent()  {}
+func (LogEvent) isLinkEvent()        {}
+
+// emit posts an event unless the consumer is gone or lagging. Telemetry is
+// disposable — a dropped spectrum frame costs one waterfall row, whereas
+// blocking here would stall the poller (embedded) or the socket reader
+// (remote) behind a busy UI thread.
+func emit(ctx context.Context, ch chan<- Event, ev Event) bool {
+	select {
+	case ch <- ev:
+		return true
+	case <-ctx.Done():
+		return false
+	default:
+		return true // consumer lagging; drop this one rather than block
+	}
+}
+
+// openLink chooses the transport for a session. The embedded engine wins when
+// it is available and the user has not pointed the UI at another machine, so
+// the desktop app talks to its own engine directly and never opens a socket to
+// itself. Naming a remote host keeps the websocket path — that is how one
+// desktop UI drives a Mercury on a Pi at the antenna.
+func openLink(host, port, scheme string) (Link, error) {
+	if isLocalHost(host) {
+		l := newEngineLink()
+		if _, err := l.probe(); err == nil {
+			return l, nil
+		}
+		// No engine in this build: fall through to the websocket, which still
+		// reaches a Mercury running as a separate process on this machine.
+	}
+	return newWSLink(scheme, host, port), nil
+}
+
+// isLocalHost reports whether the host field names this machine (or is empty,
+// the default), in which case the embedded engine is preferred.
+func isLocalHost(host string) bool {
+	switch host {
+	case "", "localhost", "127.0.0.1", "::1":
+		return true
+	}
+	return false
+}

--- a/gui_interface/fyne-ui/link.go
+++ b/gui_interface/fyne-ui/link.go
@@ -1,6 +1,9 @@
 package main
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // A Link is where the UI gets engine state and where it sends commands. It
 // exists so the rest of the UI never knows, or cares, whether Mercury is
@@ -113,29 +116,21 @@ func emit(ctx context.Context, ch chan<- Event, ev Event) bool {
 	}
 }
 
-// openLink chooses the transport for a session. The embedded engine wins when
-// it is available and the user has not pointed the UI at another machine, so
-// the desktop app talks to its own engine directly and never opens a socket to
-// itself. Naming a remote host keeps the websocket path — that is how one
-// desktop UI drives a Mercury on a Pi at the antenna.
-func openLink(host, port, scheme string) (Link, error) {
-	if isLocalHost(host) {
+// openLink builds the transport for a session. The choice is the operator's,
+// made in the UI, not inferred from a hostname: "127.0.0.1" is a perfectly
+// reasonable thing to type when you really do want to reach a separate Mercury
+// process on this machine over the network.
+//
+// Local means the engine linked into this binary, driven through CGo with no
+// socket involved. Remote means the websocket, which is how one desktop UI
+// drives a Mercury on a Pi at the antenna.
+func openLink(remote bool, host, port, scheme string) (Link, error) {
+	if !remote {
 		l := newEngineLink()
-		if _, err := l.probe(); err == nil {
-			return l, nil
+		if _, err := l.probe(); err != nil {
+			return nil, fmt.Errorf("no engine in this build: %w", err)
 		}
-		// No engine in this build: fall through to the websocket, which still
-		// reaches a Mercury running as a separate process on this machine.
+		return l, nil
 	}
 	return newWSLink(scheme, host, port), nil
-}
-
-// isLocalHost reports whether the host field names this machine (or is empty,
-// the default), in which case the embedded engine is preferred.
-func isLocalHost(host string) bool {
-	switch host {
-	case "", "localhost", "127.0.0.1", "::1":
-		return true
-	}
-	return false
 }

--- a/gui_interface/fyne-ui/link_engine.go
+++ b/gui_interface/fyne-ui/link_engine.go
@@ -34,8 +34,13 @@ type engineLink struct {
 }
 
 const (
-	engineStatusInterval   = 500 * time.Millisecond
-	engineSpectrumInterval = 50 * time.Millisecond
+	engineStatusInterval = 500 * time.Millisecond
+	// The engine produces FFT frames at ~20 Hz on its own clock. Polling at
+	// the same rate on a different clock aliases: some ticks see the frame
+	// twice, others miss one, and the waterfall stutters however fast the
+	// machine is. Poll faster and let the sequence number decide, so each
+	// frame is taken exactly once, promptly.
+	engineSpectrumInterval = 20 * time.Millisecond
 	// Matches MODEM_STATS_NSPEC; the bridge clamps to its own size anyway.
 	engineSpectrumBins = 512
 )
@@ -75,6 +80,8 @@ func (l *engineLink) Start(ctx context.Context) (<-chan Event, error) {
 		// serves the whole session for status.
 		var cst C.ui_status_t
 
+		var lastSpectrumSeq uint64
+
 		for {
 			select {
 			case <-ctx.Done():
@@ -87,10 +94,11 @@ func (l *engineLink) Start(ctx context.Context) (<-chan Event, error) {
 				emit(ctx, events, StatusEvent{Status: statusFromC(&cst)})
 
 			case <-specTick.C:
-				bins, rate, ok := pollSpectrum()
-				if !ok {
-					continue
+				bins, rate, seq, ok := pollSpectrum()
+				if !ok || seq == lastSpectrumSeq {
+					continue // nothing new since the last poll
 				}
+				lastSpectrumSeq = seq
 				emit(ctx, events, SpectrumEvent{Bins: bins, SampleRate: rate})
 
 			case <-l.refresh:
@@ -251,15 +259,17 @@ func statusFromC(cst *C.ui_status_t) telemetryState {
 	}
 }
 
-// pollSpectrum copies one FFT frame out of the engine. A fresh slice per frame
-// because the waterfall keeps the rows.
-func pollSpectrum() ([]float32, int, bool) {
+// pollSpectrum copies one FFT frame out of the engine, with the sequence number
+// that says whether it is new. A fresh slice per frame because the waterfall
+// keeps the rows.
+func pollSpectrum() ([]float32, int, uint64, bool) {
 	buf := make([]float32, engineSpectrumBins)
 	var rate C.int
+	var seq C.ulonglong
 	n := C.mercury_ui_get_spectrum((*C.float)(unsafe.Pointer(&buf[0])),
-		C.int(len(buf)), &rate)
+		C.int(len(buf)), &rate, &seq)
 	if n <= 0 {
-		return nil, 0, false
+		return nil, 0, 0, false
 	}
-	return buf[:int(n)], int(rate), true
+	return buf[:int(n)], int(rate), uint64(seq), true
 }

--- a/gui_interface/fyne-ui/link_engine.go
+++ b/gui_interface/fyne-ui/link_engine.go
@@ -1,0 +1,148 @@
+//go:build mercury_embedded
+
+package main
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/../.. -I${SRCDIR}/../../modem/freedv -I${SRCDIR}/../../modem -I${SRCDIR}/../../datalink_broadcast -I${SRCDIR}/../../data_interfaces -I${SRCDIR}/../../datalink_arq -I${SRCDIR}/../../audioio/ffaudio -I${SRCDIR}/../../common -I${SRCDIR}/../../gui_interface -I${SRCDIR}/../../radio_io -I${SRCDIR}/../../common/iniparser -I${SRCDIR}/engine -pthread -D_GNU_SOURCE
+
+#include <stdlib.h>
+#include "mercury_bridge.h"
+*/
+import "C"
+
+import (
+	"context"
+	"fmt"
+	"time"
+	"unsafe"
+)
+
+// engineLink drives the engine linked into this binary. State is pulled from
+// the engine on a ticker rather than pushed through a callback: the modem's
+// publisher threads must never end up blocked in Go code, and pulling keeps
+// the cadence tied to what the UI can actually draw.
+//
+// The intervals match what the engine publishes over the websocket, so the
+// embedded UI and a remote one see the same picture at the same rate.
+type engineLink struct {
+	statusEvery   time.Duration
+	spectrumEvery time.Duration
+}
+
+const (
+	engineStatusInterval   = 500 * time.Millisecond
+	engineSpectrumInterval = 50 * time.Millisecond
+	// Matches MODEM_STATS_NSPEC; the bridge clamps to its own size anyway.
+	engineSpectrumBins = 512
+)
+
+func newEngineLink() *engineLink {
+	return &engineLink{
+		statusEvery:   engineStatusInterval,
+		spectrumEvery: engineSpectrumInterval,
+	}
+}
+
+func (l *engineLink) Name() string { return "embedded engine" }
+
+// probe reports whether the engine is actually linked into this binary. With
+// the build tag on it always is, so this only ever fails in the stub.
+func (l *engineLink) probe() (bool, error) { return true, nil }
+
+func (l *engineLink) Start(ctx context.Context) (<-chan Event, error) {
+	events := make(chan Event, 64)
+
+	go func() {
+		defer close(events)
+
+		statusTick := time.NewTicker(l.statusEvery)
+		specTick := time.NewTicker(l.spectrumEvery)
+		defer statusTick.Stop()
+		defer specTick.Stop()
+
+		emit(ctx, events, LinkStateEvent{Up: true, Detail: "Engine running in-process (no socket)."})
+
+		// Reused across polls: the bridge copies into it, so one allocation
+		// serves the whole session for status.
+		var cst C.ui_status_t
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+
+			case <-statusTick.C:
+				if C.mercury_ui_get_status(&cst) == 0 {
+					continue // engine has not published its first snapshot yet
+				}
+				emit(ctx, events, StatusEvent{Status: statusFromC(&cst)})
+
+			case <-specTick.C:
+				bins, rate, ok := pollSpectrum()
+				if !ok {
+					continue
+				}
+				emit(ctx, events, SpectrumEvent{Bins: bins, SampleRate: rate})
+			}
+		}
+	}()
+
+	return events, nil
+}
+
+func (l *engineLink) Send(cmd Command) error {
+	cName := C.CString(cmd.Name)
+	cV1 := C.CString(cmd.Value)
+	cV2 := C.CString(cmd.Value2)
+	cV3 := C.CString(cmd.Value3)
+	defer func() {
+		C.free(unsafe.Pointer(cName))
+		C.free(unsafe.Pointer(cV1))
+		C.free(unsafe.Pointer(cV2))
+		C.free(unsafe.Pointer(cV3))
+	}()
+
+	if rc := C.mercury_ui_command(cName, cV1, cV2, cV3); rc != 0 {
+		return fmt.Errorf("engine rejected command %q (rc=%d)", cmd.Name, int(rc))
+	}
+	return nil
+}
+
+func (l *engineLink) Close() {}
+
+// statusFromC converts the engine's status struct into the UI's own type. This
+// is the only place that knows both, and it is the counterpart of
+// ui_status_to_json() on the C side — both render the same gathered snapshot.
+func statusFromC(cst *C.ui_status_t) telemetryState {
+	direction := "rx"
+	if bool(cst.transmitting) {
+		direction = "tx"
+	}
+	return telemetryState{
+		Bitrate:            int(cst.bitrate_bps),
+		SNR:                float64(cst.snr_db),
+		UserCallsign:       C.GoString(&cst.user_callsign[0]),
+		DestCallsign:       C.GoString(&cst.dest_callsign[0]),
+		Sync:               bool(cst.sync),
+		Direction:          direction,
+		ClientTCPConnected: bool(cst.client_tcp_connected),
+		BytesTransmitted:   int64(cst.bytes_transmitted),
+		BytesReceived:      int64(cst.bytes_received),
+		TXGainDB:           float64(cst.tx_gain_db),
+		TXPeakDBFS:         float64(cst.tx_peak_dbfs),
+		Waterfall:          bool(cst.waterfall_enabled),
+	}
+}
+
+// pollSpectrum copies one FFT frame out of the engine. A fresh slice per frame
+// because the waterfall keeps the rows.
+func pollSpectrum() ([]float32, int, bool) {
+	buf := make([]float32, engineSpectrumBins)
+	var rate C.int
+	n := C.mercury_ui_get_spectrum((*C.float)(unsafe.Pointer(&buf[0])),
+		C.int(len(buf)), &rate)
+	if n <= 0 {
+		return nil, 0, false
+	}
+	return buf[:int(n)], int(rate), true
+}

--- a/gui_interface/fyne-ui/link_engine.go
+++ b/gui_interface/fyne-ui/link_engine.go
@@ -74,7 +74,15 @@ func (l *engineLink) Start(ctx context.Context) (<-chan Event, error) {
 
 		// The websocket path pushes the pickers when a client connects; here
 		// there is no connect event, so read them once up front.
-		l.emitDeviceLists(ctx, events)
+		listsOK := l.emitDeviceLists(ctx, events)
+
+		// If the engine was not ready yet the lists come back empty. Retry for
+		// a few seconds rather than leaving the pickers on "(Select one)" for
+		// the rest of the session -- enumeration is slower on a Pi, and this is
+		// the only chance the local path gets.
+		listRetry := time.NewTicker(500 * time.Millisecond)
+		defer listRetry.Stop()
+		listRetriesLeft := 20
 
 		// Reused across polls: the bridge copies into it, so one allocation
 		// serves the whole session for status.
@@ -101,11 +109,19 @@ func (l *engineLink) Start(ctx context.Context) (<-chan Event, error) {
 				lastSpectrumSeq = seq
 				emit(ctx, events, SpectrumEvent{Bins: bins, SampleRate: rate})
 
+			case <-listRetry.C:
+				if listsOK || listRetriesLeft == 0 {
+					listRetry.Stop()
+					continue
+				}
+				listRetriesLeft--
+				listsOK = l.emitDeviceLists(ctx, events)
+
 			case <-l.refresh:
 				// A device or radio change was just applied; re-read so the
 				// pickers show what the engine actually ended up using, which
 				// is not always what was asked for.
-				l.emitDeviceLists(ctx, events)
+				_ = l.emitDeviceLists(ctx, events)
 			}
 		}
 	}()
@@ -141,8 +157,10 @@ func (l *engineLink) Send(cmd Command) error {
 
 // emitDeviceLists reads the audio, channel and radio pickers out of the engine
 // and publishes them as the same events the websocket path produces.
-func (l *engineLink) emitDeviceLists(ctx context.Context, events chan<- Event) {
+func (l *engineLink) emitDeviceLists(ctx context.Context, events chan<- Event) bool {
+	gotAudio, gotRadio := false, false
 	if items, selected, ok := readAudioDevices(C.UI_DEV_CAPTURE); ok {
+		gotAudio = true
 		emit(ctx, events, DeviceListEvent{Kind: DeviceCapture, Items: items, Selected: selected})
 	}
 	if items, selected, ok := readAudioDevices(C.UI_DEV_PLAYBACK); ok {
@@ -167,8 +185,10 @@ func (l *engineLink) emitDeviceLists(ctx context.Context, events chan<- Event) {
 	})
 
 	if ev, ok := readRadioList(); ok {
+		gotRadio = true
 		emit(ctx, events, ev)
 	}
+	return gotAudio && gotRadio
 }
 
 // maxAudioDevices matches the engine-side cap in ui_comm_get_audio_devices().

--- a/gui_interface/fyne-ui/link_engine.go
+++ b/gui_interface/fyne-ui/link_engine.go
@@ -27,6 +27,10 @@ import (
 type engineLink struct {
 	statusEvery   time.Duration
 	spectrumEvery time.Duration
+
+	// Signalled after a command that changes what the pickers should show, so
+	// the lists are re-read instead of going stale.
+	refresh chan struct{}
 }
 
 const (
@@ -40,6 +44,7 @@ func newEngineLink() *engineLink {
 	return &engineLink{
 		statusEvery:   engineStatusInterval,
 		spectrumEvery: engineSpectrumInterval,
+		refresh:       make(chan struct{}, 1),
 	}
 }
 
@@ -62,6 +67,10 @@ func (l *engineLink) Start(ctx context.Context) (<-chan Event, error) {
 
 		emit(ctx, events, LinkStateEvent{Up: true, Detail: "Engine running in-process (no socket)."})
 
+		// The websocket path pushes the pickers when a client connects; here
+		// there is no connect event, so read them once up front.
+		l.emitDeviceLists(ctx, events)
+
 		// Reused across polls: the bridge copies into it, so one allocation
 		// serves the whole session for status.
 		var cst C.ui_status_t
@@ -83,6 +92,12 @@ func (l *engineLink) Start(ctx context.Context) (<-chan Event, error) {
 					continue
 				}
 				emit(ctx, events, SpectrumEvent{Bins: bins, SampleRate: rate})
+
+			case <-l.refresh:
+				// A device or radio change was just applied; re-read so the
+				// pickers show what the engine actually ended up using, which
+				// is not always what was asked for.
+				l.emitDeviceLists(ctx, events)
 			}
 		}
 	}()
@@ -105,7 +120,109 @@ func (l *engineLink) Send(cmd Command) error {
 	if rc := C.mercury_ui_command(cName, cV1, cV2, cV3); rc != 0 {
 		return fmt.Errorf("engine rejected command %q (rc=%d)", cmd.Name, int(rc))
 	}
+
+	switch cmd.Name {
+	case "set_audio_config", "set_radio_config":
+		select {
+		case l.refresh <- struct{}{}:
+		default: // a refresh is already pending; one is enough
+		}
+	}
 	return nil
+}
+
+// emitDeviceLists reads the audio, channel and radio pickers out of the engine
+// and publishes them as the same events the websocket path produces.
+func (l *engineLink) emitDeviceLists(ctx context.Context, events chan<- Event) {
+	if items, selected, ok := readAudioDevices(C.UI_DEV_CAPTURE); ok {
+		emit(ctx, events, DeviceListEvent{Kind: DeviceCapture, Items: items, Selected: selected})
+	}
+	if items, selected, ok := readAudioDevices(C.UI_DEV_PLAYBACK); ok {
+		emit(ctx, events, DeviceListEvent{Kind: DevicePlayback, Items: items, Selected: selected})
+	}
+
+	// The channel list is fixed; only the selection comes from the engine.
+	channels := []optionItem{
+		{Name: "Left", ID: "left"},
+		{Name: "Right", ID: "right"},
+		{Name: "Stereo", ID: "stereo"},
+	}
+	selectedChannel := "left"
+	switch int(C.mercury_ui_get_input_channel()) {
+	case 1:
+		selectedChannel = "right"
+	case 2:
+		selectedChannel = "stereo"
+	}
+	emit(ctx, events, DeviceListEvent{
+		Kind: DeviceInputChannel, Items: channels, Selected: selectedChannel,
+	})
+
+	if ev, ok := readRadioList(); ok {
+		emit(ctx, events, ev)
+	}
+}
+
+// maxAudioDevices matches the engine-side cap in ui_comm_get_audio_devices().
+const maxAudioDevices = 32
+
+// maxRadios covers hamlib's catalogue plus the leading "None".
+const maxRadios = 513
+
+func readAudioDevices(kind C.ui_device_kind_t) ([]optionItem, string, bool) {
+	devs := make([]C.ui_device_t, maxAudioDevices)
+	sel := make([]C.char, 64)
+
+	n := C.mercury_ui_get_audio_devices(C.int(kind), &devs[0], C.int(len(devs)),
+		&sel[0], C.int(len(sel)))
+	if n <= 0 {
+		return nil, "", false
+	}
+
+	items := make([]optionItem, 0, int(n))
+	for i := 0; i < int(n); i++ {
+		items = append(items, optionItem{
+			ID:   C.GoString(&devs[i].id[0]),
+			Name: C.GoString(&devs[i].name[0]),
+		})
+	}
+	return items, C.GoString(&sel[0]), true
+}
+
+func readRadioList() (RadioListEvent, bool) {
+	devs := make([]C.ui_device_t, maxRadios)
+	sel := make([]C.char, 16)
+	devPath := make([]C.char, 512)
+	var speed C.int
+
+	n := C.mercury_ui_get_radio_list(&devs[0], C.int(len(devs)),
+		&sel[0], C.int(len(sel)),
+		&devPath[0], C.int(len(devPath)), &speed)
+	if n <= 0 {
+		return RadioListEvent{}, false
+	}
+
+	items := make([]optionItem, 0, int(n))
+	for i := 0; i < int(n); i++ {
+		items = append(items, optionItem{
+			ID:   C.GoString(&devs[i].id[0]),
+			Name: C.GoString(&devs[i].name[0]),
+		})
+	}
+	// "None" already leads the list; the rest keep hamlib order, matching what
+	// the websocket path sends before the UI sorts it.
+	sortRadioItems(items)
+
+	serial := ""
+	if speed > 0 {
+		serial = fmt.Sprintf("%d", int(speed))
+	}
+	return RadioListEvent{
+		Items:       items,
+		Selected:    C.GoString(&sel[0]),
+		DevicePath:  C.GoString(&devPath[0]),
+		SerialSpeed: serial,
+	}, true
 }
 
 func (l *engineLink) Close() {}

--- a/gui_interface/fyne-ui/link_engine_stub.go
+++ b/gui_interface/fyne-ui/link_engine_stub.go
@@ -1,0 +1,31 @@
+//go:build !mercury_embedded
+
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+// Without the engine linked in there is nothing to talk to in-process, so the
+// UI falls back to the websocket link. This stub keeps the rest of the code
+// transport-agnostic instead of sprinkling build tags through it.
+type engineLink struct{}
+
+func newEngineLink() *engineLink { return &engineLink{} }
+
+func (l *engineLink) Name() string { return "embedded engine (not built in)" }
+
+func (l *engineLink) probe() (bool, error) {
+	return false, fmt.Errorf("engine not embedded")
+}
+
+func (l *engineLink) Start(ctx context.Context) (<-chan Event, error) {
+	return nil, fmt.Errorf("engine not embedded (build with -tags mercury_embedded)")
+}
+
+func (l *engineLink) Send(cmd Command) error {
+	return fmt.Errorf("engine not embedded")
+}
+
+func (l *engineLink) Close() {}

--- a/gui_interface/fyne-ui/link_ws.go
+++ b/gui_interface/fyne-ui/link_ws.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// wsLink drives a Mercury reachable over the network — a Pi at the antenna, or
+// the engine in this same process when the UI is built without it. It speaks
+// the websocket protocol the HERMES web UI uses, and converts what arrives
+// into the transport-neutral events in link.go.
+type wsLink struct {
+	scheme string
+	host   string
+	port   string
+
+	mu   sync.RWMutex
+	conn *websocket.Conn
+}
+
+func newWSLink(scheme, host, port string) *wsLink {
+	if scheme == "" {
+		scheme = "ws"
+	}
+	if port == "" {
+		port = "10000"
+	}
+	return &wsLink{scheme: scheme, host: host, port: port}
+}
+
+func (l *wsLink) Name() string {
+	return fmt.Sprintf("%s://%s", l.scheme, netJoinHostPort(l.host, l.port))
+}
+
+func (l *wsLink) url() string {
+	u := url.URL{Scheme: l.scheme, Host: netJoinHostPort(l.host, l.port), Path: "/websocket"}
+	return u.String()
+}
+
+func (l *wsLink) Start(ctx context.Context) (<-chan Event, error) {
+	dialer := &websocket.Dialer{
+		HandshakeTimeout: 5 * time.Second,
+		TLSClientConfig:  &tls.Config{InsecureSkipVerify: l.scheme == "wss"},
+	}
+	conn, _, err := dialer.Dial(l.url(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("dial %s: %w", l.url(), err)
+	}
+
+	l.mu.Lock()
+	l.conn = conn
+	l.mu.Unlock()
+
+	events := make(chan Event, 64)
+
+	go func() {
+		<-ctx.Done()
+		_ = conn.Close()
+	}()
+
+	go func() {
+		defer close(events)
+		defer l.Close()
+
+		emit(ctx, events, LinkStateEvent{Up: true, Detail: "Connected to " + l.Name()})
+
+		for {
+			msgType, payload, err := conn.ReadMessage()
+			if err != nil {
+				emit(ctx, events, LinkStateEvent{Up: false, Detail: fmt.Sprintf("read error: %v", err)})
+				return
+			}
+			for _, ev := range decodeWSMessage(msgType, payload) {
+				if !emit(ctx, events, ev) {
+					return
+				}
+			}
+		}
+	}()
+
+	return events, nil
+}
+
+func (l *wsLink) Send(cmd Command) error {
+	l.mu.RLock()
+	conn := l.conn
+	l.mu.RUnlock()
+	if conn == nil {
+		return fmt.Errorf("not connected")
+	}
+
+	payload := map[string]any{"command": cmd.Name, "value": cmd.Value}
+	if cmd.Value2 != "" {
+		payload["value2"] = cmd.Value2
+	}
+	if cmd.Value3 != "" {
+		payload["value3"] = cmd.Value3
+	}
+	return conn.WriteJSON(payload)
+}
+
+func (l *wsLink) Close() {
+	l.mu.Lock()
+	conn := l.conn
+	l.conn = nil
+	l.mu.Unlock()
+	if conn != nil {
+		_ = conn.Close()
+	}
+}
+
+// decodeWSMessage turns one websocket frame into zero or more link events.
+// Kept free of connection state so it can be exercised on its own.
+func decodeWSMessage(msgType int, payload []byte) []Event {
+	switch msgType {
+	case websocket.BinaryMessage:
+		bins, rate, err := parseSpectrumFrame(payload)
+		if err != nil {
+			return nil
+		}
+		return []Event{SpectrumEvent{Bins: bins, SampleRate: rate}}
+
+	case websocket.TextMessage:
+		var raw map[string]any
+		if err := json.Unmarshal(payload, &raw); err != nil {
+			return []Event{LogEvent{Text: fmt.Sprintf("[Raw WS Msg]: %s\n", string(payload))}}
+		}
+
+		switch raw["type"] {
+		case "status":
+			status, err := parseStatusMessage(payload)
+			if err != nil {
+				return []Event{LogEvent{Text: fmt.Sprintf("Failed to parse status: %v\n", err)}}
+			}
+			return []Event{StatusEvent{Status: status}}
+
+		case "capture_dev_list":
+			return []Event{DeviceListEvent{
+				Kind:     DeviceCapture,
+				Items:    parseMenuItems(payload),
+				Selected: selectedValue(raw, "selected"),
+			}}
+
+		case "playback_dev_list":
+			return []Event{DeviceListEvent{
+				Kind:     DevicePlayback,
+				Items:    parseMenuItems(payload),
+				Selected: selectedValue(raw, "selected"),
+			}}
+
+		case "input_channel":
+			return []Event{DeviceListEvent{
+				Kind:     DeviceInputChannel,
+				Items:    parseChannelItems(payload),
+				Selected: selectedValue(raw, "selected"),
+			}}
+
+		case "radio_list":
+			items := parseMenuItems(payload)
+			sortRadioItems(items)
+			return []Event{RadioListEvent{
+				Items:       items,
+				Selected:    selectedValue(raw, "selected"),
+				DevicePath:  fmt.Sprint(raw["device_path"]),
+				SerialSpeed: fmt.Sprint(raw["serial_speed"]),
+			}}
+		}
+		return []Event{LogEvent{Text: fmt.Sprintf("[Raw WS Msg]: %s\n", string(payload))}}
+	}
+	return nil
+}
+
+// sortRadioItems puts "None" first and the rest alphabetically — hamlib's own
+// order is by model id, which is meaningless to a user hunting for their rig.
+func sortRadioItems(items []optionItem) {
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Name == "None" {
+			return true
+		}
+		if items[j].Name == "None" {
+			return false
+		}
+		return strings.ToLower(items[i].Name) < strings.ToLower(items[j].Name)
+	})
+}

--- a/gui_interface/fyne-ui/main.go
+++ b/gui_interface/fyne-ui/main.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -196,6 +197,17 @@ func runOnUI(fn func()) {
 	fyne.Do(fn)
 }
 
+const (
+	// Minimum heights for the two plots. Kept low deliberately: they are floors
+	// that must fit an 800x480 panel, not the size the plots are drawn at --
+	// the split below stretches them to fill a desktop window.
+	spectrumMinHeight  = 60
+	waterfallMinHeight = 90
+	// Share of the window given to the controls above the plots. Roughly
+	// matches the previous desktop proportions.
+	waterfallSplitOffset = 0.60
+)
+
 func main() {
 	// Announce the version on the terminal, just like the standalone daemon.
 	mercuryPrintVersion()
@@ -237,6 +249,12 @@ func main() {
 	})
 	schemeSelect.SetSelected(state.wsScheme)
 	schemeSelect.Resize(fyne.NewSize(90, 34))
+
+	// Set once mercuryStart() has returned. Until then the embedded engine's
+	// getters have no context to read (g_ui_ctx is still NULL), so a link
+	// opened before that point comes up with empty device and radio lists and
+	// never retries -- the pickers stay stuck on "(Select one)".
+	var engineReady atomic.Bool
 
 	// Declared here because the Engine selector below drives them, while they
 	// are built further down with the rest of the UI.
@@ -293,7 +311,10 @@ func main() {
 		if updateConnectionButton != nil {
 			updateConnectionButton()
 		}
-		if connectLink != nil {
+		// At startup this fires before the engine has been started; the
+		// goroutine that starts it connects afterwards. Connecting here too
+		// would win the race and pin empty pickers for the whole session.
+		if connectLink != nil && engineReady.Load() {
 			connectLink()
 		}
 	})
@@ -398,20 +419,23 @@ func main() {
 	})
 	bindings.waterfallCanvas = waterfallCanvas
 
-	waterfallHeight := 180
-	if myWindow.Canvas().Size().Width >= 1920 && myWindow.Canvas().Size().Height >= 1080 {
-		waterfallHeight = int(myWindow.Canvas().Size().Height / 4)
-	}
+	// Floor, not the display size: the split below hands the waterfall a share
+	// of whatever the window has, so it is large on a desktop without this
+	// number claiming space. It has to stay small enough that a 800x480 panel
+	// (a Pi with the official display) still has room for the controls --
+	// at 180 the spectrum card's minimum alone swallowed the whole window and
+	// the pickers, radio fields and telemetry vanished entirely.
+	waterfallHeight := waterfallMinHeight
 	waterfallBackground := canvas.NewRectangle(color.Transparent)
 	waterfallBackground.SetMinSize(fyne.NewSize(0, float32(waterfallHeight)))
 	waterfallCanvasBox := container.NewMax(waterfallBackground, waterfallCanvas)
 
 	spectrumBackground := canvas.NewRectangle(color.Transparent)
-	spectrumBackground.SetMinSize(fyne.NewSize(0, 90))
+	spectrumBackground.SetMinSize(fyne.NewSize(0, spectrumMinHeight))
 	spectrumCanvasBox := container.NewMax(spectrumBackground, spectrumCanvas)
 
-	// set fixed spectrum and waterfall sizes so the display remains consistent
-	spectrumCanvas.SetMinSize(fyne.NewSize(0, 90))
+	// Minimums only; the split decides how much each actually gets.
+	spectrumCanvas.SetMinSize(fyne.NewSize(0, spectrumMinHeight))
 	waterfallCanvas.SetMinSize(fyne.NewSize(0, float32(waterfallHeight)))
 
 	// open UI log file for appending; if it fails, uiLog will be nil and logs go only to the UI
@@ -476,34 +500,41 @@ func main() {
 
 	refreshTelemetry := func() {
 		runOnUI(func() {
+			// Snapshot once, under the lock, then render from the copy: this
+			// closure runs on the GL thread while the link goroutine is still
+			// publishing new status.
+			state.mu.Lock()
+			telemetry := state.telemetry
+			state.mu.Unlock()
+
 			// update compact telemetry texts
 			if bindings.bitrateText != nil {
-				bindings.bitrateText.Text = fmt.Sprintf("%d", state.telemetry.Bitrate)
+				bindings.bitrateText.Text = fmt.Sprintf("%d", telemetry.Bitrate)
 				bindings.bitrateText.Refresh()
 			}
 			if bindings.snrText != nil {
-				bindings.snrText.Text = fmt.Sprintf("%.1f dB", state.telemetry.SNR)
+				bindings.snrText.Text = fmt.Sprintf("%.1f dB", telemetry.SNR)
 				bindings.snrText.Refresh()
 			}
 			if bindings.directionText != nil {
-				bindings.directionText.Text = strings.ToUpper(state.telemetry.Direction)
+				bindings.directionText.Text = strings.ToUpper(telemetry.Direction)
 				bindings.directionText.Refresh()
 			}
 			if bindings.userCallsText != nil {
-				bindings.userCallsText.Text = state.telemetry.UserCallsign
+				bindings.userCallsText.Text = telemetry.UserCallsign
 				bindings.userCallsText.Refresh()
 			}
 			if bindings.destCallsText != nil {
-				bindings.destCallsText.Text = state.telemetry.DestCallsign
+				bindings.destCallsText.Text = telemetry.DestCallsign
 				bindings.destCallsText.Refresh()
 			}
 			if bindings.waterfallSNRText != nil {
-				bindings.waterfallSNRText.Text = fmt.Sprintf("SNR: %.1f dB", state.telemetry.SNR)
-				bindings.waterfallSNRText.Color = waterfallSNRColor(state.telemetry.SNR)
+				bindings.waterfallSNRText.Text = fmt.Sprintf("SNR: %.1f dB", telemetry.SNR)
+				bindings.waterfallSNRText.Color = waterfallSNRColor(telemetry.SNR)
 				bindings.waterfallSNRText.Refresh()
 			}
 			if bindings.waterfallSyncText != nil {
-				if state.telemetry.Sync {
+				if telemetry.Sync {
 					bindings.waterfallSyncText.Text = "SYNC"
 					bindings.waterfallSyncText.Color = color.NRGBA{R: 0x66, G: 0xFF, B: 0x66, A: 0xFF}
 				} else {
@@ -512,7 +543,7 @@ func main() {
 				bindings.waterfallSyncText.Refresh()
 			}
 			if bindings.tcpText != nil {
-				if state.telemetry.ClientTCPConnected {
+				if telemetry.ClientTCPConnected {
 					bindings.tcpText.Text = "On"
 					bindings.tcpText.Color = color.NRGBA{R: 0x66, G: 0xFF, B: 0x66, A: 0xFF}
 				} else {
@@ -522,15 +553,15 @@ func main() {
 				bindings.tcpText.Refresh()
 			}
 			if bindings.txBytesText != nil {
-				bindings.txBytesText.Text = fmt.Sprintf("%d", state.telemetry.BytesTransmitted)
+				bindings.txBytesText.Text = fmt.Sprintf("%d", telemetry.BytesTransmitted)
 				bindings.txBytesText.Refresh()
 			}
 			if bindings.rxBytesText != nil {
-				bindings.rxBytesText.Text = fmt.Sprintf("%d", state.telemetry.BytesReceived)
+				bindings.rxBytesText.Text = fmt.Sprintf("%d", telemetry.BytesReceived)
 				bindings.rxBytesText.Refresh()
 			}
-			bindings.txGainLabel.SetText(fmt.Sprintf("TX gain: %.1f dB", state.telemetry.TXGainDB))
-			bindings.txPeakLabel.SetText(fmt.Sprintf("TX peak: %.1f dBFS", state.telemetry.TXPeakDBFS))
+			bindings.txGainLabel.SetText(fmt.Sprintf("TX gain: %.1f dB", telemetry.TXGainDB))
+			bindings.txPeakLabel.SetText(fmt.Sprintf("TX peak: %.1f dBFS", telemetry.TXPeakDBFS))
 		})
 	}
 
@@ -542,9 +573,16 @@ func main() {
 	}
 
 	applyStatus := func(status telemetryState) {
+		// Under the lock: the link goroutine writes this while the GL thread
+		// reads it in refreshTelemetry(). telemetryState holds strings, so an
+		// unsynchronised write can hand the reader a torn string header and
+		// segfault the app -- the race detector flags every field of it.
+		state.mu.Lock()
 		state.telemetry = status
+		haveSpectrum := len(state.spectrumValues) > 0
+		state.mu.Unlock()
 		refreshTelemetry()
-		if len(state.spectrumValues) > 0 {
+		if haveSpectrum {
 			refreshSpectrum()
 		}
 	}
@@ -921,8 +959,6 @@ func main() {
 		nil,
 		waterfallContent,
 	))
-	const fixedWaterfallHeight = 310
-	spectrumCard.Resize(fyne.NewSize(0, fixedWaterfallHeight))
 
 	topPanel := container.NewVBox(
 		connectionCard,
@@ -931,7 +967,13 @@ func main() {
 			container.NewVBox(txCard, telemetryCard),
 		),
 	)
-	content := container.NewBorder(nil, spectrumCard, nil, nil, container.NewVScroll(topPanel))
+	// A split, not a border: with the spectrum as a border's bottom edge it was
+	// handed its full minimum height before anything else, so on a short screen
+	// it took the lot and the controls above it collapsed to a sliver. A split
+	// gives each side a proportion of the window and lets the operator drag the
+	// divider, which is the only way a 480px-tall panel can show both.
+	content := container.NewVSplit(container.NewVScroll(topPanel), spectrumCard)
+	content.SetOffset(waterfallSplitOffset)
 
 	mainLayout := container.NewBorder(topBar, nil, nil, nil, content)
 	myWindow.SetContent(mainLayout)
@@ -1009,6 +1051,7 @@ func main() {
 			return
 		}
 		appendLog("Mercury engine started — connecting...\n")
+		engineReady.Store(true)
 		connectLink()
 	}()
 

--- a/gui_interface/fyne-ui/main.go
+++ b/gui_interface/fyne-ui/main.go
@@ -38,6 +38,7 @@ type appState struct {
 	wsCancel         context.CancelFunc
 	wsConnected      bool
 	wsScheme         string
+	useRemote        bool
 	wsHost           string
 	wsPort           string
 	captureItems     []optionItem
@@ -236,6 +237,37 @@ func main() {
 	})
 	schemeSelect.SetSelected(state.wsScheme)
 	schemeSelect.Resize(fyne.NewSize(90, 34))
+
+	// Where the engine runs. "Local" drives the engine inside this binary
+	// through CGo and opens no socket at all; "Remote" reaches a Mercury on
+	// another machine over the websocket, using the fields beside it. The
+	// fields stay visible either way so it is obvious what Remote would use,
+	// but they are only editable when they apply.
+	setRemoteFieldsEnabled := func(enabled bool) {
+		if enabled {
+			hostEntry.Enable()
+			portEntry.Enable()
+			schemeSelect.Enable()
+			return
+		}
+		hostEntry.Disable()
+		portEntry.Disable()
+		schemeSelect.Disable()
+	}
+
+	engineSelect := widget.NewSelect([]string{"Local", "Remote"}, func(selected string) {
+		state.useRemote = selected == "Remote"
+		setRemoteFieldsEnabled(state.useRemote)
+	})
+	engineSelect.Resize(fyne.NewSize(110, 34))
+	// Default to the embedded engine when this build has one; without it the
+	// only way to reach a Mercury is over the network, so Remote is the honest
+	// default and the fields must stay usable.
+	if _, err := newEngineLink().probe(); err == nil {
+		engineSelect.SetSelected("Local")
+	} else {
+		engineSelect.SetSelected("Remote")
+	}
 
 	logBox := widget.NewMultiLineEntry()
 	logBox.SetMinRowsVisible(8)
@@ -523,7 +555,7 @@ func main() {
 			connectionButtonState = "connect"
 			updateConnectionButton()
 		})
-		setWSStatus("WebSocket: disconnected")
+		setWSStatus("Engine: disconnected")
 		if reason != "" {
 			appendLog(reason + "\n")
 		}
@@ -533,7 +565,7 @@ func main() {
 		state.mu.Lock()
 		if state.wsConnected && state.link != nil {
 			state.mu.Unlock()
-			appendLog("WebSocket already connected.\n")
+			appendLog("Engine already connected.\n")
 			return
 		}
 		oldCancel := state.wsCancel
@@ -553,14 +585,14 @@ func main() {
 			hostEntry.SetText(state.wsHost)
 			portEntry.SetText(state.wsPort)
 		})
-		setWSStatus("WebSocket: connecting")
+		setWSStatus("Engine: connecting")
 		appendLog(fmt.Sprintf("Connecting to WebSocket at %s://%s:%s/websocket...\n", state.wsScheme, state.wsHost, state.wsPort))
 
 		go func() {
 			// Pick the transport: the engine linked into this binary when we
 			// have one and no remote host was given, otherwise the websocket.
 			// Everything below this point is transport-agnostic — see link.go.
-			link, err := openLink(state.wsHost, state.wsPort, state.wsScheme)
+			link, err := openLink(state.useRemote, state.wsHost, state.wsPort, state.wsScheme)
 			if err != nil {
 				runOnUI(func() {
 					connectionButtonState = "connect"
@@ -749,6 +781,7 @@ func main() {
 	topBar := container.NewHBox()
 
 	connectionCard := widget.NewCard("", "", container.NewHBox(
+		container.NewVBox(widget.NewLabel("Engine"), engineSelect),
 		container.NewVBox(widget.NewLabel("Host"), hostEntryBox),
 		container.NewVBox(widget.NewLabel("Port"), portEntryBox),
 		container.NewVBox(widget.NewLabel("Scheme"), schemeSelect),

--- a/gui_interface/fyne-ui/main.go
+++ b/gui_interface/fyne-ui/main.go
@@ -238,6 +238,16 @@ func main() {
 	schemeSelect.SetSelected(state.wsScheme)
 	schemeSelect.Resize(fyne.NewSize(90, 34))
 
+	// Declared here because the Engine selector below drives them, while they
+	// are built further down with the rest of the UI.
+	var (
+		connectionButtonState  = "connect"
+		connectButton          *widget.Button
+		updateConnectionButton func()
+		connectLink            func()
+		disconnectLink         func(reason string)
+	)
+
 	// Where the engine runs. "Local" drives the engine inside this binary
 	// through CGo and opens no socket at all; "Remote" reaches a Mercury on
 	// another machine over the websocket, using the fields beside it. The
@@ -256,18 +266,38 @@ func main() {
 	}
 
 	engineSelect := widget.NewSelect([]string{"Local", "Remote"}, func(selected string) {
+		wasRemote := state.useRemote
 		state.useRemote = selected == "Remote"
 		setRemoteFieldsEnabled(state.useRemote)
+
+		// SetSelected() fires this during construction, before the link
+		// helpers further down exist — hence the nil checks.
+		if state.useRemote {
+			// Leaving Local: drop the in-process link, then wait for the
+			// operator to dial the remote one.
+			if !wasRemote && disconnectLink != nil {
+				disconnectLink("Switched to a remote engine.")
+			}
+			connectionButtonState = "connect"
+			if updateConnectionButton != nil {
+				updateConnectionButton()
+			}
+			return
+		}
+
+		// Entering Local: the engine is right here, so attach to it rather
+		// than making the operator press a button to reach their own modem.
+		if wasRemote && disconnectLink != nil {
+			disconnectLink("Switched to the local engine.")
+		}
+		if updateConnectionButton != nil {
+			updateConnectionButton()
+		}
+		if connectLink != nil {
+			connectLink()
+		}
 	})
 	engineSelect.Resize(fyne.NewSize(110, 34))
-	// Default to the embedded engine when this build has one; without it the
-	// only way to reach a Mercury is over the network, so Remote is the honest
-	// default and the fields must stay usable.
-	if _, err := newEngineLink().probe(); err == nil {
-		engineSelect.SetSelected("Local")
-	} else {
-		engineSelect.SetSelected("Remote")
-	}
 
 	logBox := widget.NewMultiLineEntry()
 	logBox.SetMinRowsVisible(8)
@@ -519,12 +549,19 @@ func main() {
 		}
 	}
 
-	var connectionButtonState = "connect"
-	var connectButton *widget.Button
-	updateConnectionButton := func() {
+	updateConnectionButton = func() {
 		if connectButton == nil {
 			return
 		}
+		// In Local mode there is nothing to dial: the engine is already
+		// running inside this process, started before the window opened, and
+		// "Disconnect" would only blind the UI while the modem carried on
+		// transmitting. The button belongs to the remote session.
+		if !state.useRemote {
+			connectButton.Hide()
+			return
+		}
+		connectButton.Show()
 		switch connectionButtonState {
 		case "connecting":
 			connectButton.SetText("Connecting")
@@ -535,7 +572,7 @@ func main() {
 		}
 	}
 
-	disconnectWS := func(reason string) {
+	disconnectLink = func(reason string) {
 		// Grab the connection handles under the lock, clear the shared state,
 		// then Close()/cancel() outside the lock (no network calls held).
 		state.mu.Lock()
@@ -561,7 +598,7 @@ func main() {
 		}
 	}
 
-	connectWS := func() {
+	connectLink = func() {
 		state.mu.Lock()
 		if state.wsConnected && state.link != nil {
 			state.mu.Unlock()
@@ -683,7 +720,7 @@ func main() {
 
 				case LinkStateEvent:
 					if !e.Up {
-						disconnectWS(e.Detail)
+						disconnectLink(e.Detail)
 						return
 					}
 					appendLog(e.Detail + "\n")
@@ -693,7 +730,7 @@ func main() {
 				}
 			}
 
-			disconnectWS("Link closed.")
+			disconnectLink("Link closed.")
 		}()
 	}
 
@@ -715,7 +752,7 @@ func main() {
 		case "connecting":
 			return
 		case "disconnect":
-			disconnectWS("Disconnect requested by user.")
+			disconnectLink("Disconnect requested by user.")
 			connectionButtonState = "connect"
 			updateConnectionButton()
 		default:
@@ -729,7 +766,7 @@ func main() {
 			}
 			connectionButtonState = "connecting"
 			updateConnectionButton()
-			connectWS()
+			connectLink()
 		}
 	})
 
@@ -950,6 +987,15 @@ func main() {
 		shutdown()
 	}()
 
+	// Pick the starting mode now that the link helpers exist. Local when this
+	// build carries an engine; otherwise the network is the only way to reach
+	// one, so Remote is the honest default and its fields stay usable.
+	if _, err := newEngineLink().probe(); err == nil {
+		engineSelect.SetSelected("Local")
+	} else {
+		engineSelect.SetSelected("Remote")
+	}
+
 	go func() {
 		time.Sleep(200 * time.Millisecond)
 
@@ -963,7 +1009,7 @@ func main() {
 			return
 		}
 		appendLog("Mercury engine started — connecting...\n")
-		connectWS()
+		connectLink()
 	}()
 
 	myWindow.ShowAndRun()

--- a/gui_interface/fyne-ui/main.go
+++ b/gui_interface/fyne-ui/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -10,13 +9,11 @@ import (
 	"image/color"
 	"math"
 	"net"
-	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -29,7 +26,6 @@ import (
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/widget"
-	"github.com/gorilla/websocket"
 )
 
 type appState struct {
@@ -37,7 +33,7 @@ type appState struct {
 	// (writer) and the Fyne render/UI goroutines (readers): the connection
 	// state and the spectrum/waterfall buffers drawn by the canvas rasters.
 	mu               sync.RWMutex
-	wsConn           *websocket.Conn
+	link             Link
 	wsContext        context.Context
 	wsCancel         context.CancelFunc
 	wsConnected      bool
@@ -511,14 +507,14 @@ func main() {
 		// Grab the connection handles under the lock, clear the shared state,
 		// then Close()/cancel() outside the lock (no network calls held).
 		state.mu.Lock()
-		conn := state.wsConn
+		link := state.link
 		cancel := state.wsCancel
-		state.wsConn = nil
+		state.link = nil
 		state.wsCancel = nil
 		state.wsConnected = false
 		state.mu.Unlock()
-		if conn != nil {
-			_ = conn.Close()
+		if link != nil {
+			link.Close()
 		}
 		if cancel != nil {
 			cancel()
@@ -535,21 +531,21 @@ func main() {
 
 	connectWS := func() {
 		state.mu.Lock()
-		if state.wsConnected && state.wsConn != nil {
+		if state.wsConnected && state.link != nil {
 			state.mu.Unlock()
 			appendLog("WebSocket already connected.\n")
 			return
 		}
 		oldCancel := state.wsCancel
-		oldConn := state.wsConn
-		state.wsConn = nil
+		oldLink := state.link
+		state.link = nil
 		state.wsContext, state.wsCancel = context.WithCancel(context.Background())
 		state.mu.Unlock()
 		if oldCancel != nil {
 			oldCancel()
 		}
-		if oldConn != nil {
-			_ = oldConn.Close()
+		if oldLink != nil {
+			oldLink.Close()
 		}
 		state.wsHost = hostEntry.Text
 		state.wsPort = portEntry.Text
@@ -561,160 +557,125 @@ func main() {
 		appendLog(fmt.Sprintf("Connecting to WebSocket at %s://%s:%s/websocket...\n", state.wsScheme, state.wsHost, state.wsPort))
 
 		go func() {
-			var schemes []string
-			if state.wsScheme == "wss" {
-				schemes = []string{"wss", "ws"}
-			} else {
-				schemes = []string{"ws", "wss"}
-			}
-			var conn *websocket.Conn
-			var err error
-			for _, scheme := range schemes {
-				wsURL := buildWebSocketURL(scheme, state.wsHost, state.wsPort)
-				dialer := &websocket.Dialer{
-					Proxy:            http.ProxyFromEnvironment,
-					HandshakeTimeout: 5 * time.Second,
-					TLSClientConfig:  &tls.Config{InsecureSkipVerify: true},
-				}
-				conn, _, err = dialer.Dial(wsURL, nil)
-				if err == nil {
-					state.wsScheme = scheme
-					break
-				}
-			}
+			// Pick the transport: the engine linked into this binary when we
+			// have one and no remote host was given, otherwise the websocket.
+			// Everything below this point is transport-agnostic — see link.go.
+			link, err := openLink(state.wsHost, state.wsPort, state.wsScheme)
 			if err != nil {
 				runOnUI(func() {
 					connectionButtonState = "connect"
 					updateConnectionButton()
 				})
-				setWSStatus("WebSocket: disconnected")
-				appendLog(fmt.Sprintf("WebSocket connection failed: %v\n", err))
+				setWSStatus("Engine: disconnected")
+				appendLog(fmt.Sprintf("Link failed: %v\n", err))
 				return
 			}
 
 			state.mu.Lock()
-			state.wsConn = conn
+			state.link = link
 			state.wsConnected = true
 			ctx := state.wsContext
 			state.mu.Unlock()
+
+			events, err := link.Start(ctx)
+			if err != nil {
+				link.Close()
+				state.mu.Lock()
+				state.link = nil
+				state.wsConnected = false
+				state.mu.Unlock()
+				runOnUI(func() {
+					connectionButtonState = "connect"
+					updateConnectionButton()
+				})
+				setWSStatus("Engine: disconnected")
+				appendLog(fmt.Sprintf("Link failed: %v\n", err))
+				return
+			}
+
 			runOnUI(func() {
 				connectionButtonState = "disconnect"
 				updateConnectionButton()
 			})
-			setWSStatus("WebSocket: connected")
-			appendLog("Connected to Mercury WebSocket successfully!\n")
+			setWSStatus("Engine: " + link.Name())
+			appendLog("Connected to " + link.Name() + "\n")
 
-			go func() {
-				<-ctx.Done()
-				_ = conn.Close()
-			}()
+			for ev := range events {
+				switch e := ev.(type) {
+				case StatusEvent:
+					applyStatus(e.Status)
 
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				default:
-					messageType, payload, readErr := conn.ReadMessage()
-					if readErr != nil {
-						disconnectWS(fmt.Sprintf("WebSocket read error: %v", readErr))
+				case SpectrumEvent:
+					// Keep a copy: the waterfall holds rows well past this frame.
+					row := make([]float32, len(e.Bins))
+					copy(row, e.Bins)
+					const maxWaterfallRows = 800
+					state.mu.Lock()
+					state.spectrumValues = e.Bins
+					state.spectrumRate = e.SampleRate
+					state.waterfallRows = append(state.waterfallRows, row)
+					if len(state.waterfallRows) > maxWaterfallRows {
+						state.waterfallRows = state.waterfallRows[len(state.waterfallRows)-maxWaterfallRows:]
+					}
+					state.mu.Unlock()
+					refreshSpectrum()
+
+				case DeviceListEvent:
+					switch e.Kind {
+					case DeviceCapture:
+						state.captureItems = e.Items
+						state.captureSelected = e.Selected
+						refreshSelect(bindings.captureSelect, e.Items, e.Selected, true)
+					case DevicePlayback:
+						state.playbackItems = e.Items
+						state.playbackSelected = e.Selected
+						refreshSelect(bindings.playbackSelect, e.Items, e.Selected, true)
+					case DeviceInputChannel:
+						refreshSelect(bindings.channelSelect, e.Items, e.Selected, false)
+					}
+
+				case RadioListEvent:
+					state.radioItems = e.Items
+					state.radioSelected = e.Selected
+					state.radioDevicePath = e.DevicePath
+					state.radioSerialSpeed = e.SerialSpeed
+					runOnUI(func() {
+						if e.DevicePath != "" {
+							bindings.devicePathEntry.SetText(e.DevicePath)
+						}
+						if e.SerialSpeed != "" {
+							bindings.serialSpeedEntry.SetSelected(e.SerialSpeed)
+						}
+					})
+					refreshSelect(bindings.radioSelect, e.Items, e.Selected, false)
+
+				case LinkStateEvent:
+					if !e.Up {
+						disconnectWS(e.Detail)
 						return
 					}
-					switch messageType {
-					case websocket.TextMessage:
-						var raw map[string]any
-						if err := json.Unmarshal(payload, &raw); err != nil {
-							appendLog(fmt.Sprintf("[Raw WS Msg]: %s\n", string(payload)))
-							continue
-						}
-						switch raw["type"] {
-						case "status":
-							status, parseErr := parseStatusMessage(payload)
-							if parseErr != nil {
-								appendLog(fmt.Sprintf("Failed to parse status: %v\n", parseErr))
-								continue
-							}
-							applyStatus(status)
-						case "capture_dev_list":
-							items := parseMenuItems(payload)
-							state.captureItems = items
-							state.captureSelected = selectedValue(raw, "selected")
-							refreshSelect(bindings.captureSelect, items, state.captureSelected, true)
-						case "playback_dev_list":
-							items := parseMenuItems(payload)
-							state.playbackItems = items
-							state.playbackSelected = selectedValue(raw, "selected")
-							refreshSelect(bindings.playbackSelect, items, state.playbackSelected, true)
-						case "input_channel":
-							items := parseChannelItems(payload)
-							refreshSelect(bindings.channelSelect, items, selectedValue(raw, "selected"), false)
-						case "radio_list":
-							items := parseMenuItems(payload)
-							sort.Slice(items, func(i, j int) bool {
-								if items[i].Name == "None" {
-									return true
-								}
-								if items[j].Name == "None" {
-									return false
-								}
-								return strings.ToLower(items[i].Name) < strings.ToLower(items[j].Name)
-							})
-							state.radioItems = items
-							state.radioSelected = selectedValue(raw, "selected")
-							state.radioDevicePath = fmt.Sprint(raw["device_path"])
-							state.radioSerialSpeed = fmt.Sprint(raw["serial_speed"])
-							runOnUI(func() {
-								if state.radioDevicePath != "" {
-									bindings.devicePathEntry.SetText(state.radioDevicePath)
-								}
-								if state.radioSerialSpeed != "" {
-									bindings.serialSpeedEntry.SetSelected(state.radioSerialSpeed)
-								}
-							})
-							refreshSelect(bindings.radioSelect, items, state.radioSelected, false)
-						default:
-							appendLog(fmt.Sprintf("[Raw WS Msg]: %s\n", string(payload)))
-						}
-					case websocket.BinaryMessage:
-						spectrum, sampleRate, parseErr := parseSpectrumFrame(payload)
-						if parseErr != nil {
-							continue
-						}
-						// append a copy of this spectrum to the waterfall buffer
-						row := make([]float32, len(spectrum))
-						copy(row, spectrum)
-						const maxWaterfallRows = 800
-						state.mu.Lock()
-						state.spectrumValues = spectrum
-						state.spectrumRate = sampleRate
-						state.waterfallRows = append(state.waterfallRows, row)
-						if len(state.waterfallRows) > maxWaterfallRows {
-							// drop oldest rows
-							state.waterfallRows = state.waterfallRows[len(state.waterfallRows)-maxWaterfallRows:]
-						}
-						state.mu.Unlock()
-						refreshSpectrum()
-					}
+					appendLog(e.Detail + "\n")
+
+				case LogEvent:
+					appendLog(e.Text)
 				}
 			}
+
+			disconnectWS("Link closed.")
 		}()
 	}
 
+	// One command path for both transports: in-process call or websocket
+	// frame, decided by whichever Link is open.
 	sendWSCommand := func(command string, value string, value2 string, value3 string) error {
 		state.mu.RLock()
-		conn := state.wsConn
+		link := state.link
 		connected := state.wsConnected
 		state.mu.RUnlock()
-		if conn == nil || !connected {
+		if link == nil || !connected {
 			return fmt.Errorf("not connected")
 		}
-		payload := map[string]any{"command": command, "value": value}
-		if value2 != "" {
-			payload["value2"] = value2
-		}
-		if value3 != "" {
-			payload["value3"] = value3
-		}
-		return conn.WriteJSON(payload)
+		return link.Send(Command{Name: command, Value: value, Value2: value2, Value3: value3})
 	}
 
 	connectButton = widget.NewButton("Connect", func() {
@@ -727,7 +688,7 @@ func main() {
 			updateConnectionButton()
 		default:
 			state.mu.RLock()
-			alreadyConnected := state.wsConnected && state.wsConn != nil
+			alreadyConnected := state.wsConnected && state.link != nil
 			state.mu.RUnlock()
 			if alreadyConnected {
 				connectionButtonState = "disconnect"
@@ -924,14 +885,14 @@ func main() {
 					os.Exit(0)
 				}()
 				state.mu.Lock()
-				conn := state.wsConn
+				link := state.link
 				cancel := state.wsCancel
-				state.wsConn = nil
+				state.link = nil
 				state.wsCancel = nil
 				state.wsConnected = false
 				state.mu.Unlock()
-				if conn != nil {
-					_ = conn.Close()
+				if link != nil {
+					link.Close()
 				}
 				if cancel != nil {
 					cancel()

--- a/gui_interface/fyne-ui/mercury.go
+++ b/gui_interface/fyne-ui/mercury.go
@@ -72,6 +72,7 @@ func mercuryStart(defaultConfig, logPath string, args []string) error {
 	if C.mercury_init(C.int(len(args)), argv, cDefault, cLog) != 0 {
 		return fmt.Errorf("mercury engine init failed")
 	}
+	C.mercury_ui_preload_device_lists()
 	return nil
 }
 

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -44,6 +44,7 @@
 #include "../modem/freedv/modem_stats.h"
 #include "../modem/modem.h"
 #include "../radio_io/radio_io.h"  /* RADIO_TYPE_NONE */
+#include "../radio_io/rigctl_parse.h"  /* preload_radio_list */
 
 extern int get_soundcard_list(int audio_system, int mode,
                               char ids[][64], char dev_names[][64], int max_count);
@@ -294,6 +295,13 @@ int ui_comm_get_input_channel(void)
 {
     ui_ctx_t *ctx = g_ui_ctx;
     return ctx ? ctx->rx_input_channel : 0;
+}
+
+void ui_comm_preload_radio_list(void)
+{
+#ifdef HAVE_HAMLIB
+    preload_radio_list();
+#endif
 }
 
 /* Gather everything the UI shows into one typed snapshot.  This is the only

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -511,12 +511,18 @@ void *spectrum_publisher_thread(void *arg)
     HLOGI(UI_LOG_TAG, "Spectrum publisher started - sending spectrum every %d ms via WebSocket",
           SPECTRUM_PUBLISH_INTERVAL_US / 1000);
 
+    uint64_t last_seq = 0;
+
     while (!shutdown_)
     {
         float spec_dB[MODEM_STATS_NSPEC];
-        int sr = modem_get_rx_spectrum(spec_dB, MODEM_STATS_NSPEC);
-        if (sr > 0)
+        uint64_t seq = 0;
+        int sr = modem_get_rx_spectrum_seq(spec_dB, MODEM_STATS_NSPEC, &seq);
+        /* Skip frames already sent: the read no longer consumes, so this
+         * thread and any embedded UI each see every frame. */
+        if (sr > 0 && seq != last_seq)
         {
+            last_seq = seq;
             // Build binary spectrum frame: magic(4) + fft_size(2) + sample_rate(2) + floats
             uint8_t frame[8 + MODEM_STATS_NSPEC * sizeof(float)];
             uint16_t fft_size = (uint16_t)MODEM_STATS_NSPEC;

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -201,6 +201,101 @@ int ui_comm_handle_command(ui_ctx_t *ctx, const ws_command_t *cmd)
 // ---------------- UI PUBLISHER THREAD ----------------
 // Periodically gathers modem/ARQ/network status and sends it to the UI.
 
+/* ---- Device enumeration ----------------------------------------------------
+ * One implementation per list, used by the websocket publisher and by the
+ * embedded UI through the bridge.  The websocket path used to build its JSON
+ * inline from get_soundcard_list(); routing both through here is what keeps a
+ * local UI and a remote one showing the same devices and the same selection. */
+
+int ui_comm_get_audio_devices(ui_device_kind_t kind, ui_device_t *out, int max,
+                              char *selected, size_t sel_len)
+{
+    ui_ctx_t *ctx = g_ui_ctx;
+    if (!ctx || !out || max <= 0)
+        return 0;
+
+    /* get_soundcard_list() takes mode 1 = capture, 0 = playback. */
+    int mode = (kind == UI_DEV_CAPTURE) ? 1 : 0;
+
+    char ids[32][64], names[32][64];
+    int cap = (max < 32) ? max : 32;
+    int count = get_soundcard_list(ctx->audio_system, mode, ids, names, cap);
+    if (count < 0)
+        count = 0;
+
+    for (int i = 0; i < count; i++)
+    {
+        /* Bound the read as well as the write: if a backend ever handed back
+         * an unterminated row, "%s" would run on into the next one. */
+        snprintf(out[i].id,   sizeof(out[i].id),   "%.*s", (int)sizeof(ids[i]) - 1, ids[i]);
+        snprintf(out[i].name, sizeof(out[i].name), "%.*s", (int)sizeof(names[i]) - 1, names[i]);
+    }
+
+    if (selected && sel_len)
+        snprintf(selected, sel_len, "%s",
+                 (kind == UI_DEV_CAPTURE) ? ctx->selected_capture_dev
+                                          : ctx->selected_playback_dev);
+    return count;
+}
+
+int ui_comm_get_radio_list(ui_device_t *out, int max, char *selected, size_t sel_len,
+                           char *device_path, size_t dev_len, int *serial_speed)
+{
+    ui_ctx_t *ctx = g_ui_ctx;
+    if (!ctx || !out || max <= 0)
+        return 0;
+
+    if (selected && sel_len)
+    {
+        int cur_type = radio_io_get_radio_type();
+        if (cur_type > 0)
+            snprintf(selected, sel_len, "%d", cur_type);
+        else
+            selected[0] = '\0';
+    }
+    if (device_path && dev_len)
+    {
+        const char *cur_dev = radio_io_get_device_path();
+        snprintf(device_path, dev_len, "%s", cur_dev ? cur_dev : "");
+    }
+    if (serial_speed)
+        *serial_speed = radio_io_get_serial_speed();
+
+    /* "None" is always first: switching the radio off is a choice, not the
+     * absence of one. */
+    int n = 0;
+    snprintf(out[n].name, sizeof(out[n].name), "None");
+    snprintf(out[n].id,   sizeof(out[n].id),   "%d", RADIO_TYPE_NONE);
+    n++;
+
+    char (*radio_ids)[16]   = malloc(sizeof(*radio_ids)   * 512);
+    char (*radio_names)[64] = malloc(sizeof(*radio_names) * 512);
+    if (!radio_ids || !radio_names)
+    {
+        HLOGE(UI_LOG_TAG, "Failed to allocate radio list arrays");
+        free(radio_ids);
+        free(radio_names);
+        return n;
+    }
+
+    int count = radio_io_get_radio_list(radio_ids, radio_names, 512);
+    for (int i = 0; i < count && n < max; i++, n++)
+    {
+        snprintf(out[n].id,   sizeof(out[n].id),   "%s", radio_ids[i]);
+        snprintf(out[n].name, sizeof(out[n].name), "%s", radio_names[i]);
+    }
+
+    free(radio_ids);
+    free(radio_names);
+    return n;
+}
+
+int ui_comm_get_input_channel(void)
+{
+    ui_ctx_t *ctx = g_ui_ctx;
+    return ctx ? ctx->rx_input_channel : 0;
+}
+
 /* Gather everything the UI shows into one typed snapshot.  This is the only
  * place that reads the engine for status; the websocket JSON and the embedded
  * UI both render THIS struct, so the two views cannot drift apart. */
@@ -329,43 +424,20 @@ void *ui_publisher_thread(void *arg)
         {
             ctx->soundcard_list_pending = 0;
 
-            // Capture (input) devices - mode 1 = FFAUDIO_DEV_CAPTURE
-            char cap_ids[32][64], cap_names[32][64];
-            int cap_count = get_soundcard_list(ctx->audio_system, 1, cap_ids, cap_names, 32);
-            if (cap_count > 0)
-            {
-                char buf[4096];
-                int pos = 0;
-                pos += snprintf(buf + pos, sizeof(buf) - pos,
-                    "{\"type\":\"capture_dev_list\",\"selected\":\"%s\",\"list\":[",
-                    ctx->selected_capture_dev);
-                for (int i = 0; i < cap_count && pos < (int)sizeof(buf) - 160; i++) {
-                    if (i > 0) buf[pos++] = ',';
-                    pos += snprintf(buf + pos, sizeof(buf) - pos,
-                        "{\"name\":\"%s\",\"id\":\"%s\"}", cap_names[i], cap_ids[i]);
-                }
-                pos += snprintf(buf + pos, sizeof(buf) - pos, "]}");
-                ws_broadcast_json(&ctx->ws, buf);
-            }
+            /* Same enumerator the embedded UI calls, rendered as JSON. */
+            ui_device_t devs[32];
+            char sel[64];
+            char buf[8192];
 
-            // Playback (output) devices - mode 0 = FFAUDIO_DEV_PLAYBACK
-            char pb_ids[32][64], pb_names[32][64];
-            int pb_count = get_soundcard_list(ctx->audio_system, 0, pb_ids, pb_names, 32);
-            if (pb_count > 0)
-            {
-                char buf[4096];
-                int pos = 0;
-                pos += snprintf(buf + pos, sizeof(buf) - pos,
-                    "{\"type\":\"playback_dev_list\",\"selected\":\"%s\",\"list\":[",
-                    ctx->selected_playback_dev);
-                for (int i = 0; i < pb_count && pos < (int)sizeof(buf) - 160; i++) {
-                    if (i > 0) buf[pos++] = ',';
-                    pos += snprintf(buf + pos, sizeof(buf) - pos,
-                        "{\"name\":\"%s\",\"id\":\"%s\"}", pb_names[i], pb_ids[i]);
-                }
-                pos += snprintf(buf + pos, sizeof(buf) - pos, "]}");
+            int cap_count = ui_comm_get_audio_devices(UI_DEV_CAPTURE, devs, 32, sel, sizeof(sel));
+            if (cap_count > 0 &&
+                ui_device_list_to_json("capture_dev_list", devs, cap_count, sel, buf, sizeof(buf)) > 0)
                 ws_broadcast_json(&ctx->ws, buf);
-            }
+
+            int pb_count = ui_comm_get_audio_devices(UI_DEV_PLAYBACK, devs, 32, sel, sizeof(sel));
+            if (pb_count > 0 &&
+                ui_device_list_to_json("playback_dev_list", devs, pb_count, sel, buf, sizeof(buf)) > 0)
+                ws_broadcast_json(&ctx->ws, buf);
 
             // Input channel selection
             const char *ch_str;
@@ -385,51 +457,40 @@ void *ui_publisher_thread(void *arg)
         if (ctx->radio_list_pending)
         {
             ctx->radio_list_pending = 0;
-            char (*radio_ids)[16] = malloc(sizeof(*radio_ids) * 512);
-            char (*radio_names)[64] = malloc(sizeof(*radio_names) * 512);
-            if (!radio_ids || !radio_names)
-            {
-                HLOGE(UI_LOG_TAG, "Failed to allocate radio list arrays");
-                free(radio_ids);
-                free(radio_names);
-                continue;
-            }
-            int radio_count = radio_io_get_radio_list(radio_ids, radio_names, 512);
-            if (radio_count > 0)
-            {
-                char sel_buf[16] = "";
-                int cur_type = radio_io_get_radio_type();
-                if (cur_type > 0)
-                    snprintf(sel_buf, sizeof(sel_buf), "%d", cur_type);
-                const char *cur_dev = radio_io_get_device_path();
-                int cur_serial_speed = radio_io_get_serial_speed();
 
-                const size_t buf_size = 65536;
-                char *buf = malloc(buf_size);
-                if (!buf) {
-                    HLOGE(UI_LOG_TAG, "Failed to allocate radio_list buffer");
-                    free(radio_ids);
-                    free(radio_names);
-                    continue;
-                }
-                int pos = 0;
-                pos += snprintf(buf + pos, buf_size - pos,
-                    "{\"type\":\"radio_list\",\"selected\":\"%s\",\"device_path\":\"%s\",\"serial_speed\":%d,\"list\":[",
-                    sel_buf, cur_dev ? cur_dev : "", cur_serial_speed);
-                // First entry always "None"
-                pos += snprintf(buf + pos, buf_size - pos,
-                    "{\"name\":\"None\",\"id\":\"%d\"}", RADIO_TYPE_NONE);
-                for (int i = 0; i < radio_count && pos < (int)buf_size - 128; i++) {
-                    buf[pos++] = ',';
-                    pos += snprintf(buf + pos, buf_size - pos,
-                        "{\"name\":\"%s\",\"id\":\"%s\"}", radio_names[i], radio_ids[i]);
-                }
-                pos += snprintf(buf + pos, buf_size - pos, "]}");
-                ws_broadcast_json(&ctx->ws, buf);
+            /* Same enumerator the embedded UI calls (hamlib's list is long, so
+             * this one is heap-allocated), rendered as JSON. */
+            const int   max_radios = 513;          /* 512 rigs + "None" */
+            ui_device_t *radios = malloc(sizeof(*radios) * max_radios);
+            char        *buf    = malloc(65536);
+            if (!radios || !buf)
+            {
+                HLOGE(UI_LOG_TAG, "Failed to allocate radio list buffers");
+                free(radios);
                 free(buf);
             }
-            free(radio_ids);
-            free(radio_names);
+            else
+            {
+                char sel[16] = "", dev_path[512] = "";
+                int  serial_speed = 0;
+                int  count = ui_comm_get_radio_list(radios, max_radios, sel, sizeof(sel),
+                                                    dev_path, sizeof(dev_path), &serial_speed);
+                if (count > 0)
+                {
+                    /* radio_list carries two fields no other list has, so it
+                     * gets the shared body plus its own preamble. */
+                    int pos = snprintf(buf, 65536,
+                        "{\"type\":\"radio_list\",\"selected\":\"%s\",\"device_path\":\"%s\","
+                        "\"serial_speed\":%d,\"list\":[", sel, dev_path, serial_speed);
+                    for (int i2 = 0; i2 < count && pos < 65536 - 160; i2++)
+                        pos += snprintf(buf + pos, 65536 - pos, "%s{\"name\":\"%s\",\"id\":\"%s\"}",
+                                        i2 ? "," : "", radios[i2].name, radios[i2].id);
+                    pos += snprintf(buf + pos, 65536 - pos, "]}");
+                    ws_broadcast_json(&ctx->ws, buf);
+                }
+                free(radios);
+                free(buf);
+            }
         }
 
         hermes_usleep(UI_PUBLISH_INTERVAL_US);

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -35,6 +35,7 @@
 
 
 #include "ui_communication.h"
+#include "ui_status.h"
 
 #include "../datalink_arq/arq.h"
 #include "../data_interfaces/net.h"
@@ -66,11 +67,31 @@ static void ws_connect_handler(void *user_data)
     }
 }
 
+/* Latest gathered status, published by ui_publisher_thread and read by the
+ * embedded UI across the CGo bridge.  The publisher owns the gathering; the
+ * bridge only ever copies out, so a slow or stopped UI can never hold up the
+ * engine. */
+static pthread_mutex_t g_status_lock = PTHREAD_MUTEX_INITIALIZER;
+static ui_status_t     g_status;
+static bool            g_status_valid = false;
+
+/* The running UI context, so the CGo bridge can route commands through the
+ * same handler the websocket uses.  Set by ui_comm_init(), cleared by
+ * ui_comm_shutdown(). */
+static ui_ctx_t       *g_ui_ctx = NULL;
+
 // ---------------- WS COMMAND CALLBACK ----------------
 // Called by the websocket server thread when a command JSON arrives from UI.
 static int ws_command_handler(const ws_command_t *cmd, void *user_data)
 {
-    ui_ctx_t *ctx = (ui_ctx_t *)user_data;
+    return ui_comm_handle_command((ui_ctx_t *)user_data, cmd);
+}
+
+/* Every UI command lands here, whether it arrived as websocket JSON from a
+ * remote client or as a direct call from the embedded UI.  One implementation
+ * means local and remote cannot diverge in behaviour. */
+int ui_comm_handle_command(ui_ctx_t *ctx, const ws_command_t *cmd)
+{
     if (!ctx || !cmd)
         return -1;
 
@@ -180,6 +201,66 @@ static int ws_command_handler(const ws_command_t *cmd, void *user_data)
 // ---------------- UI PUBLISHER THREAD ----------------
 // Periodically gathers modem/ARQ/network status and sends it to the UI.
 
+/* Gather everything the UI shows into one typed snapshot.  This is the only
+ * place that reads the engine for status; the websocket JSON and the embedded
+ * UI both render THIS struct, so the two views cannot drift apart. */
+static void ui_gather_status(ui_ctx_t *ctx, ui_status_t *out)
+{
+    memset(out, 0, sizeof(*out));
+
+    arq_runtime_snapshot_t snap;
+    int have_snap = arq_get_runtime_snapshot(&snap);
+
+    char my_call[CALLSIGN_MAX_SIZE], src_call[CALLSIGN_MAX_SIZE], dst_call[CALLSIGN_MAX_SIZE];
+    arq_conn_get_calls(my_call, src_call, dst_call, CALLSIGN_MAX_SIZE);
+
+    /* src_addr/dst_addr follow the TNC convention (initiator/target):
+     *   ISS (caller):   src = self,   dst = remote
+     *   IRS (receiver): src = remote, dst = self
+     * The peer is whichever is not us. */
+    const char *dest_call = (dst_call[0] != '\0' && strcmp(dst_call, my_call) != 0)
+                            ? dst_call : src_call;
+
+    snprintf(out->user_callsign, sizeof(out->user_callsign), "%s", my_call);
+    snprintf(out->dest_callsign, sizeof(out->dest_callsign), "%s", dest_call);
+
+    out->bitrate_bps = (int)tnc_get_last_bitrate_bps();
+    out->snr_db      = (double)tnc_get_last_snr();
+
+    if (have_snap && snap.initialized)
+    {
+        out->transmitting      = (snap.trx == 1);
+        out->sync              = snap.connected ? true : false;
+        out->bytes_transmitted = (long)snap.tx_bytes;
+        out->bytes_received    = (long)snap.rx_bytes;
+    }
+
+    int ctl_status  = net_get_status(CTL_TCP_PORT);
+    int data_status = net_get_status(DATA_TCP_PORT);
+    out->client_tcp_connected =
+        (ctl_status == NET_CONNECTED || data_status == NET_CONNECTED);
+
+    float tx_gain_linear = modem_get_tx_gain();
+    out->tx_gain_db   = (tx_gain_linear > 0.0f) ? 20.0f * log10f(tx_gain_linear) : -120.0f;
+    out->tx_peak_dbfs = modem_get_tx_peak_dbfs();
+
+    out->waterfall_enabled = ctx->waterfall_enabled ? true : false;
+}
+
+/* Copy the latest gathered status out for the embedded UI.  Returns false
+ * until the publisher has produced its first snapshot. */
+bool ui_comm_get_status(ui_status_t *out)
+{
+    if (!out)
+        return false;
+    pthread_mutex_lock(&g_status_lock);
+    bool ok = g_status_valid;
+    if (ok)
+        *out = g_status;
+    pthread_mutex_unlock(&g_status_lock);
+    return ok;
+}
+
 void *ui_publisher_thread(void *arg)
 {
     ui_ctx_t *ctx = (ui_ctx_t *)arg;
@@ -189,43 +270,25 @@ void *ui_publisher_thread(void *arg)
 
     while (!shutdown_)
     {
-        // --- Gather status from ARQ snapshot ---
-        arq_runtime_snapshot_t snap;
-        int have_snap = arq_get_runtime_snapshot(&snap);
+        /* One gather, published two ways: struct to the embedded UI, JSON to
+         * remote clients. */
+        ui_status_t st;
+        ui_gather_status(ctx, &st);
 
-        int bitrate = (int)tnc_get_last_bitrate_bps();
-        double snr = (double)tnc_get_last_snr();
-        char my_call[CALLSIGN_MAX_SIZE], src_call[CALLSIGN_MAX_SIZE], dst_call[CALLSIGN_MAX_SIZE];
-        arq_conn_get_calls(my_call, src_call, dst_call, CALLSIGN_MAX_SIZE);
-        const char *user_call = my_call;
-        /* Determine remote peer for UI display.
-         * src_addr/dst_addr follow TNC convention (initiator/target):
-         *   ISS (caller):   src_addr = self,   dst_addr = remote
-         *   IRS (receiver): src_addr = remote,  dst_addr = self
-         * Pick whichever is NOT our own callsign. */
-        const char *dest_call;
-        if (dst_call[0] != '\0' && strcmp(dst_call, my_call) != 0)
-            dest_call = dst_call;   /* ISS: dst is remote */
-        else
-            dest_call = src_call;   /* IRS: src is remote */
-        int sync = 0;
-        modem_direction_t dir = DIR_RX;
-        int tcp_connected = 0;
-        long bytes_tx = 0;
-        long bytes_rx = 0;
+        pthread_mutex_lock(&g_status_lock);
+        g_status       = st;
+        g_status_valid = true;
+        pthread_mutex_unlock(&g_status_lock);
 
-        if (have_snap && snap.initialized)
-        {
-            dir = (snap.trx == 1) ? DIR_TX : DIR_RX;
-            sync = snap.connected ? 1 : 0;
-            bytes_tx = (long)snap.tx_bytes;
-            bytes_rx = (long)snap.rx_bytes;
-        }
-
-        // --- Check TCP client connected status ---
-        int ctl_status = net_get_status(CTL_TCP_PORT);
-        int data_status = net_get_status(DATA_TCP_PORT);
-        tcp_connected = (ctl_status == NET_CONNECTED || data_status == NET_CONNECTED) ? 1 : 0;
+        int    bitrate       = st.bitrate_bps;
+        double snr           = st.snr_db;
+        int    sync          = st.sync ? 1 : 0;
+        modem_direction_t dir = st.transmitting ? DIR_TX : DIR_RX;
+        int    tcp_connected = st.client_tcp_connected ? 1 : 0;
+        long   bytes_tx      = st.bytes_transmitted;
+        long   bytes_rx      = st.bytes_received;
+        const char *user_call = st.user_callsign;
+        const char *dest_call = st.dest_callsign;
 
         // --- Log only if something meaningful changed ---
         if (bitrate != ctx->last_sent_status.bitrate ||
@@ -254,40 +317,11 @@ void *ui_publisher_thread(void *arg)
             if (dest_call) strncpy(ctx->last_sent_status.dest_callsign, dest_call, sizeof(ctx->last_sent_status.dest_callsign)-1);
         }
 
-        // --- Build and broadcast status JSON via WebSocket ---
+        // --- Render the same snapshot as JSON for remote clients ---
         {
-            float tx_gain_linear = modem_get_tx_gain();
-            float tx_gain_db = (tx_gain_linear > 0.0f)
-                                ? 20.0f * log10f(tx_gain_linear)
-                                : -120.0f;
-            float tx_peak_dbfs = modem_get_tx_peak_dbfs();
             char buf[4096];
-            int pos = 0;
-            pos += snprintf(buf + pos, sizeof(buf) - pos,
-                "{\"type\":\"status\","
-                "\"bitrate\":%d,"
-                "\"snr\":%.1f,"
-                "\"user_callsign\":\"%s\","
-                "\"dest_callsign\":\"%s\","
-                "\"sync\":%s,"
-                "\"direction\":\"%s\","
-                "\"client_tcp_connected\":%s,"
-                "\"bytes_transmitted\":%ld,"
-                "\"bytes_received\":%ld,"
-                "\"tx_gain_db\":%.1f,"
-                "\"tx_peak_dbfs\":%.1f,"
-                "\"waterfall\":%s}",
-                bitrate, snr,
-                user_call ? user_call : "",
-                dest_call ? dest_call : "",
-                sync ? "true" : "false",
-                dir == DIR_TX ? "tx" : "rx",
-                tcp_connected ? "true" : "false",
-                bytes_tx, bytes_rx,
-                tx_gain_db, tx_peak_dbfs,
-                ctx->waterfall_enabled ? "true" : "false");
-
-            ws_broadcast_json(&ctx->ws, buf);
+            if (ui_status_to_json(&st, buf, sizeof(buf)) > 0)
+                ws_broadcast_json(&ctx->ws, buf);
         }
 
         // --- Send capture/playback device lists and input channel when a new UI client connects ---
@@ -458,6 +492,25 @@ void *spectrum_publisher_thread(void *arg)
     return NULL;
 }
 
+/* Command entry point for the embedded UI: builds the same ws_command_t the
+ * websocket path builds, then runs the shared handler. */
+int ui_comm_command(const char *command, const char *value,
+                    const char *value2, const char *value3)
+{
+    ui_ctx_t *ctx = g_ui_ctx;
+    if (!ctx || !command)
+        return -1;
+
+    ws_command_t cmd;
+    memset(&cmd, 0, sizeof(cmd));
+    snprintf(cmd.command, sizeof(cmd.command), "%s", command);
+    if (value)  snprintf(cmd.value,  sizeof(cmd.value),  "%s", value);
+    if (value2) snprintf(cmd.value2, sizeof(cmd.value2), "%s", value2);
+    if (value3) snprintf(cmd.value3, sizeof(cmd.value3), "%s", value3);
+
+    return ui_comm_handle_command(ctx, &cmd);
+}
+
 // ---------------- HIGH-LEVEL INIT / SHUTDOWN ----------------
 
 int ui_comm_init(ui_ctx_t *ctx, uint16_t ws_port, bool tls_enabled,
@@ -466,6 +519,8 @@ int ui_comm_init(ui_ctx_t *ctx, uint16_t ws_port, bool tls_enabled,
                  int rx_input_channel,
                  const mercury_config *initial_cfg, const char *cfg_path)
 {
+    g_ui_ctx = ctx;
+
     memset(ctx, 0, sizeof(*ctx));
 
     ctx->waterfall_enabled = waterfall_enabled;
@@ -537,6 +592,8 @@ int ui_comm_init(ui_ctx_t *ctx, uint16_t ws_port, bool tls_enabled,
 
 void ui_comm_shutdown(ui_ctx_t *ctx)
 {
+    g_ui_ctx = NULL;
+
     // Threads check shutdown_ flag and will exit on their own.
     // Shut down the WebSocket server.
     ws_shutdown(&ctx->ws);

--- a/gui_interface/ui_communication.h
+++ b/gui_interface/ui_communication.h
@@ -29,6 +29,7 @@
 
 #include "websocket/mercury_websocket.h"
 #include "cfg_utils.h"
+#include "ui_status.h"
 
 // ---- Default ports for UI <-> backend communication ----
 // WebSocket server port = UI_DEFAULT_PORT (single bidirectional channel)
@@ -111,5 +112,22 @@ int ui_comm_init(ui_ctx_t *ctx, uint16_t ws_port, bool tls_enabled,
                  int rx_input_channel,
                  const mercury_config *initial_cfg, const char *cfg_path);
 void ui_comm_shutdown(ui_ctx_t *ctx);
+
+/* ---- Local (in-process) UI access -----------------------------------------
+ * The embedded Fyne UI drives the engine through these instead of opening a
+ * websocket to itself.  Remote clients keep using the websocket; both end up
+ * in the same gatherer and the same command handler. */
+
+/* Handle one UI command.  Shared by the websocket callback and the CGo bridge
+ * so local and remote behave identically. */
+int  ui_comm_handle_command(ui_ctx_t *ctx, const ws_command_t *cmd);
+
+/* Same, addressed to the running engine (no ctx to hand around from Go).
+ * Returns -1 if no UI context is running. */
+int  ui_comm_command(const char *command, const char *value,
+                     const char *value2, const char *value3);
+
+/* Copy the most recent status snapshot.  False until the first publish. */
+bool ui_comm_get_status(ui_status_t *out);
 
 #endif

--- a/gui_interface/ui_communication.h
+++ b/gui_interface/ui_communication.h
@@ -143,4 +143,9 @@ int  ui_comm_get_radio_list(ui_device_t *out, int max, char *selected, size_t se
 /* Current RX input channel: 0 = left, 1 = right, 2 = stereo. */
 int  ui_comm_get_input_channel(void);
 
+/* Pre-load the radio model list from the main thread.  The embedded UI calls
+ * this during mercury_init() so hamlib backend loading happens on a regular
+ * POSIX thread, not a CGo goroutine. */
+void ui_comm_preload_radio_list(void);
+
 #endif

--- a/gui_interface/ui_communication.h
+++ b/gui_interface/ui_communication.h
@@ -130,4 +130,17 @@ int  ui_comm_command(const char *command, const char *value,
 /* Copy the most recent status snapshot.  False until the first publish. */
 bool ui_comm_get_status(ui_status_t *out);
 
+/* Enumerate audio devices of one kind.  Returns how many were written and, if
+ * `selected` is non-NULL, the id currently in use. */
+int  ui_comm_get_audio_devices(ui_device_kind_t kind, ui_device_t *out, int max,
+                               char *selected, size_t sel_len);
+
+/* Enumerate radios ("None" first), plus the current selection, device path and
+ * serial speed.  Returns how many entries were written. */
+int  ui_comm_get_radio_list(ui_device_t *out, int max, char *selected, size_t sel_len,
+                            char *device_path, size_t dev_len, int *serial_speed);
+
+/* Current RX input channel: 0 = left, 1 = right, 2 = stereo. */
+int  ui_comm_get_input_channel(void);
+
 #endif

--- a/gui_interface/ui_status.c
+++ b/gui_interface/ui_status.c
@@ -1,0 +1,49 @@
+/* HERMES Modem — UI status rendering
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <stdio.h>
+
+#include "ui_status.h"
+
+int ui_status_to_json(const ui_status_t *st, char *buf, size_t buflen)
+{
+    if (!st || !buf || buflen == 0)
+        return -1;
+
+    /* Field order and formatting are the established wire format — remote
+     * clients parse this. Keep it byte-for-byte stable; test_ui_status.c
+     * fails if it drifts. */
+    int n = snprintf(buf, buflen,
+        "{\"type\":\"status\","
+        "\"bitrate\":%d,"
+        "\"snr\":%.1f,"
+        "\"user_callsign\":\"%s\","
+        "\"dest_callsign\":\"%s\","
+        "\"sync\":%s,"
+        "\"direction\":\"%s\","
+        "\"client_tcp_connected\":%s,"
+        "\"bytes_transmitted\":%ld,"
+        "\"bytes_received\":%ld,"
+        "\"tx_gain_db\":%.1f,"
+        "\"tx_peak_dbfs\":%.1f,"
+        "\"waterfall\":%s}",
+        st->bitrate_bps,
+        st->snr_db,
+        st->user_callsign,
+        st->dest_callsign,
+        st->sync ? "true" : "false",
+        st->transmitting ? "tx" : "rx",
+        st->client_tcp_connected ? "true" : "false",
+        st->bytes_transmitted,
+        st->bytes_received,
+        (double)st->tx_gain_db,
+        (double)st->tx_peak_dbfs,
+        st->waterfall_enabled ? "true" : "false");
+
+    if (n < 0 || (size_t)n >= buflen)
+        return -1;
+    return n;
+}

--- a/gui_interface/ui_status.c
+++ b/gui_interface/ui_status.c
@@ -47,3 +47,29 @@ int ui_status_to_json(const ui_status_t *st, char *buf, size_t buflen)
         return -1;
     return n;
 }
+
+int ui_device_list_to_json(const char *type_name, const ui_device_t *devs, int count,
+                           const char *selected, char *buf, size_t buflen)
+{
+    if (!type_name || !buf || buflen == 0 || (count > 0 && !devs))
+        return -1;
+
+    int pos = snprintf(buf, buflen, "{\"type\":\"%s\",\"selected\":\"%s\",\"list\":[",
+                       type_name, selected ? selected : "");
+    if (pos < 0 || (size_t)pos >= buflen)
+        return -1;
+
+    for (int i = 0; i < count; i++)
+    {
+        int n = snprintf(buf + pos, buflen - pos, "%s{\"name\":\"%s\",\"id\":\"%s\"}",
+                         i ? "," : "", devs[i].name, devs[i].id);
+        if (n < 0 || (size_t)(pos + n) >= buflen)
+            return -1;   /* truncated JSON is worse than none — see the status path */
+        pos += n;
+    }
+
+    int n = snprintf(buf + pos, buflen - pos, "]}");
+    if (n < 0 || (size_t)(pos + n) >= buflen)
+        return -1;
+    return pos + n;
+}

--- a/gui_interface/ui_status.h
+++ b/gui_interface/ui_status.h
@@ -43,4 +43,29 @@ typedef struct {
  * buffer is too small.  Pure function: no locks, no globals, unit-testable. */
 int ui_status_to_json(const ui_status_t *st, char *buf, size_t buflen);
 
+/* ---- Device enumeration ----------------------------------------------------
+ * Audio and radio choices, in one shape for both consumers: the websocket path
+ * renders them as JSON, the embedded UI copies the array out over CGo.  Same
+ * reason as the status struct — the two must not be able to disagree about
+ * what is on the list or which entry is selected. */
+
+#define UI_DEV_ID_MAX   64
+#define UI_DEV_NAME_MAX 64
+
+typedef struct {
+    char id[UI_DEV_ID_MAX];     /* device id / hamlib model number as text */
+    char name[UI_DEV_NAME_MAX]; /* what the operator sees                  */
+} ui_device_t;
+
+typedef enum {
+    UI_DEV_CAPTURE  = 0,
+    UI_DEV_PLAYBACK = 1,
+} ui_device_kind_t;
+
+/* Render a device list as the JSON a remote client expects.  `type_name` is
+ * the message type ("capture_dev_list", "playback_dev_list", "radio_list").
+ * Returns bytes written, or -1 if the buffer is too small. */
+int ui_device_list_to_json(const char *type_name, const ui_device_t *devs, int count,
+                           const char *selected, char *buf, size_t buflen);
+
 #endif /* UI_STATUS_H */

--- a/gui_interface/ui_status.h
+++ b/gui_interface/ui_status.h
@@ -1,0 +1,46 @@
+/* HERMES Modem — UI status snapshot
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * One typed description of "what the UI shows", filled by a single gatherer in
+ * ui_communication.c and rendered two ways:
+ *
+ *   - the embedded Fyne UI reads the struct directly across the CGo bridge;
+ *   - remote clients (HERMES web UI, mercury-qt) get ui_status_to_json().
+ *
+ * The point of the struct existing is that both paths read the SAME gathered
+ * snapshot, so a field can never mean one thing locally and another remotely.
+ * Adding a field means: add it here, set it in the gatherer, and — if remote
+ * clients need it — render it in ui_status_to_json(), whose exact output is
+ * pinned by tests/gui_interface/test_ui_status.c.
+ */
+#ifndef UI_STATUS_H
+#define UI_STATUS_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "arq.h"   /* CALLSIGN_MAX_SIZE */
+
+typedef struct {
+    int    bitrate_bps;
+    double snr_db;
+    char   user_callsign[CALLSIGN_MAX_SIZE];
+    char   dest_callsign[CALLSIGN_MAX_SIZE];
+    bool   sync;                 /* ARQ session established               */
+    bool   transmitting;         /* PTT asserted (direction tx vs rx)     */
+    bool   client_tcp_connected; /* a host is attached to the TNC ports   */
+    long   bytes_transmitted;
+    long   bytes_received;
+    float  tx_gain_db;
+    float  tx_peak_dbfs;
+    bool   waterfall_enabled;
+} ui_status_t;
+
+/* Render the snapshot as the status JSON remote clients already expect.
+ * Returns the number of bytes written (excluding the NUL), or -1 if the
+ * buffer is too small.  Pure function: no locks, no globals, unit-testable. */
+int ui_status_to_json(const ui_status_t *st, char *buf, size_t buflen);
+
+#endif /* UI_STATUS_H */

--- a/modem/modem.c
+++ b/modem/modem.c
@@ -80,6 +80,11 @@ static float g_rx_spectrum_dB[MODEM_STATS_NSPEC];
 static pthread_mutex_t g_spectrum_lock = PTHREAD_MUTEX_INITIALIZER;
 static int g_spectrum_sample_rate = 8000;
 static bool g_spectrum_valid = false;
+/* Bumped on every new FFT frame.  Readers compare it against what they last
+ * saw, which lets several of them (the websocket publisher, an embedded UI,
+ * both at once) each take every frame exactly once — a destructive read would
+ * have them stealing frames from each other. */
+static uint64_t g_spectrum_seq = 0;
 static struct MODEM_STATS g_spectrum_stats;
 static bool g_spectrum_stats_inited = false;
 
@@ -1960,6 +1965,7 @@ void *rx_thread(void *g_modem)
                 modem_stats_get_rx_spectrum(&g_spectrum_stats, g_rx_spectrum_dB,
                                             rx_fdm, spec_nin);
                 g_spectrum_valid = true;
+                g_spectrum_seq++;
                 /* Determine sample rate from the modem */
                 pthread_mutex_lock(&modem_freedv_lock);
                 if (modem->freedv)
@@ -2044,7 +2050,7 @@ void *rx_thread(void *g_modem)
 }
 
 /* --- Public API: get latest rx spectrum for UI waterfall --- */
-int modem_get_rx_spectrum(float *out_dB, int max_bins)
+int modem_get_rx_spectrum_seq(float *out_dB, int max_bins, uint64_t *seq_out)
 {
     int sr = 0;
         /* Validate output buffer and requested number of bins */
@@ -2065,9 +2071,15 @@ int modem_get_rx_spectrum(float *out_dB, int max_bins)
         {
             memcpy(out_dB, g_rx_spectrum_dB, (size_t)n * sizeof(float));
             sr = g_spectrum_sample_rate;
-            g_spectrum_valid = false;
+            if (seq_out)
+                *seq_out = g_spectrum_seq;
         }
     }
     pthread_mutex_unlock(&g_spectrum_lock);
     return sr;
+}
+
+int modem_get_rx_spectrum(float *out_dB, int max_bins)
+{
+    return modem_get_rx_spectrum_seq(out_dB, max_bins, NULL);
 }

--- a/modem/modem.h
+++ b/modem/modem.h
@@ -61,6 +61,11 @@ void *rx_thread(void *g_modem);
 // Returns the sample rate on success, 0 if no spectrum is available yet.
 int modem_get_rx_spectrum(float *out_dB, int max_bins);
 
+/* Same, plus the frame's sequence number.  Copying is non-destructive, so each
+ * consumer keeps its own last-seen value and skips a frame it already has;
+ * that is how a local UI and a remote one can both run at full rate. */
+int modem_get_rx_spectrum_seq(float *out_dB, int max_bins, uint64_t *seq_out);
+
 /* Enable/disable the RX spectrum FFT (skipped when no UI consumes it). */
 void modem_set_spectrum_enabled(bool enabled);
 

--- a/radio_io/Makefile
+++ b/radio_io/Makefile
@@ -37,8 +37,12 @@ endif
 ifeq ($(HAVE_HAMLIB),1)
 ifeq ($(OS),Windows_NT)
 HAMLIB_CFLAGS_LOCAL = -Ihamlib-w64/include -DHAVE_HAMLIB
-else ifneq ($(wildcard hamlib-macos/lib/libhamlib*.a),)
+else ifeq ($(UNAME_S),Darwin)
+ifneq ($(wildcard hamlib-macos/lib/libhamlib*.a),)
 HAMLIB_CFLAGS_LOCAL = -Ihamlib-macos/include -DHAVE_HAMLIB
+else
+HAMLIB_CFLAGS_LOCAL = $(shell pkg-config --cflags hamlib) -DHAVE_HAMLIB
+endif
 else
 HAMLIB_CFLAGS_LOCAL = $(shell pkg-config --cflags hamlib) -DHAVE_HAMLIB
 endif

--- a/radio_io/rigctl_parse.c
+++ b/radio_io/rigctl_parse.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <pthread.h>
 #include <hamlib/rig.h>
 
 #ifndef _WIN32
@@ -70,13 +71,13 @@ static int collect_model(const struct rig_caps *caps, void *data)
 
     struct mod_entry *e = &g_models[g_count++];
     e->id = caps->rig_model;
-    snprintf(e->mfg_name, sizeof(e->mfg_name), "%s", caps->mfg_name);
-    snprintf(e->model_name, sizeof(e->model_name), "%s", caps->model_name);
-    snprintf(e->version, sizeof(e->version), "%s", caps->version);
-    snprintf(e->macro_name, sizeof(e->macro_name), "%s", caps->macro_name);
+    snprintf(e->mfg_name, sizeof(e->mfg_name), "%s", caps->mfg_name ? caps->mfg_name : "");
+    snprintf(e->model_name, sizeof(e->model_name), "%s", caps->model_name ? caps->model_name : "");
+    snprintf(e->version, sizeof(e->version), "%s", caps->version ? caps->version : "");
+    snprintf(e->macro_name, sizeof(e->macro_name), "%s", caps->macro_name ? caps->macro_name : "");
     snprintf(e->status, sizeof(e->status), "%s", rig_strstatus(caps->status));
 
-    return 1;  /* !=0, we want them all */
+    return 1;
 }
 
 static int cmp_model_id(const void *a, const void *b)
@@ -84,6 +85,74 @@ static int cmp_model_id(const void *a, const void *b)
     const struct mod_entry *ea = a;
     const struct mod_entry *eb = b;
     return (ea->id > eb->id) - (ea->id < eb->id);
+}
+
+static void do_load_backends(void)
+{
+    rig_load_all_backends();
+    int status = rig_list_foreach(collect_model, NULL);
+    if (status != RIG_OK)
+        fprintf(stderr, "rig_list_foreach: error = %s\n", rigerror(status));
+    else
+        qsort(g_models, g_count, sizeof(struct mod_entry), cmp_model_id);
+}
+
+#ifndef _WIN32
+static int redirect_stdio(const char *path)
+{
+    fflush(stdout);
+    fflush(stderr);
+    int saved_stdout = dup(STDOUT_FILENO);
+    int saved_stderr = dup(STDERR_FILENO);
+    int devnull = open(path, O_WRONLY);
+    if (devnull >= 0) {
+        dup2(devnull, STDOUT_FILENO);
+        dup2(devnull, STDERR_FILENO);
+        close(devnull);
+    }
+    return (saved_stdout << 16) | (saved_stderr & 0xffff);
+}
+
+static void restore_stdio(int saved)
+{
+    int saved_stdout = saved >> 16;
+    int saved_stderr = saved & 0xffff;
+    fflush(stdout);
+    fflush(stderr);
+    dup2(saved_stdout, STDOUT_FILENO);
+    dup2(saved_stderr, STDERR_FILENO);
+    close(saved_stdout);
+    close(saved_stderr);
+}
+#else
+static int redirect_stdio(const char *path) { (void)path; return 0; }
+static void restore_stdio(int saved) { (void)saved; }
+#endif
+
+static void *load_thread(void *arg)
+{
+    (void)arg;
+    int saved = redirect_stdio("/dev/null");
+    do_load_backends();
+    restore_stdio(saved);
+    return NULL;
+}
+
+static void ensure_backends_loaded(void)
+{
+    if (g_count > 0)
+        return;
+
+    /* Hammer: use a real POSIX thread (full 8 MiB stack) to load hamlib
+     * backends.  CGo goroutines run on g0's scheduling stack which is too
+     * small for the recursive init calls some backends make. */
+    pthread_t tid;
+    int rc = pthread_create(&tid, NULL, load_thread, NULL);
+    if (rc != 0) {
+        fprintf(stderr, "pthread_create for radio list failed: %d\n", rc);
+        return;
+    }
+    pthread_join(tid, NULL);
 }
 
 void list_models(void)
@@ -146,44 +215,7 @@ void list_models(void)
 
 int get_radio_list(char ids[][16], char names[][64], int max_count)
 {
-    /* Load backends quietly — redirect stdout & stderr to /dev/null
-     * so the hamlib "initrigs4_*" messages don't pollute the console. */
-    if (g_count == 0)
-    {
-#ifndef _WIN32
-        fflush(stdout);
-        fflush(stderr);
-        int saved_stdout = dup(STDOUT_FILENO);
-        int saved_stderr = dup(STDERR_FILENO);
-        int devnull = open("/dev/null", O_WRONLY);
-        if (devnull >= 0)
-        {
-            dup2(devnull, STDOUT_FILENO);
-            dup2(devnull, STDERR_FILENO);
-            close(devnull);
-        }
-#endif
-
-        rig_load_all_backends();
-
-#ifndef _WIN32
-        /* Restore original stdout / stderr */
-        fflush(stdout);
-        fflush(stderr);
-        dup2(saved_stdout, STDOUT_FILENO);
-        dup2(saved_stderr, STDERR_FILENO);
-        close(saved_stdout);
-        close(saved_stderr);
-#endif
-        int status = rig_list_foreach(collect_model, NULL);
-        if (status != RIG_OK)
-        {
-            fprintf(stderr, "rig_list_foreach: error = %s\n", rigerror(status));
-            return 0;
-        }
-
-        qsort(g_models, g_count, sizeof(struct mod_entry), cmp_model_id);
-    }
+    ensure_backends_loaded();
 
     int n = g_count < max_count ? g_count : max_count;
     for (int i = 0; i < n; i++)
@@ -193,6 +225,11 @@ int get_radio_list(char ids[][16], char names[][64], int max_count)
         snprintf(names[i], 64, "%s %s", e->mfg_name, e->model_name);
     }
     return n;
+}
+
+void preload_radio_list(void)
+{
+    ensure_backends_loaded();
 }
 
 #endif /* HAVE_HAMLIB */

--- a/radio_io/rigctl_parse.h
+++ b/radio_io/rigctl_parse.h
@@ -34,6 +34,11 @@ void list_models(void);
  * Returns the number of entries written (up to max_count). */
 int get_radio_list(char ids[][16], char names[][64], int max_count);
 
+/* Force-load backends and build the model cache from the main thread,
+ * before any CGo goroutine touches hamlib.  Safe to call multiple times
+ * (subsequent calls are no-ops). */
+void preload_radio_list(void);
+
 #endif /* HAVE_HAMLIB */
 
 #endif  /* RIGCTL_PARSE_H */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -144,5 +144,9 @@ test_sock_wire: audioio/test_sock_wire.c $(UNITY_SRC)
 test_virtual_clock: common/test_virtual_clock.c $(UNITY_SRC) ../common/virtual_clock.c
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
+# UI status wire format (embedded struct vs remote JSON must not drift)
+test_ui_status: gui_interface/test_ui_status.c $(UNITY_SRC) ../gui_interface/ui_status.c
+	$(CC) $(CFLAGS) -I../gui_interface -I../datalink_arq -I../modem -I../common -o $@ $^ $(LDFLAGS)
+
 clean:
 	rm -f $(TEST_BINS)

--- a/tests/gui_interface/test_ui_status.c
+++ b/tests/gui_interface/test_ui_status.c
@@ -1,0 +1,122 @@
+/* Pins the UI status wire format.
+ *
+ * The embedded UI now reads ui_status_t directly while remote clients (HERMES
+ * web UI, mercury-qt) keep parsing the JSON. Both render the same gathered
+ * snapshot, so the risk worth guarding is the JSON drifting as fields are
+ * added to the struct — a rename or a reordered field silently breaks every
+ * remote client, and nothing else in the build would notice.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <string.h>
+
+#include "unity.h"
+#include "ui_status.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+static ui_status_t sample(void)
+{
+    ui_status_t st;
+    memset(&st, 0, sizeof(st));
+    st.bitrate_bps = 1200;
+    st.snr_db      = 7.25;      /* renders at one decimal */
+    snprintf(st.user_callsign, sizeof(st.user_callsign), "PU2UIT");
+    snprintf(st.dest_callsign, sizeof(st.dest_callsign), "K7EK");
+    st.sync                = true;
+    st.transmitting        = false;
+    st.client_tcp_connected = true;
+    st.bytes_transmitted   = 4096;
+    st.bytes_received      = 128;
+    st.tx_gain_db          = -15.0f;
+    st.tx_peak_dbfs        = -3.5f;
+    st.waterfall_enabled   = true;
+    return st;
+}
+
+/* The exact bytes a remote client receives. */
+void test_status_json_is_byte_exact(void)
+{
+    ui_status_t st = sample();
+    char buf[512];
+    int n = ui_status_to_json(&st, buf, sizeof(buf));
+
+    const char *expect =
+        "{\"type\":\"status\","
+        "\"bitrate\":1200,"
+        "\"snr\":7.2,"
+        "\"user_callsign\":\"PU2UIT\","
+        "\"dest_callsign\":\"K7EK\","
+        "\"sync\":true,"
+        "\"direction\":\"rx\","
+        "\"client_tcp_connected\":true,"
+        "\"bytes_transmitted\":4096,"
+        "\"bytes_received\":128,"
+        "\"tx_gain_db\":-15.0,"
+        "\"tx_peak_dbfs\":-3.5,"
+        "\"waterfall\":true}";
+
+    TEST_ASSERT_EQUAL_STRING(expect, buf);
+    TEST_ASSERT_EQUAL_INT((int)strlen(expect), n);
+}
+
+/* direction is derived from the transmit flag, not carried separately. */
+void test_direction_follows_ptt(void)
+{
+    ui_status_t st = sample();
+    char buf[512];
+
+    st.transmitting = true;
+    TEST_ASSERT_TRUE(ui_status_to_json(&st, buf, sizeof(buf)) > 0);
+    TEST_ASSERT_NOT_NULL(strstr(buf, "\"direction\":\"tx\""));
+
+    st.transmitting = false;
+    TEST_ASSERT_TRUE(ui_status_to_json(&st, buf, sizeof(buf)) > 0);
+    TEST_ASSERT_NOT_NULL(strstr(buf, "\"direction\":\"rx\""));
+}
+
+/* Booleans must render as JSON literals, not 0/1 — clients test them as bools. */
+void test_booleans_render_as_json_literals(void)
+{
+    ui_status_t st = sample();
+    st.sync                 = false;
+    st.client_tcp_connected = false;
+    st.waterfall_enabled    = false;
+
+    char buf[512];
+    TEST_ASSERT_TRUE(ui_status_to_json(&st, buf, sizeof(buf)) > 0);
+    TEST_ASSERT_NOT_NULL(strstr(buf, "\"sync\":false"));
+    TEST_ASSERT_NOT_NULL(strstr(buf, "\"client_tcp_connected\":false"));
+    TEST_ASSERT_NOT_NULL(strstr(buf, "\"waterfall\":false"));
+}
+
+/* A short buffer must fail rather than emit truncated JSON: half a status
+ * object would leave a remote client parsing garbage. */
+void test_truncation_is_reported_not_emitted(void)
+{
+    ui_status_t st = sample();
+    char small[32];
+    TEST_ASSERT_EQUAL_INT(-1, ui_status_to_json(&st, small, sizeof(small)));
+}
+
+void test_null_arguments_are_rejected(void)
+{
+    ui_status_t st = sample();
+    char buf[512];
+    TEST_ASSERT_EQUAL_INT(-1, ui_status_to_json(NULL, buf, sizeof(buf)));
+    TEST_ASSERT_EQUAL_INT(-1, ui_status_to_json(&st, NULL, sizeof(buf)));
+    TEST_ASSERT_EQUAL_INT(-1, ui_status_to_json(&st, buf, 0));
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_status_json_is_byte_exact);
+    RUN_TEST(test_direction_follows_ptt);
+    RUN_TEST(test_booleans_render_as_json_literals);
+    RUN_TEST(test_truncation_is_reported_not_emitted);
+    RUN_TEST(test_null_arguments_are_rejected);
+    return UNITY_END();
+}


### PR DESCRIPTION
The desktop UI already ran the engine in-process, then opened a websocket to `127.0.0.1:10000` and talked to itself over TCP. Now it reads the engine directly, behind an abstraction so the UI code does not know which transport it is on.

## Go: a Link is where the UI gets state and sends commands

```go
type Link interface {
    Name() string
    Start(ctx context.Context) (<-chan Event, error)
    Send(cmd Command) error
    Close()
}
```

Two implementations — `engineLink` (the engine linked into this binary, read across CGo) and `wsLink` (a Mercury elsewhere, or this one when the engine is not built in). Both deliver the same events: status, spectrum, device lists, radio list, link state, log lines.

`openLink()` picks: embedded when available and no remote host is named, websocket otherwise. **Pointing the UI at a Pi at the antenna still works** — that is why the websocket path stays.

`main.go` lost 216 lines of transport handling and no longer imports `gorilla/websocket`, `crypto/tls` or `net/http`; `appState.wsConn` became `link Link`, and the message loop is a type switch over events.

State is **pulled** on a ticker rather than pushed through a callback: the modem's publisher threads must never block in Go code, and the cadence then matches what the UI can draw. Telemetry is dropped rather than queued when the UI lags — a stale spectrum frame is worth less than a responsive engine.

## C: one gather, two renderings

The risk with a typed bridge is two encoders drifting apart, so there is only one reader of the engine per thing:

| | single source | rendered for remote as |
|---|---|---|
| status | `ui_gather_status()` → `ui_status_t` | `ui_status_to_json()` |
| audio devices | `ui_comm_get_audio_devices()` | `ui_device_list_to_json()` |
| radios | `ui_comm_get_radio_list()` | (same, plus its two extra fields) |
| commands | `ui_comm_handle_command()` | — both transports call it |

The publisher used to build that JSON inline from `get_soundcard_list()`; now it renders the enumerator's output. A local UI and a remote one cannot end up offering different devices or disagreeing about which is selected.

## Tests

`test_ui_status` pins the status JSON byte-for-byte. Nothing else in the build would notice it drifting as fields are added to the struct, and every remote client parses it. It passed first run against the format extracted from the old inline `snprintf`, which is the evidence that the refactor did not change what remote clients receive.

Also fixed while moving the audio enumeration: the copy bounded its destination but not its source, so `"%s"` on an unterminated 64-byte row would have run into the next one.

## Verification

Clean C build (only two pre-existing `arq.c` warnings), full suite green, Go builds and vets clean **both** with and without `mercury_embedded`, `make fyne-ui` links the embedded binary.

**Not yet done:** none of this has been exercised against a radio. It compiles and the wire format is pinned, but the embedded UI has not been run live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
