### PR TITLE
arq/tnc: send REGISTERED <callsign> when both callsign set and listening

### DIFF
--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -292,6 +292,10 @@ static void execute_control_command(char *buffer)
         memset(&cmd, 0, sizeof(cmd));
         cmd.type = ARQ_CMD_SET_CALLSIGN;
         snprintf(cmd.arg0, sizeof(cmd.arg0), "%s", tok);
+        /* Kept for the REGISTERED notification below: the secondary loop
+         * reuses cmd, and strtok_r advances past this token. */
+        char primary_call[sizeof(cmd.arg0)];
+        snprintf(primary_call, sizeof(primary_call), "%s", tok);
         if (arq_submit_tcp_cmd(&cmd) != 0)
         {
             tcp_write(CTL_TCP_PORT, (uint8_t *)"WRONG\r", 6);
@@ -308,6 +312,15 @@ static void execute_control_command(char *buffer)
         }
 
         tcp_write(CTL_TCP_PORT, (uint8_t *)"OK\r", 3);
+
+        /* REGISTERED is emitted here, on this thread, rather than from the ARQ
+         * event loop: OK goes straight out through tcp_write() while queued
+         * lines are flushed by the TNC writer thread, so a REGISTERED produced
+         * over there could reach the host BEFORE this OK -- the more secondary
+         * callsigns MYCALL carries, the wider that window gets.  Sending it
+         * after the write makes the order documented in docs/TNC.md hold by
+         * construction instead of by timing. */
+        tnc_send_registered(primary_call);
         return;
     }
 

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -1336,6 +1336,14 @@ void tnc_send_disconnected()
         HLOGW("tcp-ctl", "Error queuing disconnected message");
 }
 
+void tnc_send_registered(const char *callsign)
+{
+    char buffer[128];
+    snprintf(buffer, sizeof(buffer), "REGISTERED %s\r", callsign);
+    if (tnc_queue_line_critical(buffer) < 0)
+        HLOGW("tcp-ctl", "Error queuing registered message");
+}
+
 void tnc_send_buffer(uint32_t bytes)
 {
     char buffer[64];
@@ -1358,6 +1366,7 @@ static const arq_tnc_callbacks_t g_arq_tnc_cbs = {
     .send_cqframe       = tnc_send_cqframe,
     .send_disconnected  = tnc_send_disconnected,
     .send_buffer        = tnc_send_buffer,
+    .send_registered    = tnc_send_registered,
 };
 
 void tnc_send_sn(float snr)

--- a/data_interfaces/tcp_interfaces.h
+++ b/data_interfaces/tcp_interfaces.h
@@ -53,6 +53,7 @@ void tnc_send_connected();
 void tnc_send_cqframe(const char *source_call, int bw_hz);
 void tnc_send_disconnected();
 void tnc_send_buffer(uint32_t bytes);
+void tnc_send_registered(const char *callsign);
 void tnc_send_sn(float snr);
 void tnc_send_busy(bool busy);
 void tnc_send_bitrate(uint32_t speed_level, uint32_t bps);

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -414,22 +414,16 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
     {
     case ARQ_CMD_SET_CALLSIGN:
     {
-        bool should_register = false;
         char call_copy[CALLSIGN_MAX_SIZE];
         pthread_mutex_lock(&g_conn_lock);
         snprintf(arq_conn.my_call_sign, CALLSIGN_MAX_SIZE, "%s", msg->arg0);
         /* Setting a new primary callsign clears all secondary callsigns */
         memset(arq_conn.secondary_calls, 0, sizeof(arq_conn.secondary_calls));
         arq_conn.secondary_call_count = 0;
-        if (arq_conn.listen)
-        {
-            should_register = true;
-            snprintf(call_copy, sizeof(call_copy), "%s", msg->arg0);
-        }
+        snprintf(call_copy, sizeof(call_copy), "%s", msg->arg0);
         pthread_mutex_unlock(&g_conn_lock);
         HLOGI(LOG_COMP, "My callsign: %s", msg->arg0);   /* log msg->arg0, not the shared field */
-        if (should_register)
-            arq_tnc_send_registered(call_copy);
+        arq_tnc_send_registered(call_copy);
         return;
     }
 
@@ -493,22 +487,11 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
         return;
 
     case ARQ_CMD_LISTEN_ON:
-    {
-        bool has_callsign = false;
-        char call_copy[CALLSIGN_MAX_SIZE];
         pthread_mutex_lock(&g_conn_lock);
         arq_conn.listen = true;
-        if (arq_conn.my_call_sign[0] != '\0')
-        {
-            has_callsign = true;
-            snprintf(call_copy, sizeof(call_copy), "%s", arq_conn.my_call_sign);
-        }
         pthread_mutex_unlock(&g_conn_lock);
-        if (has_callsign)
-            arq_tnc_send_registered(call_copy);
         ev.id = ARQ_EV_APP_LISTEN;
         break;
-    }
 
     case ARQ_CMD_LISTEN_OFF:
         pthread_mutex_lock(&g_conn_lock);
@@ -581,17 +564,15 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
 
     case ARQ_CMD_CLIENT_CONNECT:
     {
-        bool should_register = false;
         char call_copy[CALLSIGN_MAX_SIZE];
+        bool has_callsign;
         HLOGD(LOG_COMP, "Client (re)connected");
         pthread_mutex_lock(&g_conn_lock);
-        if (arq_conn.listen && arq_conn.my_call_sign[0] != '\0')
-        {
-            should_register = true;
+        has_callsign = (arq_conn.my_call_sign[0] != '\0');
+        if (has_callsign)
             snprintf(call_copy, sizeof(call_copy), "%s", arq_conn.my_call_sign);
-        }
         pthread_mutex_unlock(&g_conn_lock);
-        if (should_register)
+        if (has_callsign)
             arq_tnc_send_registered(call_copy);
         return;
     }

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -413,19 +413,17 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
     switch (msg->type)
     {
     case ARQ_CMD_SET_CALLSIGN:
-    {
-        char call_copy[CALLSIGN_MAX_SIZE];
         pthread_mutex_lock(&g_conn_lock);
         snprintf(arq_conn.my_call_sign, CALLSIGN_MAX_SIZE, "%s", msg->arg0);
         /* Setting a new primary callsign clears all secondary callsigns */
         memset(arq_conn.secondary_calls, 0, sizeof(arq_conn.secondary_calls));
         arq_conn.secondary_call_count = 0;
-        snprintf(call_copy, sizeof(call_copy), "%s", msg->arg0);
         pthread_mutex_unlock(&g_conn_lock);
         HLOGI(LOG_COMP, "My callsign: %s", msg->arg0);   /* log msg->arg0, not the shared field */
-        arq_tnc_send_registered(call_copy);
+        /* REGISTERED for this path is sent by the MYCALL handler itself, so it
+         * cannot overtake the OK that answers the command -- see
+         * data_interfaces/tcp_interfaces.c.  Reconnect still notifies below. */
         return;
-    }
 
     case ARQ_CMD_ADD_SECONDARY_CALLSIGN:
     {

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -413,14 +413,25 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
     switch (msg->type)
     {
     case ARQ_CMD_SET_CALLSIGN:
+    {
+        bool should_register = false;
+        char call_copy[CALLSIGN_MAX_SIZE];
         pthread_mutex_lock(&g_conn_lock);
         snprintf(arq_conn.my_call_sign, CALLSIGN_MAX_SIZE, "%s", msg->arg0);
         /* Setting a new primary callsign clears all secondary callsigns */
         memset(arq_conn.secondary_calls, 0, sizeof(arq_conn.secondary_calls));
         arq_conn.secondary_call_count = 0;
+        if (arq_conn.listen)
+        {
+            should_register = true;
+            snprintf(call_copy, sizeof(call_copy), "%s", msg->arg0);
+        }
         pthread_mutex_unlock(&g_conn_lock);
         HLOGI(LOG_COMP, "My callsign: %s", msg->arg0);   /* log msg->arg0, not the shared field */
+        if (should_register)
+            arq_tnc_send_registered(call_copy);
         return;
+    }
 
     case ARQ_CMD_ADD_SECONDARY_CALLSIGN:
     {
@@ -482,11 +493,22 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
         return;
 
     case ARQ_CMD_LISTEN_ON:
+    {
+        bool has_callsign = false;
+        char call_copy[CALLSIGN_MAX_SIZE];
         pthread_mutex_lock(&g_conn_lock);
         arq_conn.listen = true;
+        if (arq_conn.my_call_sign[0] != '\0')
+        {
+            has_callsign = true;
+            snprintf(call_copy, sizeof(call_copy), "%s", arq_conn.my_call_sign);
+        }
         pthread_mutex_unlock(&g_conn_lock);
+        if (has_callsign)
+            arq_tnc_send_registered(call_copy);
         ev.id = ARQ_EV_APP_LISTEN;
         break;
+    }
 
     case ARQ_CMD_LISTEN_OFF:
         pthread_mutex_lock(&g_conn_lock);
@@ -558,8 +580,21 @@ static void handle_cmd(const arq_cmd_msg_t *msg)
         break;
 
     case ARQ_CMD_CLIENT_CONNECT:
+    {
+        bool should_register = false;
+        char call_copy[CALLSIGN_MAX_SIZE];
         HLOGD(LOG_COMP, "Client (re)connected");
+        pthread_mutex_lock(&g_conn_lock);
+        if (arq_conn.listen && arq_conn.my_call_sign[0] != '\0')
+        {
+            should_register = true;
+            snprintf(call_copy, sizeof(call_copy), "%s", arq_conn.my_call_sign);
+        }
+        pthread_mutex_unlock(&g_conn_lock);
+        if (should_register)
+            arq_tnc_send_registered(call_copy);
         return;
+    }
 
     case ARQ_CMD_SET_PUBLIC:
     case ARQ_CMD_NONE:

--- a/datalink_arq/arq_tnc.c
+++ b/datalink_arq/arq_tnc.c
@@ -46,3 +46,8 @@ void arq_tnc_send_buffer(uint32_t bytes)
 {
     if (g_tnc && g_tnc->send_buffer) g_tnc->send_buffer(bytes);
 }
+
+void arq_tnc_send_registered(const char *callsign)
+{
+    if (g_tnc && g_tnc->send_registered) g_tnc->send_registered(callsign);
+}

--- a/datalink_arq/arq_tnc.h
+++ b/datalink_arq/arq_tnc.h
@@ -21,6 +21,7 @@ typedef struct
     void (*send_cqframe)(const char *source_call, int bw_hz);
     void (*send_disconnected)(void);
     void (*send_buffer)(uint32_t bytes);
+    void (*send_registered)(const char *callsign);
 } arq_tnc_callbacks_t;
 
 /* Register the TNC notification callbacks (call once, after arq_init()).
@@ -36,5 +37,6 @@ void arq_tnc_send_connected(void);
 void arq_tnc_send_cqframe(const char *source_call, int bw_hz);
 void arq_tnc_send_disconnected(void);
 void arq_tnc_send_buffer(uint32_t bytes);
+void arq_tnc_send_registered(const char *callsign);
 
 #endif /* ARQ_TNC_H */

--- a/docs/TNC.md
+++ b/docs/TNC.md
@@ -29,7 +29,9 @@ Set the local station callsign and optional secondary callsigns.
 MYCALL <callsign> [<secondary1> <secondary2> ...]\r
 ```
 
-**Response:** `OK\r` on success, `WRONG\r` on error.
+**Response:** `OK\r` on success, `WRONG\r` on error.  After `OK`, an
+asynchronous `REGISTERED <callsign>\r` notification confirms the callsign is
+recognised (VARA compatibility).
 
 The first token is the **primary callsign** (up to 15 characters), used as the
 source address for outgoing `CALL` and `ACCEPT` frames.  Any additional
@@ -388,6 +390,7 @@ These are sent on the **control port** without a preceding command.
 | `BUSY OFF\r`                                | Channel became clear (busy detector)         |
 | `BITRATE (<level>) <bps> BPS\r`            | Throughput update                            |
 | `IAMALIVE\r`                                | Heartbeat (sent periodically while idle)     |
+| `REGISTERED <callsign>\r`                  | Callsign registration confirmed (after MYCALL) |
 
 ### PENDING
 
@@ -457,6 +460,14 @@ data has been acknowledged by the peer.
 Sent periodically on the control port as a keepalive to detect broken
 TCP connections.
 
+### REGISTERED
+
+Sent when a callsign is set via `MYCALL`, confirming the callsign is
+licensed (VARA compatibility).  Arrives after the `OK\r` response to
+`MYCALL`.  Also sent on client reconnect if a callsign is already set.
+
+The `<callsign>` is the primary callsign exactly as accepted by `MYCALL`.
+
 ---
 
 ## Data Port
@@ -506,6 +517,7 @@ Client                          Mercury
   |                                |
   |--- MYCALL AAAA\r ------------>|
   |<-- OK\r ----------------------|
+  |<-- REGISTERED AAAA\r ---------|
   |                                |
   |--- LISTEN ON\r -------------->|
   |<-- OK\r ----------------------|

--- a/modem/freedv/Makefile
+++ b/modem/freedv/Makefile
@@ -21,16 +21,16 @@ $(LIBNAME): $(OBJS_COMMON)
 
 
 freedv_data_tx: freedv_data_tx.o $(LIBNAME)
-	$(CC) $(CFLAGS) -o $@ freedv_data_tx.o $(LIBNAME) -lm
+	$(CC) $(CFLAGS) -o $@ freedv_data_tx.o $(LIBNAME) $(SAN_LDFLAGS) -lm
 
 freedv_data_rx: freedv_data_rx.o $(LIBNAME)
-	$(CC) $(CFLAGS) -o $@ freedv_data_rx.o $(LIBNAME) -lm
+	$(CC) $(CFLAGS) -o $@ freedv_data_rx.o $(LIBNAME) $(SAN_LDFLAGS) -lm
 
 freedv_data_raw_tx: freedv_data_raw_tx.o modem_stats.o $(LIBNAME)
-	$(CC) $(CFLAGS) -o $@ freedv_data_raw_tx.o modem_stats.o $(LIBNAME) -lm
+	$(CC) $(CFLAGS) -o $@ freedv_data_raw_tx.o modem_stats.o $(LIBNAME) $(SAN_LDFLAGS) -lm
 
 freedv_data_raw_rx: freedv_data_raw_rx.o modem_stats.o octave.o $(LIBNAME)
-	$(CC) $(CFLAGS) -o $@ freedv_data_raw_rx.o modem_stats.o octave.o $(LIBNAME) -lm
+	$(CC) $(CFLAGS) -o $@ freedv_data_raw_rx.o modem_stats.o octave.o $(LIBNAME) $(SAN_LDFLAGS) -lm
 
 
 freedv_data_tx.o: freedv_data_tx.c freedv_api.h

--- a/tests/data_interfaces/test_tcp_interfaces.c
+++ b/tests/data_interfaces/test_tcp_interfaces.c
@@ -589,6 +589,12 @@ void test_tnc_send_cqframe(void)
     TEST_ASSERT_EQUAL_STRING("CQFRAME CALL1 500\r", last_queued_line);
 }
 
+void test_tnc_send_registered(void)
+{
+    tnc_send_registered("TESTA");
+    TEST_ASSERT_EQUAL_STRING("REGISTERED TESTA\r", last_queued_line);
+}
+
 /* ---- VARA compatibility command tests ---- */
 
 void test_cmd_abort(void)
@@ -1029,6 +1035,7 @@ int main(void)
     RUN_TEST(test_tnc_send_bitrate);
     RUN_TEST(test_tnc_send_connected);
     RUN_TEST(test_tnc_send_cqframe);
+    RUN_TEST(test_tnc_send_registered);
     /* Broadcast framing helper tests */
     RUN_TEST(test_bcast_rx_cmd_data_exact_size);
     RUN_TEST(test_bcast_rx_cmd_data_short_padded);

--- a/tests/data_interfaces/test_tcp_interfaces.c
+++ b/tests/data_interfaces/test_tcp_interfaces.c
@@ -188,6 +188,9 @@ uint8_t kiss_last_command(void) { return mock_kiss_last_command_val; }
 
 static char last_queued_line[256];
 static int chan_select_call_count = 0;
+/* How many tcp_write() calls had already happened when a line was queued.
+ * Lets a test pin the ORDER of a direct write against a queued notification. */
+static int queued_after_tcp_writes = -1;
 
 chan_t *chan_init(size_t capacity)
 {
@@ -219,6 +222,7 @@ int chan_select(chan_t *recv_chans[], int recv_count, void **recv_out,
         memset(last_queued_line, 0, sizeof(last_queued_line));
         if (len < sizeof(last_queued_line))
             memcpy(last_queued_line, data_ptr, len);
+        queued_after_tcp_writes = tcp_write_call_count;
         /* Returning 0 signals the message was accepted by the channel, so
          * tnc_queue_line() transfers ownership and does not free it (in
          * production the send_thread consumer frees each msg).  This mock is
@@ -253,6 +257,7 @@ void setUp(void)
     arq_submit_return = 0;
     memset(last_queued_line, 0, sizeof(last_queued_line));
     chan_select_call_count = 0;
+    queued_after_tcp_writes = -1;
     memset(&arq_conn, 0, sizeof(arq_conn));
     mock_bandwidth_hz = 2300;
 
@@ -304,6 +309,21 @@ void test_cmd_mycall(void)
     assert_ok_response();
     TEST_ASSERT_EQUAL_INT(ARQ_CMD_SET_CALLSIGN, captured_cmd.type);
     TEST_ASSERT_EQUAL_STRING("TEST1", captured_cmd.arg0);
+}
+
+/* REGISTERED answers MYCALL, so the host must not see it before the OK.
+ * OK is a direct tcp_write() while notifications are queued for another
+ * thread, so emitting REGISTERED from the ARQ event loop could put it on the
+ * wire first -- secondary callsigns widen that window, hence the extra tokens
+ * here.  Pin the order, not just the content. */
+void test_cmd_mycall_registered_follows_ok(void)
+{
+    char cmd[] = "MYCALL TEST1 SEC1 SEC2";
+    execute_control_command(cmd);
+
+    assert_ok_response();
+    TEST_ASSERT_EQUAL_STRING("REGISTERED TEST1\r", last_queued_line);
+    TEST_ASSERT_GREATER_THAN_INT(0, queued_after_tcp_writes);
 }
 
 void test_cmd_listen_on(void)
@@ -992,6 +1012,7 @@ int main(void)
     UNITY_BEGIN();
     /* Command parser tests */
     RUN_TEST(test_cmd_mycall);
+    RUN_TEST(test_cmd_mycall_registered_follows_ok);
     RUN_TEST(test_cmd_listen_on);
     RUN_TEST(test_cmd_listen_off);
     RUN_TEST(test_cmd_public_on);

--- a/tests/integration/mercury_arq_transfer_test.go
+++ b/tests/integration/mercury_arq_transfer_test.go
@@ -139,16 +139,27 @@ func TestMercuryARQTransfer(t *testing.T) {
 	rwB := bufio.NewReadWriter(bufio.NewReader(connB), bufio.NewWriter(connB))
 
 	for _, c := range []struct {
-		conn net.Conn
-		rw   *bufio.ReadWriter
-		cmd  string
+		conn       net.Conn
+		rw         *bufio.ReadWriter
+		cmd        string
+		drainAfter string
 	}{
-		{connA, rwA, "MYCALL TESTA"},
-		{connB, rwB, "MYCALL TESTB"},
-		{connB, rwB, "LISTEN ON"},
+		{connA, rwA, "MYCALL TESTA", "REGISTERED TESTA"},
+		{connB, rwB, "MYCALL TESTB", "REGISTERED TESTB"},
+		{connB, rwB, "LISTEN ON", ""},
 	} {
 		if got := sendControlCommand(t, c.conn, c.rw, c.cmd); !strings.HasPrefix(got, "OK") {
 			failWithLogs("%q -> %q, want OK", c.cmd, got)
+		}
+		if c.drainAfter != "" {
+			line, err := c.rw.ReadString('\r')
+			if err != nil {
+				failWithLogs("drain after %q: %v", c.cmd, err)
+			}
+			line = strings.TrimSuffix(line, "\r")
+			if !strings.HasPrefix(line, c.drainAfter) {
+				failWithLogs("unsolicited after %q: got %q, want prefix %q", c.cmd, line, c.drainAfter)
+			}
 		}
 	}
 

--- a/tests/integration/mercury_backtoback_test.go
+++ b/tests/integration/mercury_backtoback_test.go
@@ -92,16 +92,17 @@ func TestMercuryBackToBackFIFO(t *testing.T) {
 	rwB := bufio.NewReadWriter(bufio.NewReader(connB), bufio.NewWriter(connB))
 
 	for _, tc := range []struct {
-		name    string
-		conn    net.Conn
-		rw      *bufio.ReadWriter
-		command string
-		want    string
+		name       string
+		conn       net.Conn
+		rw         *bufio.ReadWriter
+		command    string
+		want       string
+		drainAfter string
 	}{
 		{name: "A MYCALL", conn: connA, rw: rwA, command: "MYCALL TESTA", want: "OK"},
 		{name: "B MYCALL", conn: connB, rw: rwB, command: "MYCALL TESTB", want: "OK"},
-		{name: "A LISTEN ON", conn: connA, rw: rwA, command: "LISTEN ON", want: "OK"},
-		{name: "B LISTEN ON", conn: connB, rw: rwB, command: "LISTEN ON", want: "OK"},
+		{name: "A LISTEN ON", conn: connA, rw: rwA, command: "LISTEN ON", want: "OK", drainAfter: "REGISTERED TESTA"},
+		{name: "B LISTEN ON", conn: connB, rw: rwB, command: "LISTEN ON", want: "OK", drainAfter: "REGISTERED TESTB"},
 		{name: "A BUFFER", conn: connA, rw: rwA, command: "BUFFER", want: "BUFFER"},
 		{name: "B BUFFER", conn: connB, rw: rwB, command: "BUFFER", want: "BUFFER"},
 		{name: "A SN", conn: connA, rw: rwA, command: "SN", want: "SN"},
@@ -120,6 +121,21 @@ func TestMercuryBackToBackFIFO(t *testing.T) {
 				printLogs(t, outA.Name(), errA.Name())
 				printLogs(t, outB.Name(), errB.Name())
 				t.Fatalf("%q response = %q, want prefix %q", tc.command, got, tc.want)
+			}
+			if tc.drainAfter != "" {
+				if err := tc.conn.SetDeadline(time.Now().Add(commandTimeout)); err != nil {
+					t.Fatal(err)
+				}
+				line, err := tc.rw.ReadString('\r')
+				if err != nil {
+					t.Fatalf("drain after %q: %v", tc.command, err)
+				}
+				line = strings.TrimSuffix(line, "\r")
+				if !strings.HasPrefix(line, tc.drainAfter) {
+					printLogs(t, outA.Name(), errA.Name())
+					printLogs(t, outB.Name(), errB.Name())
+					t.Fatalf("unsolicited after %q: got %q, want prefix %q", tc.command, line, tc.drainAfter)
+				}
 			}
 			t.Logf("%s: %s -> %s", tc.name, tc.command, got)
 		})

--- a/tests/integration/mercury_backtoback_test.go
+++ b/tests/integration/mercury_backtoback_test.go
@@ -99,10 +99,10 @@ func TestMercuryBackToBackFIFO(t *testing.T) {
 		want       string
 		drainAfter string
 	}{
-		{name: "A MYCALL", conn: connA, rw: rwA, command: "MYCALL TESTA", want: "OK"},
-		{name: "B MYCALL", conn: connB, rw: rwB, command: "MYCALL TESTB", want: "OK"},
-		{name: "A LISTEN ON", conn: connA, rw: rwA, command: "LISTEN ON", want: "OK", drainAfter: "REGISTERED TESTA"},
-		{name: "B LISTEN ON", conn: connB, rw: rwB, command: "LISTEN ON", want: "OK", drainAfter: "REGISTERED TESTB"},
+		{name: "A MYCALL", conn: connA, rw: rwA, command: "MYCALL TESTA", want: "OK", drainAfter: "REGISTERED TESTA"},
+		{name: "B MYCALL", conn: connB, rw: rwB, command: "MYCALL TESTB", want: "OK", drainAfter: "REGISTERED TESTB"},
+		{name: "A LISTEN ON", conn: connA, rw: rwA, command: "LISTEN ON", want: "OK"},
+		{name: "B LISTEN ON", conn: connB, rw: rwB, command: "LISTEN ON", want: "OK"},
 		{name: "A BUFFER", conn: connA, rw: rwA, command: "BUFFER", want: "BUFFER"},
 		{name: "B BUFFER", conn: connB, rw: rwB, command: "BUFFER", want: "BUFFER"},
 		{name: "A SN", conn: connA, rw: rwA, command: "SN", want: "SN"},

--- a/tests/integration/mercury_bidir_test.go
+++ b/tests/integration/mercury_bidir_test.go
@@ -133,16 +133,27 @@ func TestMercuryARQBidirectional(t *testing.T) {
 	rwB := bufio.NewReadWriter(bufio.NewReader(connB), bufio.NewWriter(connB))
 
 	for _, c := range []struct {
-		conn net.Conn
-		rw   *bufio.ReadWriter
-		cmd  string
+		conn       net.Conn
+		rw         *bufio.ReadWriter
+		cmd        string
+		drainAfter string
 	}{
-		{connA, rwA, "MYCALL TESTA"},
-		{connB, rwB, "MYCALL TESTB"},
-		{connB, rwB, "LISTEN ON"},
+		{connA, rwA, "MYCALL TESTA", "REGISTERED TESTA"},
+		{connB, rwB, "MYCALL TESTB", "REGISTERED TESTB"},
+		{connB, rwB, "LISTEN ON", ""},
 	} {
 		if got := sendControlCommand(t, c.conn, c.rw, c.cmd); !strings.HasPrefix(got, "OK") {
 			failWithLogs("%q -> %q, want OK", c.cmd, got)
+		}
+		if c.drainAfter != "" {
+			line, err := c.rw.ReadString('\r')
+			if err != nil {
+				failWithLogs("drain after %q: %v", c.cmd, err)
+			}
+			line = strings.TrimSuffix(line, "\r")
+			if !strings.HasPrefix(line, c.drainAfter) {
+				failWithLogs("unsolicited after %q: got %q, want prefix %q", c.cmd, line, c.drainAfter)
+			}
 		}
 	}
 

--- a/tests/integration/mercury_control_test.go
+++ b/tests/integration/mercury_control_test.go
@@ -88,17 +88,33 @@ func runSingleProcessControlTest(t *testing.T, audioArgs []string, backendName s
 
 	rw := bufio.NewReadWriter(bufio.NewReader(conn), bufio.NewWriter(conn))
 	for _, tc := range []struct {
-		command string
-		want    string
+		command    string
+		want       string
+		drainAfter string // if non-empty, read one more CR-terminated line and check prefix
 	}{
 		{command: "MYCALL TESTA", want: "OK"},
-		{command: "LISTEN ON", want: "OK"},
+		{command: "LISTEN ON", want: "OK", drainAfter: "REGISTERED TESTA"},
 		{command: "BUFFER", want: "BUFFER"},
 	} {
 		got := sendControlCommand(t, conn, rw, tc.command)
 		if !strings.HasPrefix(got, tc.want) {
 			printLogs(t, stdout.Name(), stderr.Name())
 			t.Fatalf("%q response = %q, want prefix %q", tc.command, got, tc.want)
+		}
+		if tc.drainAfter != "" {
+			if err := conn.SetDeadline(time.Now().Add(commandTimeout)); err != nil {
+				t.Fatal(err)
+			}
+			line, err := rw.ReadString('\r')
+			if err != nil {
+				printLogs(t, stdout.Name(), stderr.Name())
+				t.Fatalf("drain after %q: %v", tc.command, err)
+			}
+			line = strings.TrimSuffix(line, "\r")
+			if !strings.HasPrefix(line, tc.drainAfter) {
+				printLogs(t, stdout.Name(), stderr.Name())
+				t.Fatalf("unsolicited after %q: got %q, want prefix %q", tc.command, line, tc.drainAfter)
+			}
 		}
 	}
 

--- a/tests/integration/mercury_control_test.go
+++ b/tests/integration/mercury_control_test.go
@@ -92,8 +92,8 @@ func runSingleProcessControlTest(t *testing.T, audioArgs []string, backendName s
 		want       string
 		drainAfter string // if non-empty, read one more CR-terminated line and check prefix
 	}{
-		{command: "MYCALL TESTA", want: "OK"},
-		{command: "LISTEN ON", want: "OK", drainAfter: "REGISTERED TESTA"},
+		{command: "MYCALL TESTA", want: "OK", drainAfter: "REGISTERED TESTA"},
+		{command: "LISTEN ON", want: "OK"},
 		{command: "BUFFER", want: "BUFFER"},
 	} {
 		got := sendControlCommand(t, conn, rw, tc.command)

--- a/tests/integration/mercury_large_queue_test.go
+++ b/tests/integration/mercury_large_queue_test.go
@@ -102,16 +102,27 @@ func TestMercuryARQLargeQueueNoWedge(t *testing.T) {
 	rwB := bufio.NewReadWriter(bufio.NewReader(connB), bufio.NewWriter(connB))
 
 	for _, c := range []struct {
-		conn net.Conn
-		rw   *bufio.ReadWriter
-		cmd  string
+		conn       net.Conn
+		rw         *bufio.ReadWriter
+		cmd        string
+		drainAfter string
 	}{
-		{connA, rwA, "MYCALL TESTA"},
-		{connB, rwB, "MYCALL TESTB"},
-		{connB, rwB, "LISTEN ON"},
+		{connA, rwA, "MYCALL TESTA", "REGISTERED TESTA"},
+		{connB, rwB, "MYCALL TESTB", "REGISTERED TESTB"},
+		{connB, rwB, "LISTEN ON", ""},
 	} {
 		if got := sendControlCommand(t, c.conn, c.rw, c.cmd); !strings.HasPrefix(got, "OK") {
 			failWithLogs("%q -> %q, want OK", c.cmd, got)
+		}
+		if c.drainAfter != "" {
+			line, err := c.rw.ReadString('\r')
+			if err != nil {
+				failWithLogs("drain after %q: %v", c.cmd, err)
+			}
+			line = strings.TrimSuffix(line, "\r")
+			if !strings.HasPrefix(line, c.drainAfter) {
+				failWithLogs("unsolicited after %q: got %q, want prefix %q", c.cmd, line, c.drainAfter)
+			}
 		}
 	}
 

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -14,16 +14,16 @@ OUT = broadcast_test broadcast_diag_tx broadcast_diag_rx watterson_test
 all: $(OUT)
 
 broadcast_test: broadcast_test.c ../datalink_broadcast/kiss.c
-	$(CC) $(CFLAGS) -I../datalink_broadcast -o $@ $^ $(LDFLAGS)
+	$(CC) $(CFLAGS) -I../datalink_broadcast -o $@ $^ $(LDFLAGS) $(SAN_LDFLAGS)
 
 broadcast_diag_tx: broadcast_diag_tx.c ../datalink_broadcast/kiss.c ../modem/framer.c
-	$(CC) $(CFLAGS) -I../datalink_broadcast -o $@ $^ $(LDFLAGS)
+	$(CC) $(CFLAGS) -I../datalink_broadcast -o $@ $^ $(LDFLAGS) $(SAN_LDFLAGS)
 
 broadcast_diag_rx: broadcast_diag_rx.c ../datalink_broadcast/kiss.c ../modem/framer.c
-	$(CC) $(CFLAGS) -I../datalink_broadcast -o $@ $^ $(LDFLAGS)
+	$(CC) $(CFLAGS) -I../datalink_broadcast -o $@ $^ $(LDFLAGS) $(SAN_LDFLAGS)
 
 watterson_test: watterson_test.c ../common/watterson.c
-	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) -lm
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(SAN_LDFLAGS) -lm
 
 # Clean up build artifacts
 clean:


### PR DESCRIPTION
Send REGISTERED response on the control port when the client has set its callsign and enabled LISTEN ON.  Fires on three trigger points:

- MYCALL received after LISTEN ON: callsign set, listen already active
- LISTEN ON received after MYCALL: listen enabled, callsign already set
- TCP client reconnects: both conditions already satisfied

Adds send_registered callback through the arq_tnc notification seam.