### PR TITLE
channel: busy detector back to opt-in, and never during a session

### DIFF
--- a/common/cfg_utils.c
+++ b/common/cfg_utils.c
@@ -64,7 +64,7 @@ void cfg_set_defaults(mercury_config *cfg)
     cfg->keepalive_miss_limit        = ARQ_KEEPALIVE_MISS_LIMIT_DEFAULT;
     cfg->peer_payload_hold_s         = ARQ_PEER_PAYLOAD_HOLD_S_DEFAULT;
     cfg->startup_max_s               = ARQ_STARTUP_MAX_S_DEFAULT;
-    cfg->busy_detect                 = true;
+    cfg->busy_detect                 = false;
     cfg->busy_threshold_db           = 10;
     cfg->busy_hysteresis_db          = 3;
     cfg->busy_on_debounce_ms         = 300;

--- a/docs/TNC.md
+++ b/docs/TNC.md
@@ -432,8 +432,11 @@ HF channel transition between clear and occupied, using VARA's exact wording so
 existing VARA-compatible hosts (VarAC, BPQ32, Winlink) act on them unchanged.
 Edge-triggered: `BUSY ON\r` on clear→busy, `BUSY OFF\r` on busy→clear.
 
-The detector is **enabled by default** and can be turned off via the `[channel]`
-section of `mercury.ini` (`busy_detect = false`); its sensitivity/timing knobs
+The detector is **disabled by default** and is enabled via the `[channel]`
+section of `mercury.ini` (`busy_detect = true`).  It is off because the hosts
+that consume these notifications act on them: BPQ32 and Winlink hold
+transmissions while BUSY is asserted, so a false or over-eager BUSY stops the
+station transmitting.  Enable it if your host scans.  Its sensitivity/timing knobs
 (`busy_threshold_db`, `busy_hysteresis_db`, `busy_on_debounce_ms`,
 `busy_hang_ms`) typically need on-air tuning per band/noise environment. When
 disabled, these notifications are never sent. See `mercury.ini.example`.

--- a/mercury.ini.example
+++ b/mercury.ini.example
@@ -146,12 +146,19 @@ startup_max_s = 10
 ; Channel-busy (occupancy) detector.  Mercury classifies the HF channel as
 ; busy/clear from the RX spectrum and reports transitions to the host with
 ; VARA-compatible "BUSY ON" / "BUSY OFF" notifications on the control port.
-; Enabled by default: it is report-only (it never gates transmission), and it is
-; the ONLY early warning a host gets — everything else waits for a full frame to
-; decode, which is 3.7 s for a connect request.  A scanning host cannot hold its
-; dwell that long, so with the detector off it steps over incoming calls.
-; Thresholds below typically need on-air tuning per band/noise environment.
-busy_detect = true
+;
+; OFF by default, deliberately.  Mercury itself never gates transmission on it,
+; but the hosts that consume these notifications do: BPQ32 and Winlink hold
+; transmissions while BUSY is asserted, so a detector that fires on noise, or on
+; a station you are already in QSO with, stops the station transmitting and
+; strands traffic in the queue.  That is field experience on HF, not theory, and
+; it is why VARA ships with busy detection off as well.
+;
+; Turn it on if you scan: it is then the only early warning a host gets, since
+; everything else waits for a full frame to decode (3.7 s for a connect request)
+; and a scanning host cannot hold its dwell that long.  Expect to tune the
+; thresholds below per band and noise environment before trusting it.
+busy_detect = false
 
 ; Passband peak level, in dB above the tracked noise floor, required to call the
 ; channel BUSY (default 10, range 3..40).  Lower = more sensitive.

--- a/modem/modem.c
+++ b/modem/modem.c
@@ -1984,8 +1984,27 @@ void *rx_thread(void *g_modem)
                 }
                 pthread_mutex_unlock(&g_spectrum_lock);
 
-                /* Channel-busy classification (RX-only: never while we key). */
-                if (busy_on && arq_get_trx() != TX)
+                /* Channel-busy classification (RX-only: never while we key).
+                 *
+                 * Also never during a session.  The energy we would classify
+                 * there is our own peer answering us, and the hosts that
+                 * consume BUSY act on it -- BPQ32 and Winlink hold
+                 * transmissions while it is asserted -- so reporting it would
+                 * stall the very link that is running.  Clear a latched BUSY
+                 * on the way in, or a host is left holding one for the whole
+                 * QSO with no BUSY OFF to release it. */
+                if (busy_on && arq_get_trx() != TX && arq_is_link_connected())
+                {
+                    if (atomic_exchange_explicit(&g_channel_busy, false,
+                                                 memory_order_relaxed))
+                    {
+                        channel_busy_init(&g_busy_state);
+                        tnc_send_busy(false);
+                        HLOGI("modem-rx", "channel CLEAR (in session: peer "
+                              "traffic is not occupancy)");
+                    }
+                }
+                else if (busy_on && arq_get_trx() != TX)
                 {
                     busy_cfg_t cfg;
                     pthread_mutex_lock(&g_busy_cfg_lock);

--- a/tests/common/test_cfg_utils.c
+++ b/tests/common/test_cfg_utils.c
@@ -45,7 +45,9 @@ void test_defaults_match_constants(void)
     TEST_ASSERT_EQUAL_INT(5,   c.keepalive_miss_limit);
     TEST_ASSERT_EQUAL_INT(15,  c.peer_payload_hold_s);
     TEST_ASSERT_EQUAL_INT(10,  c.startup_max_s);
-    TEST_ASSERT_TRUE(c.busy_detect);   /* report-only, and the only early warning a host gets */
+    /* Opt-in: hosts hold transmissions while BUSY is asserted, so this must
+     * never switch on under a station that did not ask for it. */
+    TEST_ASSERT_FALSE(c.busy_detect);
     TEST_ASSERT_EQUAL_INT(10,   c.busy_threshold_db);
     TEST_ASSERT_EQUAL_INT(3,    c.busy_hysteresis_db);
     TEST_ASSERT_EQUAL_INT(300,  c.busy_on_debounce_ms);
@@ -67,7 +69,7 @@ void test_arq_tunables_roundtrip(void)
     w.keepalive_miss_limit        = 8;
     w.peer_payload_hold_s         = 25;
     w.startup_max_s               = 20;
-    w.busy_detect                 = false;  /* non-default: proves it round-trips */
+    w.busy_detect                 = true;   /* non-default: proves it round-trips */
     w.busy_threshold_db           = 14;
     w.busy_hysteresis_db          = 5;
     w.busy_on_debounce_ms         = 500;
@@ -87,7 +89,7 @@ void test_arq_tunables_roundtrip(void)
     TEST_ASSERT_EQUAL_INT(8,    r.keepalive_miss_limit);
     TEST_ASSERT_EQUAL_INT(25,   r.peer_payload_hold_s);
     TEST_ASSERT_EQUAL_INT(20,   r.startup_max_s);
-    TEST_ASSERT_FALSE(r.busy_detect);
+    TEST_ASSERT_TRUE(r.busy_detect);
     TEST_ASSERT_EQUAL_INT(14,   r.busy_threshold_db);
     TEST_ASSERT_EQUAL_INT(5,    r.busy_hysteresis_db);
     TEST_ASSERT_EQUAL_INT(500,  r.busy_on_debounce_ms);


### PR DESCRIPTION
Acts on a field report from **Gary K7EK**, running 1.9.11 (`cc5bbc7`) with BPQ32.

## Why the default was wrong

Mercury itself never gates transmission on the busy flag — `modem_channel_busy()` has **no callers**, and `ARQ_CONNECT_BUSY_EXT_S` is defined but unused. Connects, data, ACKs and answering a call are all unaffected.

But the notification's consumers do act on it: **BPQ32 and Winlink hold transmissions while `BUSY` is asserted.** #144 switched the detector on by default, so every such station changed behaviour on upgrade without asking, and the reported symptom is exactly that — a station that stops transmitting and strands its queue. VARA ships with busy detection off for the same reason. Scanning hosts genuinely want it, so it stays available, as the opt-in the header comment claimed it already was.

## The second bug: we called our own peer "occupancy"

The gate was RX-vs-TX only:

```c
if (busy_on && arq_get_trx() != TX)
```

No session check anywhere — so during a link, the energy being classified is **the far end answering us**, and we would report BUSY every time our peer transmits. For a host that holds transmissions on BUSY that stalls the very link it is running, which fits Gary's *"stops a robust link cold for minutes at a time, leading to unnecessary session timeouts"*.

Now suppressed while connected, and a latched BUSY is cleared on the way in — otherwise the host is left holding one for the whole QSO with no `BUSY OFF` to release it.

## Also

`docs/TNC.md` and `mercury.ini.example` now say off-by-default and, more usefully, *why*: it is the host that acts on BUSY, not Mercury. The unit test asserting the default is updated, and the round-trip test now uses `true` as its non-default value.

Build clean, unit suite green.