### PR TITLE
build: drop the redundant SAN_LDFLAGS from freedv and utils link lines

### DIFF
--- a/modem/freedv/Makefile
+++ b/modem/freedv/Makefile
@@ -21,16 +21,16 @@ $(LIBNAME): $(OBJS_COMMON)
 
 
 freedv_data_tx: freedv_data_tx.o $(LIBNAME)
-	$(CC) $(CFLAGS) -o $@ freedv_data_tx.o $(LIBNAME) $(SAN_LDFLAGS) -lm
+	$(CC) $(CFLAGS) -o $@ freedv_data_tx.o $(LIBNAME) -lm
 
 freedv_data_rx: freedv_data_rx.o $(LIBNAME)
-	$(CC) $(CFLAGS) -o $@ freedv_data_rx.o $(LIBNAME) $(SAN_LDFLAGS) -lm
+	$(CC) $(CFLAGS) -o $@ freedv_data_rx.o $(LIBNAME) -lm
 
 freedv_data_raw_tx: freedv_data_raw_tx.o modem_stats.o $(LIBNAME)
-	$(CC) $(CFLAGS) -o $@ freedv_data_raw_tx.o modem_stats.o $(LIBNAME) $(SAN_LDFLAGS) -lm
+	$(CC) $(CFLAGS) -o $@ freedv_data_raw_tx.o modem_stats.o $(LIBNAME) -lm
 
 freedv_data_raw_rx: freedv_data_raw_rx.o modem_stats.o octave.o $(LIBNAME)
-	$(CC) $(CFLAGS) -o $@ freedv_data_raw_rx.o modem_stats.o octave.o $(LIBNAME) $(SAN_LDFLAGS) -lm
+	$(CC) $(CFLAGS) -o $@ freedv_data_raw_rx.o modem_stats.o octave.o $(LIBNAME) -lm
 
 
 freedv_data_tx.o: freedv_data_tx.c freedv_api.h

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -14,16 +14,16 @@ OUT = broadcast_test broadcast_diag_tx broadcast_diag_rx watterson_test
 all: $(OUT)
 
 broadcast_test: broadcast_test.c ../datalink_broadcast/kiss.c
-	$(CC) $(CFLAGS) -I../datalink_broadcast -o $@ $^ $(LDFLAGS) $(SAN_LDFLAGS)
+	$(CC) $(CFLAGS) -I../datalink_broadcast -o $@ $^ $(LDFLAGS)
 
 broadcast_diag_tx: broadcast_diag_tx.c ../datalink_broadcast/kiss.c ../modem/framer.c
-	$(CC) $(CFLAGS) -I../datalink_broadcast -o $@ $^ $(LDFLAGS) $(SAN_LDFLAGS)
+	$(CC) $(CFLAGS) -I../datalink_broadcast -o $@ $^ $(LDFLAGS)
 
 broadcast_diag_rx: broadcast_diag_rx.c ../datalink_broadcast/kiss.c ../modem/framer.c
-	$(CC) $(CFLAGS) -I../datalink_broadcast -o $@ $^ $(LDFLAGS) $(SAN_LDFLAGS)
+	$(CC) $(CFLAGS) -I../datalink_broadcast -o $@ $^ $(LDFLAGS)
 
 watterson_test: watterson_test.c ../common/watterson.c
-	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(SAN_LDFLAGS) -lm
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) -lm
 
 # Clean up build artifacts
 clean:


### PR DESCRIPTION
Follow-up to #155: removes the `$(SAN_LDFLAGS)` additions from `utils/Makefile` and `modem/freedv/Makefile`, which are redundant.

Every link line in both files already passes `$(CFLAGS)`, and with `SANITIZE_ASAN_UBSAN=1` (or `SANITIZE_TSAN=1`) `COMMON_CFLAGS` carries the `-fsanitize` flags — both files `include ../config.mk`, and make forwards command-line variables to sub-makes. It's `-fsanitize` on the *link* line that pulls in the sanitizer runtime, so it was already there.

Verified rather than assumed. With them removed:

| check | result |
|---|---|
| `make SANITIZE_ASAN_UBSAN=1 -C utils` | 0 link errors |
| `make SANITIZE_ASAN_UBSAN=1 -C modem/freedv freedv_data_raw_rx` | 0 link errors |
| `make SANITIZE_ASAN_UBSAN=1 -j` (what `sanitizers.yml` runs) | exit 0, 0 undefined refs |
| `make -C tests SANITIZE_ASAN_UBSAN=1 test` | all pass |
| normal `make -j` | clean |

And the binaries are genuinely instrumented, not just linked: `utils/watterson_test` carries 19 `__asan` symbols, `freedv_data_raw_rx` 36. The `freedv_data_*` binaries are worth calling out because `make all` never builds them — they're the case a top-level build wouldn't have covered either way.

`SAN_LDFLAGS` stays defined in `config.mk` for link lines that use only `LDFLAGS`; this just stops carrying it where it does nothing.

@pedromessetti — if you were hitting a real failure in some other configuration, say so and I'll reopen this rather than have you re-add it later. I could not reproduce one on any invocation I tried.