### PR TITLE
Add configurable tx_delay_ms

### DIFF
--- a/common/cfg_utils.c
+++ b/common/cfg_utils.c
@@ -54,6 +54,7 @@ void cfg_set_defaults(mercury_config *cfg)
     cfg->tnc_keepalive_s = 60;
     cfg->tnc_buffer_report_ms = 1000;
     cfg->tx_gain_db            = 0.0f;
+    cfg->tx_delay_ms           = 10;
     cfg->data_retry_slots            = ARQ_DATA_RETRY_SLOTS_DEFAULT;
     cfg->mode_hold_after_downgrade_s = ARQ_MODE_HOLD_AFTER_DOWNGRADE_S_DEFAULT;
     cfg->ladder_up_successes         = ARQ_LADDER_UP_SUCCESSES_DEFAULT;
@@ -243,6 +244,9 @@ bool cfg_read(mercury_config *cfg, const char *ini_path)
     if (d >  20.0) d =  20.0;
     cfg->tx_gain_db = (float)d;
 
+    i = iniparser_getint(ini, CFG_KEY_TX_DELAY_MS, cfg->tx_delay_ms);
+    if (i >= 0 && i <= 2000) cfg->tx_delay_ms = i;
+
     iniparser_freedict(ini);
     return true;
 }
@@ -348,6 +352,7 @@ bool cfg_write(const mercury_config *cfg, const char *ini_path)
 
     fprintf(f, "\n[audio]\n");
     fprintf(f, "tx_gain_db = %.2f\n", cfg->tx_gain_db);
+    fprintf(f, "tx_delay_ms = %d\n", cfg->tx_delay_ms);
 
     fprintf(f, "\n[tnc]\n");
     fprintf(f, "keepalive_s = %d\n", cfg->tnc_keepalive_s);

--- a/common/cfg_utils.h
+++ b/common/cfg_utils.h
@@ -44,6 +44,7 @@
 #define CFG_KEY_NO_PROGRESS_TIMEOUT_S "arq:no_progress_timeout_s"
 #define CFG_KEY_DISCONNECT_DRAIN_TIMEOUT_S "arq:disconnect_drain_timeout_s"
 #define CFG_KEY_TX_GAIN_DB          "audio:tx_gain_db"
+#define CFG_KEY_TX_DELAY_MS         "audio:tx_delay_ms"
 #define CFG_KEY_TNC_KEEPALIVE_S     "tnc:keepalive_s"
 #define CFG_KEY_TNC_BUFFER_REPORT_MS "tnc:buffer_report_ms"
 #define CFG_KEY_ARQ_DATA_RETRY_SLOTS          "arq:data_retry_slots"
@@ -109,6 +110,13 @@ typedef struct {
     float    tx_gain_db;            /* Linear-equivalent gain on the modulator
                                     * TX samples, in dB. 0.0 = no change.
                                     * Range -20.0 .. +20.0 (clamped). */
+    int      tx_delay_ms;           /* Delay (ms) after PTT ON before audio is
+                                    * sent to the playback device on TX.
+                                    * Default 10 covers the local radio
+                                    * relay's switch time; raise it to give a
+                                    * slow external PTT more time to key up
+                                    * before the signal starts. Clamped
+                                    * 0..2000. */
     int      tnc_keepalive_s;       /* IAMALIVE interval on the TNC control
                                     * port. Default 60, clamped 5..600.   */
     int      tnc_buffer_report_ms;  /* BUFFER report interval on the TNC

--- a/common/mercury_engine.c
+++ b/common/mercury_engine.c
@@ -127,6 +127,7 @@ int mercury_engine_init(const mercury_config *cfg,
     arq_set_peer_payload_hold_s(cfg->peer_payload_hold_s);
     arq_set_startup_max_s(cfg->startup_max_s);
     modem_set_tx_gain(powf(10.0f, cfg->tx_gain_db / 20.0f));
+    modem_set_tx_delay_ms(cfg->tx_delay_ms);
     modem_set_busy_cfg((float)cfg->busy_threshold_db,
                        (float)cfg->busy_hysteresis_db,
                        (uint32_t)cfg->busy_on_debounce_ms,

--- a/mercury.ini.example
+++ b/mercury.ini.example
@@ -81,6 +81,15 @@ hamlib_log_level = 0
 ; Range: -20.0 .. +20.0 (values outside are clamped).
 tx_gain_db = 0.0
 
+; TX keying delay in milliseconds (default: 10), waited after PTT ON before
+; audio is written to the playback device on TX. The default covers the
+; local radio relay's switch time. Increase this if your host app drives
+; PTT off Mercury's "PTT ON" TNC notification and needs more time to
+; actually key the radio (e.g. a slow serial/CAT relay) — otherwise the
+; start of the transmission can be clipped before the radio is keyed.
+; Range: 0 .. 2000 (values outside are clamped).
+tx_delay_ms = 10
+
 [arq]
 
 ; ARQ link no-progress disconnect budget (seconds, default: 180).

--- a/modem/modem.c
+++ b/modem/modem.c
@@ -99,6 +99,25 @@ float modem_get_tx_gain(void)
     return atomic_load(&g_tx_gain);
 }
 
+/* --- TX keying delay (ms), waited after PTT ON before audio is handed to
+ * the playback device. Covers the local radio relay's switch time and,
+ * beyond that, gives a slow external PTT (host app driving a serial/CAT
+ * relay off the "PTT ON" TNC notification) time to actually key the radio
+ * before the signal starts. Default 10ms is the relay-switch baseline. */
+static _Atomic int g_tx_delay_ms = 10;
+
+void modem_set_tx_delay_ms(int delay_ms)
+{
+    if (delay_ms < 0)    delay_ms = 0;
+    if (delay_ms > 2000) delay_ms = 2000;
+    atomic_store(&g_tx_delay_ms, delay_ms);
+}
+
+int modem_get_tx_delay_ms(void)
+{
+    return atomic_load(&g_tx_delay_ms);
+}
+
 float modem_get_tx_peak_dbfs(void)
 {
     return atomic_load(&g_tx_peak_dbfs);
@@ -1070,8 +1089,9 @@ int send_modulated_data(generic_modem_t *g_modem, uint8_t *bytes_in, int frames_
     }
     else
     {
-        /* Wait for radio relay to switch (10ms for your radio) */
-        usleep(10000);
+        /* Wait for radio relay to switch, plus any extra keying delay
+         * configured for a slower external PTT path. */
+        usleep((useconds_t)modem_get_tx_delay_ms() * 1000);
 
         /* Write entire pre-generated buffer to playback */
         write_buffer(playback_buffer, (uint8_t *)tx_buffer, total_samples * sizeof(int32_t));

--- a/modem/modem.h
+++ b/modem/modem.h
@@ -80,6 +80,12 @@ bool modem_channel_busy(void);
 void  modem_set_tx_gain(float linear);
 float modem_get_tx_gain(void);
 
+/* TX keying delay (ms, clamped 0..2000) waited after PTT ON before audio is
+ * written to the playback device. Default 10ms covers the local radio
+ * relay's switch time; raise it for a slower external PTT path. */
+void modem_set_tx_delay_ms(int delay_ms);
+int  modem_get_tx_delay_ms(void);
+
 // Most recent TX burst peak amplitude in dBFS (0 dBFS = INT32 full-scale,
 // i.e. the clip ceiling).  Measured post-gain but pre-saturation, once per
 // burst, so a return value above 0 dBFS means the burst clipped by that many


### PR DESCRIPTION
Adds a configuration setting to set the delay between PTT ON and actual audio being sent. 

Fixes #154.