### PR TITLE
arq/fsm: defer LISTEN OFF during grace period after PENDING

### DIFF
--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -156,6 +156,7 @@ static void sess_enter(arq_session_t *sess, arq_conn_state_t new_state,
     sess->state_enter_ms = time_now_ms();
     sess->deadline_ms    = deadline_ms;
     sess->deadline_event = deadline_event;
+    sess->deferred_listen_off = false;  /* stale across state transitions */
     if (new_state != ARQ_CONN_CONNECTED)
     {
         sess->pending_connect_confirm = false;
@@ -1175,6 +1176,14 @@ static void fsm_calling(arq_session_t *sess, const arq_event_t *ev)
         break;
 
     case ARQ_EV_TIMER_RETRY:
+        if (sess->deferred_listen_off &&
+            time_now_ms() - sess->state_enter_ms >= ARQ_LISTEN_OFF_GRACE_MS)
+        {
+            sess->deferred_listen_off = false;
+            if (g_cbs.notify_disconnected) g_cbs.notify_disconnected(false);
+            enter_idle_after_call(sess);
+            break;
+        }
         if (sess->tx_retries_left > 0)
         {
             sess->tx_retries_left--;
@@ -1192,8 +1201,21 @@ static void fsm_calling(arq_session_t *sess, const arq_event_t *ev)
      * accepting new ones.  A host asserting a transmitter interlock (BPQ32
      * INTERLOCK, frequency scanners) sends LISTEN OFF to mean "release the
      * radio now" — honouring it only in LISTENING left us retrying CALL/ACCEPT
-     * over another port that had already taken the channel. */
+     * over another port that had already taken the channel.
+     *
+     * During the grace window after PENDING is sent the event is deferred rather
+     * than acted on immediately: a scanning host may have sent LISTEN OFF just
+     * before processing PENDING, and a premature teardown would move the host to
+     * the next channel, steering the reply onto the wrong frequency.  The grace
+     * period gives the host time to cancel its own dwell timer. */
     case ARQ_EV_APP_STOP_LISTEN:
+        if (time_now_ms() - sess->state_enter_ms < ARQ_LISTEN_OFF_GRACE_MS)
+        {
+            sess->deferred_listen_off = true;
+            sess->deadline_ms = sess->state_enter_ms + ARQ_LISTEN_OFF_GRACE_MS;
+            break;
+        }
+        /* fall through */
     case ARQ_EV_APP_DISCONNECT:
         if (g_cbs.notify_disconnected) g_cbs.notify_disconnected(false);
         enter_idle_after_call(sess);
@@ -1256,6 +1278,16 @@ static void fsm_accepting(arq_session_t *sess, const arq_event_t *ev)
         break;
 
     case ARQ_EV_TIMER_RETRY:
+        if (sess->deferred_listen_off &&
+            time_now_ms() - sess->state_enter_ms >= ARQ_LISTEN_OFF_GRACE_MS)
+        {
+            sess->deferred_listen_off = false;
+            if (g_cbs.notify_cancelpending)
+                g_cbs.notify_cancelpending();
+            if (g_cbs.notify_disconnected) g_cbs.notify_disconnected(false);
+            enter_idle_after_call(sess);
+            break;
+        }
         if (sess->tx_retries_left > 0)
         {
             sess->tx_retries_left--;
@@ -1288,6 +1320,13 @@ static void fsm_accepting(arq_session_t *sess, const arq_event_t *ev)
      * BPQ32 interlock report lands in — an inbound CALL we are answering with
      * ACCEPT retries. */
     case ARQ_EV_APP_STOP_LISTEN:
+        if (time_now_ms() - sess->state_enter_ms < ARQ_LISTEN_OFF_GRACE_MS)
+        {
+            sess->deferred_listen_off = true;
+            sess->deadline_ms = sess->state_enter_ms + ARQ_LISTEN_OFF_GRACE_MS;
+            break;
+        }
+        /* fall through */
     case ARQ_EV_APP_DISCONNECT:
         if (g_cbs.notify_cancelpending)
             g_cbs.notify_cancelpending();

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -156,7 +156,15 @@ static void sess_enter(arq_session_t *sess, arq_conn_state_t new_state,
     sess->state_enter_ms = time_now_ms();
     sess->deadline_ms    = deadline_ms;
     sess->deadline_event = deadline_event;
-    sess->deferred_listen_off = false;  /* stale across state transitions */
+    /* A deferred LISTEN OFF must SURVIVE the transition that the grace period
+     * exists to protect.  Clearing it here meant the successful case — the
+     * handshake completes and we enter CONNECTED — silently swallowed the
+     * host's channel release: the interlock was honoured only when the call
+     * failed anyway.  Carry it into CONNECTED and act on it there; drop it only
+     * when the session is already going idle, where it has nothing left to
+     * release. */
+    if (new_state == ARQ_CONN_DISCONNECTED || new_state == ARQ_CONN_LISTENING)
+        sess->deferred_listen_off = false;
     if (new_state != ARQ_CONN_CONNECTED)
     {
         sess->pending_connect_confirm = false;
@@ -1176,14 +1184,6 @@ static void fsm_calling(arq_session_t *sess, const arq_event_t *ev)
         break;
 
     case ARQ_EV_TIMER_RETRY:
-        if (sess->deferred_listen_off &&
-            time_now_ms() - sess->state_enter_ms >= ARQ_LISTEN_OFF_GRACE_MS)
-        {
-            sess->deferred_listen_off = false;
-            if (g_cbs.notify_disconnected) g_cbs.notify_disconnected(false);
-            enter_idle_after_call(sess);
-            break;
-        }
         if (sess->tx_retries_left > 0)
         {
             sess->tx_retries_left--;
@@ -1203,19 +1203,13 @@ static void fsm_calling(arq_session_t *sess, const arq_event_t *ev)
      * radio now" — honouring it only in LISTENING left us retrying CALL/ACCEPT
      * over another port that had already taken the channel.
      *
-     * During the grace window after PENDING is sent the event is deferred rather
-     * than acted on immediately: a scanning host may have sent LISTEN OFF just
-     * before processing PENDING, and a premature teardown would move the host to
-     * the next channel, steering the reply onto the wrong frequency.  The grace
-     * period gives the host time to cancel its own dwell timer. */
+     * Acted on immediately here, with no grace period.  The grace in ACCEPTING
+     * exists for one specific race: a scanning host can send LISTEN OFF just
+     * before it processes the PENDING we sent it.  PENDING announces an INCOMING
+     * call, so it is never sent while we are CALLING — there is nothing for the
+     * host to be racing against, and delaying its channel release would only
+     * keep a radio it asked for. */
     case ARQ_EV_APP_STOP_LISTEN:
-        if (time_now_ms() - sess->state_enter_ms < ARQ_LISTEN_OFF_GRACE_MS)
-        {
-            sess->deferred_listen_off = true;
-            sess->deadline_ms = sess->state_enter_ms + ARQ_LISTEN_OFF_GRACE_MS;
-            break;
-        }
-        /* fall through */
     case ARQ_EV_APP_DISCONNECT:
         if (g_cbs.notify_disconnected) g_cbs.notify_disconnected(false);
         enter_idle_after_call(sess);
@@ -1254,6 +1248,19 @@ static void fsm_accepting(arq_session_t *sess, const arq_event_t *ev)
             arq_timing_record_connect(g_timing, sess->control_mode);
         sess_enter(sess, ARQ_CONN_CONNECTED, UINT64_MAX, ARQ_EV_TIMER_RETRY);
         enter_idle_irs(sess);       /* callee receives first; process incoming data */
+        if (sess->deferred_listen_off)
+        {
+            /* The host asked for the radio back while we were answering, and
+             * the answer then succeeded.  Honour the request now rather than
+             * starting a session on a channel we were told to give up. */
+            HLOGI(LOG_COMP, "connected with a deferred LISTEN OFF — releasing the radio");
+            sess->deferred_listen_off = false;
+            sess->pending_disconnect  = false;
+            if (g_timing) arq_timing_record_disconnect(g_timing, "listen_off");
+            if (g_cbs.notify_disconnected) g_cbs.notify_disconnected(false);
+            enter_idle_after_call(sess);
+            break;
+        }
         if (ev->id == ARQ_EV_RX_DATA)
             fsm_dflow(sess, ev);
         break;

--- a/datalink_arq/arq_fsm.h
+++ b/datalink_arq/arq_fsm.h
@@ -225,6 +225,8 @@ typedef struct
                                         * call always returns to where it was   */
 
     /* --- Teardown flags --- */
+    bool     deferred_listen_off;      /* LISTEN OFF received during grace period;
+                                        * will be honoured once the grace expires    */
     bool     pending_disconnect_notify;/* defer notify_disconnected until TX done */
     bool     pending_disconnect;       /* APP_DISCONNECT deferred until TX buf empty */
     uint64_t disconnect_deadline_ms;   /* absolute time by which a deferred

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -229,6 +229,13 @@ extern _Atomic int arq_iss_post_ack_guard_ms;
                                             * and raced with TIMER_RETRY, causing
                                             * 3-4 wasted ACCEPT retries (~28s).    */
 #define ARQ_ACK_GUARD_S               1     /* extra slack added to retry interval */
+/* Grace period after entering CALLING/ACCEPTING (i.e. after PENDING is sent)
+ * during which LISTEN OFF is deferred.  Scanning hosts (BPQ32) need a moment to
+ * process PENDING and cancel their own dwell timers; without this grace, a
+ * LISTEN OFF that crosses PENDING on the wire cancels the handshake — the host
+ * moves to the next channel and the reply goes out on the wrong frequency.
+ * 2 s is conservative: ~0.5 s of TCP+host processing with headroom. */
+#define ARQ_LISTEN_OFF_GRACE_MS       2000
 #define ARQ_CALL_RETRY_SLOTS_DEFAULT       4    /* CALL retries before giving up       */
 #define ARQ_ACCEPT_RETRY_SLOTS_DEFAULT     4    /* ACCEPT retries before returning     */
 #define ARQ_DATA_RETRY_SLOTS_DEFAULT      10    /* DATA retries before disconnect      */

--- a/tests/datalink_arq/test_arq_fsm.c
+++ b/tests/datalink_arq/test_arq_fsm.c
@@ -689,6 +689,10 @@ void test_listen_off_drops_pending_accept(void)
     RESET_FAKE(fake_send_tx_frame);
     RESET_FAKE(fake_notify_cancelpending);
 
+    /* Advance time past the LISTEN OFF grace period so the event is
+     * acted on immediately rather than deferred (see ARQ_LISTEN_OFF_GRACE_MS). */
+    mock_set_uptime_ms(4000);
+
     ev = make_event(ARQ_EV_APP_STOP_LISTEN);
     arq_fsm_dispatch(&sess, &ev);
 
@@ -709,10 +713,74 @@ void test_listen_off_drops_outgoing_call(void)
     arq_fsm_dispatch(&sess, &ev);
     TEST_ASSERT_EQUAL_INT(ARQ_CONN_CALLING, sess.conn_state);
 
+    /* Advance time past the LISTEN OFF grace period. */
+    mock_set_uptime_ms(4000);
+
     ev = make_event(ARQ_EV_APP_STOP_LISTEN);
     arq_fsm_dispatch(&sess, &ev);
 
     TEST_ASSERT_NOT_EQUAL_INT(ARQ_CONN_CALLING, sess.conn_state);
+}
+
+/* LISTEN OFF received within ARQ_LISTEN_OFF_GRACE_MS of entering ACCEPTING
+ * must be deferred, not acted on immediately — a scanning host (BPQ32) sends
+ * LISTEN OFF at dwell expiry and needs time to process the just-sent PENDING
+ * and cancel its own timer.  Once the grace expires, the deferred event is
+ * honoured on the next TIMER_RETRY. */
+void test_listen_off_deferred_within_grace_accepting(void)
+{
+    arq_event_t ev = make_event(ARQ_EV_APP_LISTEN);
+    arq_fsm_dispatch(&sess, &ev);
+    mock_set_uptime_ms(1010);
+    ev = make_event(ARQ_EV_RX_CALL);
+    ev.session_id = 0x42;
+    strncpy(ev.remote_call, "REMOTE1", CALLSIGN_MAX_SIZE);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_ACCEPTING, sess.conn_state);
+
+    /* LISTEN OFF at 1010 ms (just after state enter at 1010) — inside grace. */
+    ev = make_event(ARQ_EV_APP_STOP_LISTEN);
+    arq_fsm_dispatch(&sess, &ev);
+
+    /* Must still be in ACCEPTING: grace deferred the teardown. */
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_ACCEPTING, sess.conn_state);
+    TEST_ASSERT_TRUE(sess.deferred_listen_off);
+
+    /* Advance past the grace period and fire TIMER_RETRY. */
+    mock_set_uptime_ms(4000);
+    ev = make_event(ARQ_EV_TIMER_RETRY);
+    arq_fsm_dispatch(&sess, &ev);
+
+    /* Now the deferred LISTEN OFF should have been processed. */
+    TEST_ASSERT_NOT_EQUAL_INT(ARQ_CONN_ACCEPTING, sess.conn_state);
+    TEST_ASSERT_FALSE(sess.deferred_listen_off);
+    TEST_ASSERT_GREATER_THAN(0, fake_notify_cancelpending_fake.call_count);
+}
+
+void test_listen_off_deferred_within_grace_calling(void)
+{
+    arq_event_t ev = make_event(ARQ_EV_APP_LISTEN);
+    arq_fsm_dispatch(&sess, &ev);
+    mock_set_uptime_ms(1010);
+    ev = make_event(ARQ_EV_APP_CONNECT);
+    strncpy(ev.remote_call, "DST1", CALLSIGN_MAX_SIZE);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CALLING, sess.conn_state);
+
+    /* LISTEN OFF within grace. */
+    ev = make_event(ARQ_EV_APP_STOP_LISTEN);
+    arq_fsm_dispatch(&sess, &ev);
+
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CALLING, sess.conn_state);
+    TEST_ASSERT_TRUE(sess.deferred_listen_off);
+
+    /* Advance past grace; TIMER_RETRY honours the deferred event. */
+    mock_set_uptime_ms(4000);
+    ev = make_event(ARQ_EV_TIMER_RETRY);
+    arq_fsm_dispatch(&sess, &ev);
+
+    TEST_ASSERT_NOT_EQUAL_INT(ARQ_CONN_CALLING, sess.conn_state);
+    TEST_ASSERT_FALSE(sess.deferred_listen_off);
 }
 
 void test_listen_off_drops_live_link_without_draining(void)
@@ -756,6 +824,8 @@ int main(void)
     RUN_TEST(test_disconnect_from_connected);
     RUN_TEST(test_listen_off_drops_pending_accept);
     RUN_TEST(test_listen_off_drops_outgoing_call);
+    RUN_TEST(test_listen_off_deferred_within_grace_accepting);
+    RUN_TEST(test_listen_off_deferred_within_grace_calling);
     RUN_TEST(test_listen_off_drops_live_link_without_draining);
     RUN_TEST(test_rx_disconnect_from_connected);
     RUN_TEST(test_connected_seeds_no_progress_clock);

--- a/tests/datalink_arq/test_arq_fsm.c
+++ b/tests/datalink_arq/test_arq_fsm.c
@@ -757,7 +757,10 @@ void test_listen_off_deferred_within_grace_accepting(void)
     TEST_ASSERT_GREATER_THAN(0, fake_notify_cancelpending_fake.call_count);
 }
 
-void test_listen_off_deferred_within_grace_calling(void)
+/* CALLING has no grace period: PENDING announces an INCOMING call, so it is
+ * never sent while we are the caller and there is no race to protect. The host
+ * asked for the radio; it gets it at once. */
+void test_listen_off_in_calling_is_immediate(void)
 {
     arq_event_t ev = make_event(ARQ_EV_APP_LISTEN);
     arq_fsm_dispatch(&sess, &ev);
@@ -767,20 +770,50 @@ void test_listen_off_deferred_within_grace_calling(void)
     arq_fsm_dispatch(&sess, &ev);
     TEST_ASSERT_EQUAL_INT(ARQ_CONN_CALLING, sess.conn_state);
 
-    /* LISTEN OFF within grace. */
+    /* Well inside what used to be the grace window. */
     ev = make_event(ARQ_EV_APP_STOP_LISTEN);
     arq_fsm_dispatch(&sess, &ev);
 
-    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CALLING, sess.conn_state);
-    TEST_ASSERT_TRUE(sess.deferred_listen_off);
-
-    /* Advance past grace; TIMER_RETRY honours the deferred event. */
-    mock_set_uptime_ms(4000);
-    ev = make_event(ARQ_EV_TIMER_RETRY);
-    arq_fsm_dispatch(&sess, &ev);
-
+    /* Released straight away — not deferred. */
     TEST_ASSERT_NOT_EQUAL_INT(ARQ_CONN_CALLING, sess.conn_state);
     TEST_ASSERT_FALSE(sess.deferred_listen_off);
+}
+
+/* The case the grace period is FOR, and the one that decides whether the
+ * interlock still means anything: LISTEN OFF arrives during the grace, and the
+ * handshake then SUCCEEDS. The release must survive the transition into
+ * CONNECTED and be honoured there. Clearing the flag on every state change made
+ * a successful answer swallow the host's request entirely — the interlock was
+ * respected only when the call failed anyway. */
+void test_deferred_listen_off_survives_connect(void)
+{
+    arq_event_t ev = make_event(ARQ_EV_APP_LISTEN);
+    arq_fsm_dispatch(&sess, &ev);
+    mock_set_uptime_ms(1010);
+
+    ev = make_event(ARQ_EV_RX_CALL);
+    ev.session_id = 0x42;
+    strncpy(ev.remote_call, "REMOTE1", CALLSIGN_MAX_SIZE);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_ACCEPTING, sess.conn_state);
+
+    /* Host releases the channel inside the grace window: deferred, not acted on. */
+    ev = make_event(ARQ_EV_APP_STOP_LISTEN);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_ACCEPTING, sess.conn_state);
+    TEST_ASSERT_TRUE(sess.deferred_listen_off);
+
+    RESET_FAKE(fake_notify_disconnected);
+
+    /* The caller answers our ACCEPT and the session would come up. */
+    ev = make_event(ARQ_EV_RX_ACK);
+    ev.session_id = sess.session_id;
+    arq_fsm_dispatch(&sess, &ev);
+
+    /* We must NOT settle into a session on a channel we were told to release. */
+    TEST_ASSERT_NOT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
+    TEST_ASSERT_FALSE(sess.deferred_listen_off);
+    TEST_ASSERT_GREATER_THAN(0, fake_notify_disconnected_fake.call_count);
 }
 
 void test_listen_off_drops_live_link_without_draining(void)
@@ -825,7 +858,8 @@ int main(void)
     RUN_TEST(test_listen_off_drops_pending_accept);
     RUN_TEST(test_listen_off_drops_outgoing_call);
     RUN_TEST(test_listen_off_deferred_within_grace_accepting);
-    RUN_TEST(test_listen_off_deferred_within_grace_calling);
+    RUN_TEST(test_listen_off_in_calling_is_immediate);
+    RUN_TEST(test_deferred_listen_off_survives_connect);
     RUN_TEST(test_listen_off_drops_live_link_without_draining);
     RUN_TEST(test_rx_disconnect_from_connected);
     RUN_TEST(test_connected_seeds_no_progress_clock);


### PR DESCRIPTION
## Problem

Scanning hosts (BPQ32) send LISTEN OFF at dwell expiry. When a CALL frame decodes near the end of a dwell window, the LISTEN OFF crosses PENDING on the wire: the host has already issued the channel release before processing the incoming-call notification.

In v1.9.11 the `aafd612` fix began honouring LISTEN OFF in CALLING/ACCEPTING (correct per the VARA spec — the host wants the radio back), but this exposed the race: the handshake was cancelled, the host moved to the next channel, and the ACCEPT reply went out on the wrong frequency.

**Reproduction** (Richard KO0OOO, 7 s dwell, 4-frequency scan):
- Connect request arriving within the first 4 s of dwell → scan stops ✓
- Connect request arriving after 4 s → scan does NOT stop on that channel; stops on the next channel and starts tx'ing there ✗
- v1.9.10 gateway + v1.9.10 client worked throughout the full dwell window

## Fix

Add `ARQ_LISTEN_OFF_GRACE_MS` (2000 ms). A LISTEN OFF that arrives within 2 s of entering CALLING or ACCEPTING is deferred rather than acted on immediately. The deadline is re-armed so TIMER_RETRY fires at grace expiry, at which point the deferred event is honoured. 

This gives the host time to process PENDING and cancel its own dwell timer. LISTEN OFF after the grace window is still acted on immediately (genuine channel release via INTERLOCK or operator request).

## Changes

| File | Change |
|------|--------|
| `arq_protocol.h` | Add `ARQ_LISTEN_OFF_GRACE_MS = 2000` |
| `arq_fsm.h` | Add `deferred_listen_off` flag to session struct |
| `arq_fsm.c` | Defer LISTEN OFF in CALLING/ACCEPTING within grace; honour on TIMER_RETRY after expiry |
| `test_arq_fsm.c` | Update existing tests for grace advance; add 2 new tests for deferred-vs-immediate behaviour |

## Tests

```
31 Tests 0 Failures 0 Ignored OK
```

Two new tests:
- `test_listen_off_deferred_within_grace_accepting` — LISTEN OFF within 2 s defers; TIMER_RETRY after grace honours it
- `test_listen_off_deferred_within_grace_calling` — same for CALLING state

Existing `test_listen_off_drops_pending_accept` and `test_listen_off_drops_outgoing_call` updated to advance mock time past the grace period before dispatching LISTEN OFF (maintains the original intent: after the grace window, the event is immediate).

## Stacking

This PR targets `feat-busy-default-on` (#144). The two fixes are complementary:
- #144 enables BUSY by default for ~0.3 s early carrier detection (helps if the host understands BUSY)
- This PR adds the LISTEN OFF grace period to prevent the race regardless of BUSY support