### PR TITLE
Fix coreaudio device id mismatch on macOS

### DIFF
--- a/audioio/ffaudio/ffaudio/coreaudio.c
+++ b/audioio/ffaudio/ffaudio/coreaudio.c
@@ -7,6 +7,8 @@
 #include <ffbase/ring.h>
 #include <CoreAudio/CoreAudio.h>
 #include <CoreFoundation/CFString.h>
+#include <stdlib.h>
+#include <stdio.h>
 
 
 int ffcoreaudio_init(ffaudio_init_conf *conf)
@@ -28,6 +30,7 @@ struct ffaudio_dev {
 
 	ffuint err;
 	char *errmsg;
+	char id_str[16];
 };
 
 ffaudio_dev* ffcoreaudio_dev_alloc(ffuint mode)
@@ -191,7 +194,8 @@ const char* ffcoreaudio_dev_info(ffaudio_dev *d, ffuint i)
 		if (d->idev == 0)
 			return NULL;
 
-		return (char*)&d->devs[d->idev - 1];
+		snprintf(d->id_str, sizeof(d->id_str), "%u", (unsigned)d->devs[d->idev - 1]);
+		return d->id_str;
 
 	case FFAUDIO_DEV_NAME:
 		return d->name;
@@ -283,7 +287,7 @@ int ffcoreaudio_open(ffaudio_buf *b, ffaudio_conf *conf, ffuint flags)
 
 	int dev = -1;
 	if (conf->device_id != NULL)
-		dev = *(int*)conf->device_id;
+		dev = (int)strtoul(conf->device_id, NULL, 10);
 	if (dev < 0) {
 		dev = coreaudio_dev_default(capture);
 		if (dev < 0) {

--- a/audioio/ffaudio/ffaudio/coreaudio.c
+++ b/audioio/ffaudio/ffaudio/coreaudio.c
@@ -286,8 +286,17 @@ int ffcoreaudio_open(ffaudio_buf *b, ffaudio_conf *conf, ffuint flags)
 	b->nonblock = !!(flags & FFAUDIO_O_NONBLOCK);
 
 	int dev = -1;
-	if (conf->device_id != NULL)
-		dev = (int)strtoul(conf->device_id, NULL, 10);
+	if (conf->device_id != NULL) {
+		/* Validate the parse: strtoul() returns 0 on a string it cannot read,
+		 * which would silently select device 0 instead of falling back to the
+		 * default. A config written by an older build holds exactly such an
+		 * unparsable id (it stored the raw AudioDeviceID bytes), so this is the
+		 * upgrade path, not a hypothetical. */
+		char *end = NULL;
+		unsigned long v = strtoul(conf->device_id, &end, 10);
+		if (end != conf->device_id && *end == '\0' && v <= 0x7fffffffUL)
+			dev = (int)v;
+	}
 	if (dev < 0) {
 		dev = coreaudio_dev_default(capture);
 		if (dev < 0) {


### PR DESCRIPTION
There was a bug handling the audio devices on macOS coreaudio.

Before:

```
% ./mercury -z              
Rhizomatica Mercury Version 1.9.11 (git 8a59f073)
playback devices:
device: name: 'USB Audio CODEC'  id: '?'  default: (null)
device: name: 'BlackHole 16ch'  id: 'V'  default: (null)
device: name: 'BlackHole 2ch'  id: 'k'  default: (null)
device: name: 'MacBook Air Speakers'  id: '?'  default: (null)
device: name: 'Microsoft Teams Audio'  id: '|'  default: (null)
device: name: 'MO BH 2ch'  id: ';'  default: (null)
device: name: 'MO BH 16ch'  id: '?'  default: (null)
capture devices:
device: name: 'USB Audio CODEC'  id: '?'  default: (null)
device: name: 'BlackHole 16ch'  id: 'V'  default: (null)
device: name: 'BlackHole 2ch'  id: 'k'  default: (null)
device: name: 'MacBook Air Microphone'  id: '?'  default: (null)
device: name: 'Microsoft Teams Audio'  id: '|'  default: (null)
```

```
% ./mercury -i "?" -o "?"   
Rhizomatica Mercury Version 1.9.11 (git 8a59f073)
(...)
19:01:19.238 [+0.000s] [INF] [engine] Initialising audio I/O (subsystem=4)
19:01:19.238 [+0.001s] [INF] [radio-io] Initializing radio (type=-1, device=(none), hamlib_log_level=0, serial_speed=0)
(...)
19:01:19.240 [+0.002s] [INF] [modem] Modem expects sample rate: 8000 Hz
19:01:19.240 [+0.002s] [INF] [modem] Modem payload bytes per frame: 126
(...)
19:01:19.326 [+0.088s] [ERR] [audio-cap] error in audio->open(): -1: AudioStreamBasicDescription
19:01:19.326 [+0.089s] [INF] [audio-cap] radio_capture_thread exit
```

With the fix:
```
% ./mercury -z
Rhizomatica Mercury Version 1.9.11 (git 342ecba1)
playback devices:
device: name: 'USB Audio CODEC'  id: '154'  default: (null)
device: name: 'BlackHole 16ch'  id: '86'  default: (null)
device: name: 'BlackHole 2ch'  id: '107'  default: (null)
device: name: 'MacBook Air Speakers'  id: '142'  default: (null)
device: name: 'Microsoft Teams Audio'  id: '124'  default: (null)
device: name: 'MO BH 2ch'  id: '59'  default: (null)
device: name: 'MO BH 16ch'  id: '63'  default: (null)
capture devices:
device: name: 'IPhone 12 Pro Microphone'  id: '162'  default: (null)
device: name: 'USB Audio CODEC'  id: '160'  default: (null)
device: name: 'BlackHole 16ch'  id: '86'  default: (null)
device: name: 'BlackHole 2ch'  id: '107'  default: (null)
device: name: 'MacBook Air Microphone'  id: '149'  default: (null)
device: name: 'Microsoft Teams Audio'  id: '124'  default: (null)
```

```
% ./mercury -i 160 -o 154           
Rhizomatica Mercury Version 1.9.11 (git 342ecba1)
(...)
19:23:33.747 [+0.083s] [INF] [audio-play] I/O playback (154) float32 / 48000Hz / 2ch / 40ms buffer
19:23:33.753 [+0.089s] [INF] [audio-cap] I/O capture (160) float32 / 48000Hz / 2ch / 40ms buffer

```