### PR TITLE
audioio: fix segfault on UI connect when a PulseAudio device has no description (#150)

### DIFF
--- a/audioio/ffaudio/ffaudio/pulse.c
+++ b/audioio/ffaudio/ffaudio/pulse.c
@@ -253,8 +253,18 @@ static void pulse_dev_on_next_sink(pa_context *c, const pa_sink_info *info, int 
 		d->err = errno;
 		return;
 	}
+	/* A device may carry no name and/or no description: PipeWire's PulseAudio
+	 * shim omits them for nodes that have no node.description, and so do some
+	 * PA modules.  ffsz_dup() is strlen()-based, so a NULL here killed the
+	 * whole modem on the libpulse thread the moment a UI client connected and
+	 * triggered enumeration (issue #150).  Skip a device with no id, and fall
+	 * back to the id when only the description is missing. */
+	if (info->name == NULL) {
+		ffmem_free(p);
+		return;
+	}
 	p->id = ffsz_dup(info->name);
-	p->name = ffsz_dup(info->description);
+	p->name = ffsz_dup(info->description != NULL ? info->description : info->name);
 	if (p->id == NULL || p->name == NULL) {
 		d->errfunc = "mem alloc";
 		d->err = errno;
@@ -285,8 +295,18 @@ static void pulse_dev_on_next_source(pa_context *c, const pa_source_info *info, 
 		d->err = errno;
 		return;
 	}
+	/* A device may carry no name and/or no description: PipeWire's PulseAudio
+	 * shim omits them for nodes that have no node.description, and so do some
+	 * PA modules.  ffsz_dup() is strlen()-based, so a NULL here killed the
+	 * whole modem on the libpulse thread the moment a UI client connected and
+	 * triggered enumeration (issue #150).  Skip a device with no id, and fall
+	 * back to the id when only the description is missing. */
+	if (info->name == NULL) {
+		ffmem_free(p);
+		return;
+	}
 	p->id = ffsz_dup(info->name);
-	p->name = ffsz_dup(info->description);
+	p->name = ffsz_dup(info->description != NULL ? info->description : info->name);
 	if (p->id == NULL || p->name == NULL) {
 		d->errfunc = "mem alloc";
 		d->err = errno;


### PR DESCRIPTION
Fixes #150 — mercury segfaults the moment a UI client (mercury-qt or a browser) connects with `-G`.

## Root cause

`pulse_dev_on_next_sink()` / `pulse_dev_on_next_source()` build the device list with:

```c
p->id   = ffsz_dup(info->name);
p->name = ffsz_dup(info->description);
```

`ffsz_dup()` is `strlen()`-based (`#define ffsz_len(sz) strlen(sz)`), so either field arriving NULL dereferences NULL.

Device enumeration runs **only** when a UI client connects (`ws_connect_handler` sets `soundcard_list_pending`), which is exactly when the crash is observed. It happens on libpulse's `threaded-ml` thread, so no mercury log line follows the segfault — the log just stops:

```
[INF] [websocket] Client connected (conn 0x745578000ca0)
Segmentation fault (core dumped)
```

The waterfall paints once or twice first because the spectrum publisher runs every 50 ms while the status publisher enumerates on its 500 ms tick — matching the reporter's "briefly displays a spectrum then crashes".

PulseAudio proper always fills both fields, which is why this never showed up on our hosts. PipeWire's PulseAudio shim does not guarantee a description for every node; the reporter runs Linux Mint 22.3 with pipewire + qpwgraph.

## Fix

Skip a device with no id, and fall back to the id when only the description is missing. A nameless node now costs a display string instead of the modem.

## Verification

Reproduced deterministically by forcing the NULL at the callback under gdb (`break pulse_dev_on_next_source if info != 0`, `set var *(char **)&info->description = 0`):

- **before:** first injected NULL segfaults — `__strlen_avx2 ← ffsz_dup (sz=0x0) ← pulse_dev_on_next_source (pulse.c:289)`
- **after:** six injected NULLs across sink *and* source enumeration are survived, and the capture/playback lists still reach the UI
- normal enumeration unchanged (descriptions still shown in `-z` and in the UI lists)
- unit suite green

Every other ffaudio backend was checked — `pulse.c` is the only one with this pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
