### PR TITLE
1.9.12: callsign truncation, CALL retry anchor, Watterson double, acquire/decode instrument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ claude_context.txt
 context-*.txt
 copilot-*.txt
 screen.jpg
+
+# utils build outputs
+utils/watterson_test
+utils/acquire_vs_decode

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ screen.jpg
 # utils build outputs
 utils/watterson_test
 utils/acquire_vs_decode
+utils/resampler_bench
+utils/rxcost_bench

--- a/audioio/resampler.c
+++ b/audioio/resampler.c
@@ -124,6 +124,7 @@ void resampler_global_init(void)
 void resamp_up_reset(resamp_up_t *r)
 {
     memset(r->hist, 0, sizeof(r->hist));
+    r->w = RESAMP_TAPS_PER_PHASE - 1;
 }
 
 int resamp_up_process(resamp_up_t *r, const int32_t *in, int n_in, int32_t *out)
@@ -136,18 +137,23 @@ int resamp_up_process(resamp_up_t *r, const int32_t *in, int n_in, int32_t *out)
         return n_in;
     }
 
+    const int K = RESAMP_TAPS_PER_PHASE;
     int o = 0;
     for (int i = 0; i < n_in; i++) {
-        /* Shift newest input into hist[0]. */
-        for (int t = RESAMP_TAPS_PER_PHASE - 1; t > 0; t--)
-            r->hist[t] = r->hist[t - 1];
-        r->hist[0] = in[i];
+        /* Advance the circular head and write the sample at both mirrors. */
+        if (++r->w >= K) r->w = 0;
+        r->hist[r->w]     = in[i];
+        r->hist[r->w + K] = in[i];
 
+        /* hist_logical[t] (t=0 newest) == hist[w + K - t]: a contiguous run,
+         * walked in the SAME order as the old shift version so the
+         * accumulation is bit-identical. */
+        const int32_t *win = &r->hist[r->w + K];
         for (int p = 0; p < L; p++) {
             double acc = 0.0;
             const float *hp = h_up[p];
-            for (int t = 0; t < RESAMP_TAPS_PER_PHASE; t++)
-                acc += (double)hp[t] * (double)r->hist[t];
+            for (int t = 0; t < K; t++)
+                acc += (double)hp[t] * (double)win[-t];
             out[o++] = clamp_i32(acc);
         }
     }
@@ -159,6 +165,7 @@ int resamp_up_process(resamp_up_t *r, const int32_t *in, int n_in, int32_t *out)
 void resamp_down_reset(resamp_down_t *r)
 {
     memset(r->hist, 0, sizeof(r->hist));
+    r->w     = 0;
     r->phase = 0;
 }
 
@@ -176,18 +183,30 @@ int resamp_down_process(resamp_down_t *r, const int32_t *in, int n_in,
     const int ntaps = L * RESAMP_TAPS_PER_PHASE;
     int o = 0;
     for (int i = 0; i < n_in; i++) {
-        /* Shift newest input into hist[0]. */
-        for (int t = ntaps - 1; t > 0; t--)
-            r->hist[t] = r->hist[t - 1];
-        r->hist[0] = in[i];
+        /* Advance the circular head and write the sample at both mirrors.
+         * The old code shifted all `ntaps` words here for every input sample;
+         * at a 48 kHz device rate that was 8.6 M word-moves a second to feed a
+         * filter that only fires once every L samples. */
+        if (++r->w >= ntaps) r->w = 0;
+        r->hist[r->w]         = in[i];
+        r->hist[r->w + ntaps] = in[i];
 
         if (++r->phase >= L) {
             r->phase = 0;
+            /* hist_logical[t] (t=0 newest) == hist[w + ntaps - t]; same walk
+             * order as before, so the sum is bit-identical. */
+            const int32_t *win = &r->hist[r->w + ntaps];
             double acc = 0.0;
             for (int t = 0; t < ntaps; t++)
-                acc += (double)h_down[t] * (double)r->hist[t];
+                acc += (double)h_down[t] * (double)win[-t];
             out[o++] = clamp_i32(acc);
         }
     }
     return o;
+}
+
+float resampler_down_tap(int t)
+{
+    if (t < 0 || t >= RESAMP_NTAPS_MAX) return 0.0f;
+    return h_down[t];
 }

--- a/audioio/resampler.h
+++ b/audioio/resampler.h
@@ -61,8 +61,14 @@ void resampler_init_down(int L);   /* 8000*L -> 8 kHz (capture)  */
 void resampler_global_init(void);
 
 /* --- Upsampler: 8 kHz -> 8000*L (anti-imaging) --- */
+/* The history is a circular buffer stored DOUBLED: every sample is written at
+ * both `w` and `w + K`, so the K-sample window ending at the newest sample is
+ * always a contiguous descending run and the filter loop needs no modulo and
+ * no per-sample shuffling.  Costs K extra words; saves shifting the whole
+ * history once per input sample. */
 typedef struct {
-    int32_t hist[RESAMP_TAPS_PER_PHASE];  /* last K input samples (8 kHz)  */
+    int32_t hist[2 * RESAMP_TAPS_PER_PHASE];
+    int     w;                            /* index of the newest sample    */
 } resamp_up_t;
 
 void resamp_up_reset(resamp_up_t *r);
@@ -73,8 +79,12 @@ int  resamp_up_process(resamp_up_t *r, const int32_t *in, int n_in,
                        int32_t *out);
 
 /* --- Downsampler: 8000*L -> 8 kHz (anti-aliasing) --- */
+/* Doubled circular history, as above.  This is the direction that matters:
+ * it runs on every captured sample at the DEVICE rate, so at 48 kHz the old
+ * shift moved 180 words 48000 times a second. */
 typedef struct {
-    int32_t hist[RESAMP_NTAPS_MAX];       /* last N input samples (device) */
+    int32_t hist[2 * RESAMP_NTAPS_MAX];
+    int     w;                            /* index of the newest sample    */
     int     phase;                        /* 0..L-1 decimation phase       */
 } resamp_down_t;
 
@@ -84,5 +94,10 @@ void resamp_down_reset(resamp_down_t *r);
  * (8 kHz) to out (must hold at least n_in/L + 1 samples).  Returns the count. */
 int  resamp_down_process(resamp_down_t *r, const int32_t *in, int n_in,
                          int32_t *out);
+
+/* One decimation-filter coefficient.  Exposed so a test can reimplement the
+ * FIR and prove the fast history representation did not change any output
+ * sample; not part of the audio path.  Returns 0 for out-of-range t. */
+float resampler_down_tap(int t);
 
 #endif /* AUDIOIO_RESAMPLER_H */

--- a/common/watterson.c
+++ b/common/watterson.c
@@ -47,23 +47,23 @@ static float gaussian()
  *
  * Result: H(z) = (b0 + b1·z⁻¹ + b2·z⁻²) / (1 + a1·z⁻¹ + a2·z⁻²)
  */
-static void butterworth_2nd_lp(float fc, float fs,
-                                float *b0, float *b1, float *b2,
-                                float *a1, float *a2)
+static void butterworth_2nd_lp(double fc, double fs,
+                                double *b0, double *b1, double *b2,
+                                double *a1, double *a2)
 {
     /* Pre-warp cutoff frequency */
-    float c = tanf(M_PI * fc / fs);
-    float c2 = c * c;
-    float sqrt2c = 1.41421356237f * c;  /* √2 */
+    double c = tan(M_PI * fc / fs);
+    double c2 = c * c;
+    double sqrt2c = 1.41421356237309505 * c;  /* sqrt(2) */
 
-    float den0 = 1.0f + sqrt2c + c2;
+    double den0 = 1.0 + sqrt2c + c2;
 
     *b0 = c2 / den0;
-    *b1 = 2.0f * c2 / den0;
+    *b1 = 2.0 * c2 / den0;
     *b2 = c2 / den0;
 
-    *a1 = 2.0f * (c2 - 1.0f) / den0;
-    *a2 = (1.0f - sqrt2c + c2) / den0;
+    *a1 = 2.0 * (c2 - 1.0) / den0;
+    *a2 = (1.0 - sqrt2c + c2) / den0;
 }
 
 /* Apply a 2nd-order IIR filter to one scalar sample.
@@ -73,9 +73,9 @@ static void butterworth_2nd_lp(float fc, float fs,
  *
  * The x[3] and y[3] arrays hold {x[n-2], x[n-1], x[n]}.
  */
-static float iir_tick(float xn, float x[3], float y[3],
-                      float b0, float b1, float b2,
-                      float a1, float a2)
+static double iir_tick(double xn, double x[3], double y[3],
+                       double b0, double b1, double b2,
+                       double a1, double a2)
 {
     /* shift input history */
     x[0] = x[1];
@@ -178,9 +178,9 @@ int watterson_add_path(watterson_t *w, float delay_ms, float doppler_hz,
         /* The filter bandwidth is matched to the Doppler spread.
          * A Butterworth LPF with fc = σ provides a reasonable
          * approximation of the Gaussian spectrum. */
-        float fc = p->doppler_hz;
+        double fc = p->doppler_hz;
 
-        butterworth_2nd_lp(fc, (float)w->sample_rate,
+        butterworth_2nd_lp(fc, (double)w->sample_rate,
                            &p->b0, &p->b1, &p->b2,
                            &p->a1, &p->a2);
 
@@ -196,15 +196,15 @@ int watterson_add_path(watterson_t *w, float delay_ms, float doppler_hz,
          * narrow Doppler: the fade is ~constant over any short window, so it
          * would normalise to a single fade realisation, not the ensemble.) */
         {
-            float xh[3] = {0,0,0}, yh[3] = {0,0,0};
+            double xh[3] = {0,0,0}, yh[3] = {0,0,0};
             double e_h = 0.0;
-            float in = 1.0f;        /* unit impulse at n=0, zero thereafter */
+            double in = 1.0;        /* unit impulse at n=0, zero thereafter */
             int n;
             for (n = 0; n < 2000000; n++)
             {
-                float y = iir_tick(in, xh, yh, p->b0, p->b1, p->b2, p->a1, p->a2);
-                in = 0.0f;
-                e_h += (double)y * y;
+                double y = iir_tick(in, xh, yh, p->b0, p->b1, p->b2, p->a1, p->a2);
+                in = 0.0;
+                e_h += y * y;
                 if (n > 2000 && (double)y * y < e_h * 1e-13)
                     break;          /* impulse-response tail is negligible */
             }

--- a/common/watterson.h
+++ b/common/watterson.h
@@ -44,14 +44,21 @@ typedef struct watterson_path
 
     /* IIR filter state for Doppler shaping (2nd-order Butterworth LPF)
      * Separate filters are used for the I and Q components */
-    float x_i[3];        /* Input history, I component */
-    float y_i[3];        /* Output history, I component */
-    float x_q[3];        /* Input history, Q component */
-    float y_q[3];        /* Output history, Q component */
+    /* double, not float: at a high sample rate with a slow Doppler the
+     * cutoff ratio fc/fs becomes tiny and the Butterworth poles sit within
+     * ~1e-4 of the unit circle. float carries only ~6e-8 of relative
+     * resolution there, which is enough to push a pole OUTSIDE the circle:
+     * the filter then diverges instead of fading. Measured before the change,
+     * 2 paths at 1 Hz: 8 kHz gave a sane SNR3k of -8.37 dB but 48 kHz gave
+     * +65.76 dB, i.e. the "signal" was the filter blowing up. */
+    double x_i[3];       /* Input history, I component */
+    double y_i[3];       /* Output history, I component */
+    double x_q[3];       /* Input history, Q component */
+    double y_q[3];       /* Output history, Q component */
 
     /* IIR filter coefficients (a0 is normalised to 1.0) */
-    float b0, b1, b2;    /* Numerator */
-    float a1, a2;        /* Denominator (a0 = 1) */
+    double b0, b1, b2;   /* Numerator   (double: see the history arrays) */
+    double a1, a2;       /* Denominator (a0 = 1) */
 
     /* Frequency offset state */
     float phase;          /* Current phase accumulator for rotation */

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -1191,11 +1191,29 @@ static void fsm_calling(arq_session_t *sess, const arq_event_t *ev)
         }
         break;
 
+    case ARQ_EV_TX_COMPLETE:
+        /* CALL frame just finished transmitting: re-anchor the retry deadline
+         * to PTT-OFF rather than to whenever the frame was queued.
+         *
+         * fsm_accepting already does this for ACCEPT; CALLING never got the
+         * same treatment, and the arithmetic is unforgiving.  The retry
+         * interval is measured from the TIMER_RETRY that *queued* the CALL,
+         * but the CALL itself occupies ~3.7 s of DATAC16 airtime, and the peer
+         * cannot even begin its ACCEPT until our PTT drops.  With the default
+         * interval that leaves the retransmission firing at roughly the same
+         * moment the ACCEPT is arriving -- so the retry keys the transmitter on
+         * top of the reply it was waiting for, on essentially every connect.
+         * Measuring the interval from here gives the peer a full turnaround. */
+        sess->deadline_ms = deadline_from_s(arq_protocol_call_interval_s());
+        break;
+
     case ARQ_EV_TIMER_RETRY:
         if (sess->tx_retries_left > 0)
         {
             sess->tx_retries_left--;
             send_call_accept(sess, false);
+            /* Deadline is re-anchored on TX_COMPLETE above; this is the
+             * fallback if that event is ever missed. */
             sess->deadline_ms = deadline_from_s(arq_protocol_call_interval_s());
         }
         else

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -759,6 +759,14 @@ static void send_call_accept(arq_session_t *sess, bool is_accept)
                                     my_call, sess->remote_call, bw_hz);
     if (n > 0)
         send_frame(PACKET_TYPE_ARQ_CALL, sess->control_mode, (size_t)n, frame, 0);
+    else
+        /* Almost always an over-long callsign: the 10-byte SRC slot holds ~14
+         * characters at ~5.25 bits each.  The encoder refuses rather than
+         * truncating (a truncated arithmetic code decodes to a DIFFERENT
+         * callsign), so say why — otherwise this is a CALL that never goes out
+         * and a session that retries against silence. */
+        HLOGW(LOG_COMP, "%s not sent: cannot encode callsign '%s' (too long?)",
+              is_accept ? "ACCEPT" : "CALL", my_call);
 }
 
 static void send_ctrl_frame(arq_session_t *sess, arq_subtype_t subtype)

--- a/datalink_arq/arq_protocol.c
+++ b/datalink_arq/arq_protocol.c
@@ -444,8 +444,13 @@ static int encode_callsign_payload(const char *src, const char *dst,
         return -1;
 
     size_t src_cap = out_cap - ARQ_CONNECT_DST_CRC_SIZE;
+    /* Refuse rather than truncate.  A truncated arithmetic code is not a
+     * shortened callsign -- it decodes to a DIFFERENT string at the far end,
+     * so the peer either answers a call from a station that does not exist or
+     * silently drops one that does.  Failing here makes the operator's
+     * over-long callsign visible instead of turning it into a wrong one. */
     if ((size_t)enc_len > src_cap)
-        enc_len = (int)src_cap;
+        return -1;
     memcpy(out + ARQ_CONNECT_DST_CRC_SIZE, tmp, (size_t)enc_len);
     return (int)(ARQ_CONNECT_DST_CRC_SIZE + (size_t)enc_len);
 }
@@ -492,8 +497,10 @@ static int encode_callsign_only_payload(const char *src, uint8_t *out, size_t ou
     if (enc_len <= 0)
         return -1;
 
+    /* Same reasoning as encode_callsign_payload: a truncated arithmetic code
+     * decodes to a different callsign, so refuse it. */
     if ((size_t)enc_len > out_cap)
-        enc_len = (int)out_cap;
+        return -1;
     memcpy(out, tmp, (size_t)enc_len);
     return enc_len;
 }

--- a/docs/MODES.md
+++ b/docs/MODES.md
@@ -118,7 +118,36 @@ Operational consequences, reflected in the ARQ design (see `docs/ARQ.md`):
   is small.  See the control-mode comparison table below.
 - Acquisition (preamble/UW detection) is the dominant loss for both new modes
   above −5 dB MPP — a future tuning candidate (`timing_mx_thresh`, UW length)
-  independent of the FEC design.
+  independent of the FEC design.  It is also what sets the *fringe* floor, which
+  is measurable rather than inferred (`utils/acquire_vs_decode DATAC16 100 -13 -8`,
+  AWGN, 0 % clipped):
+
+  | SNR3k | acquired | delivered | decode given sync |
+  |---|---|---|---|
+  | −8 dB | 100/100 | 99/100 | 99 % |
+  | −9 dB | 99/100 | 98/100 | 99 % |
+  | −10 dB | 84/100 | 78/100 | 93 % |
+  | −11 dB | 52/100 | 48/100 | 92 % |
+  | −12 dB | 26/100 | 19/100 | 73 % |
+  | −13 dB | 7/100 | 2/100 | 29 % |
+
+  Acquisition falls away far faster than decoding: 99 → 52 → 7 between −9 and
+  −13 dB, while frames that do sync still decode 92–99 % of the time down to
+  −11 dB.  The decoder does eventually join in below that, so acquisition is the
+  *first-order* limiter rather than the only one.  These figures agree with the
+  independent AWGN table above (98 vs 96 delivered at −9 dB, 78 vs 82 at −10,
+  48 vs 52 at −11), which is what licenses trusting them.
+
+  Two traps, both of which produced confident and wrong tables first.  **Level:**
+  freedv emits DATAC16 at rms ~8000 / peak ~16400, so at fringe SNRs
+  signal+noise hits the int16 rail — 23 % of samples clipped, delivering −7.1 dB
+  when −9.0 was asked for.  The tool normalises the burst before adding noise and
+  prints the clipped percentage on every row.  **Budget arithmetic:** DATAC16's
+  floor implies Eb/N0 ≈ 9.3 dB against ~1–2 dB for a rate-0.2 code near
+  capacity, which looks like ~7 dB of acquisition deficit — until cyclic prefix
+  (~1.3 dB), pilots (~1.3 dB), channel-estimation and implementation loss
+  (~1.5 dB) and short-code loss at N=640 (~2.5 dB) are subtracted, leaving ~1 dB.
+  The budget cannot answer this question; the split above can.
 
 ## Control-mode comparison: DATAC13 vs DATAC16 vs DATAC18
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -45,7 +45,7 @@ ARQ_STUBS = datalink_arq/arq_test_stubs.c
 TEST_BINS = test_ring_buffer test_arq_protocol test_arq_timing test_arq_fsm \
             test_tcp_interfaces test_resampler test_pcm24 test_arq_olla test_arq_sim \
             test_arq_conn test_cfg_utils test_arq_tnc test_channel_busy \
-            test_freedv_harq test_sock_wire test_virtual_clock
+            test_freedv_harq test_sock_wire test_virtual_clock test_watterson
 
 .PHONY: all test clean
 
@@ -143,6 +143,11 @@ test_sock_wire: audioio/test_sock_wire.c $(UNITY_SRC)
 # Virtual clock (time base for -x sock); hermes_uptime_ms stubbed in-test
 test_virtual_clock: common/test_virtual_clock.c $(UNITY_SRC) ../common/virtual_clock.c
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+
+# Channel model: pins that fading stays finite across sample rates (-I.. because
+# the test includes common/watterson.h by path).
+test_watterson: common/test_watterson.c $(UNITY_SRC) ../common/watterson.c
+	$(CC) $(CFLAGS) -I.. -o $@ $^ $(LDFLAGS)
 
 # UI status wire format (embedded struct vs remote JSON must not drift)
 test_ui_status: gui_interface/test_ui_status.c $(UNITY_SRC) ../gui_interface/ui_status.c

--- a/tests/audioio/test_resampler.c
+++ b/tests/audioio/test_resampler.c
@@ -14,6 +14,7 @@
 #include <math.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define FS8   8000
 #define FS48  48000
@@ -300,6 +301,82 @@ void test_up_and_down_ratios_are_independent(void)
     resampler_global_init();   /* restore the default for later tests */
 }
 
+/* ---- circular history must be bit-identical to the naive shift ----
+ *
+ * The history used to be shifted one word at a time for every input sample --
+ * at a 48 kHz device rate, 180 words moved 48000 times a second to feed a
+ * filter that fires once every 6 samples.  It is now a doubled circular
+ * buffer.  That is a pure representation change and MUST NOT alter a single
+ * output sample: these are audio paths feeding a demodulator, and a resampler
+ * that quietly rounds differently is far worse than a slow one.
+ *
+ * Floating-point addition is not associative, so the fast path deliberately
+ * walks the taps in the same order the shift version did.  The references
+ * below are the original implementations, kept verbatim. */
+
+static int ref_down_process(int L, const int32_t *in, int n_in, int32_t *out,
+                            int32_t *hist, int *phase)
+{
+    const int ntaps = L * RESAMP_TAPS_PER_PHASE;
+    int o = 0;
+    for (int i = 0; i < n_in; i++) {
+        for (int t = ntaps - 1; t > 0; t--)
+            hist[t] = hist[t - 1];
+        hist[0] = in[i];
+        if (++(*phase) >= L) {
+            *phase = 0;
+            double acc = 0.0;
+            for (int t = 0; t < ntaps; t++)
+                acc += (double)resampler_down_tap(t) * (double)hist[t];
+            double v = acc;
+            if (v >  2147483647.0) v =  2147483647.0;
+            if (v < -2147483648.0) v = -2147483648.0;
+            out[o++] = (int32_t)v;
+        }
+    }
+    return o;
+}
+
+void test_circular_history_matches_naive_shift(void)
+{
+    const int rates[] = { 16000, 24000, 48000, 96000 };
+
+    for (unsigned k = 0; k < sizeof(rates) / sizeof(rates[0]); k++)
+    {
+        int L = resampler_ratio_for_rate(rates[k]);
+        TEST_ASSERT_GREATER_THAN_INT(0, L);
+        resampler_init_down(L);
+
+        resamp_down_t fast;
+        resamp_down_reset(&fast);
+
+        static int32_t ref_hist[2 * RESAMP_NTAPS_MAX];
+        memset(ref_hist, 0, sizeof(ref_hist));
+        int ref_phase = 0;
+
+        /* Several chunks, so the comparison also covers state carried across
+         * call boundaries -- the whole reason the history exists. */
+        uint32_t rng = 0xC0FFEEu;
+        for (int chunk = 0; chunk < 8; chunk++)
+        {
+            int n = 137 + chunk * 53;          /* deliberately not a multiple of L */
+            static int32_t in[4096], a[4096], b[4096];
+            for (int i = 0; i < n; i++) {
+                rng = rng * 1664525u + 1013904223u;
+                in[i] = (int32_t)((int)(rng >> 8) % 2000000) - 1000000;
+            }
+
+            int na = resamp_down_process(&fast, in, n, a);
+            int nb = ref_down_process(L, in, n, b, ref_hist, &ref_phase);
+
+            TEST_ASSERT_EQUAL_INT(nb, na);
+            for (int i = 0; i < na; i++)
+                TEST_ASSERT_EQUAL_INT32_MESSAGE(b[i], a[i],
+                    "circular history changed an output sample");
+        }
+    }
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -318,5 +395,6 @@ int main(void)
     RUN_TEST(test_roundtrip_ratio_12);
     RUN_TEST(test_ratio_1_is_passthrough);
     RUN_TEST(test_up_and_down_ratios_are_independent);
+    RUN_TEST(test_circular_history_matches_naive_shift);
     return UNITY_END();
 }

--- a/tests/common/test_watterson.c
+++ b/tests/common/test_watterson.c
@@ -1,0 +1,91 @@
+/* Watterson channel model — numerical sanity across sample rates.
+ *
+ * The model is the instrument behind every sensitivity number in this project,
+ * so it needs a guard of its own. The Doppler tap is a 2nd-order Butterworth
+ * driven by white noise; as fc/fs shrinks its poles crowd the unit circle, and
+ * in single precision they can land OUTSIDE it. The filter then diverges
+ * instead of fading, and the "measured SNR" becomes the blow-up rather than
+ * the signal: at 48 kHz with 1 Hz Doppler this read +65.76 dB where 8 kHz read
+ * -8.37 dB. Mercury runs at 8 kHz today, which is why it went unnoticed --
+ * it surfaced only when driving a 48 kHz modem through the same channel.
+ */
+#include "unity.h"
+#include "watterson.h"
+#include <math.h>
+#include <stdlib.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+static float measure(int fs, float doppler_hz, int two_path)
+{
+    watterson_t w;
+    TEST_ASSERT_EQUAL_INT(0, watterson_init(&w, fs));
+    watterson_add_path(&w, 0.0f, doppler_hz, 0.0f, 1.0f);
+    if (two_path) watterson_add_path(&w, 2.0f, doppler_hz, 0.0f, 1.0f);
+    watterson_set_noise(&w, -20.0f);
+    watterson_reset_meas(&w);
+
+    int n = fs * 2;
+    COMP *s = malloc(sizeof(COMP) * (size_t)n);
+    TEST_ASSERT_NOT_NULL(s);
+    for (int i = 0; i < n; i++) {
+        s[i].real = 3000.0f * sinf(2.0f * (float)M_PI * 1500.0f * i / fs);
+        s[i].imag = 0.0f;
+    }
+    watterson_process(&w, s, n);
+
+    for (int i = 0; i < n; i++)
+        TEST_ASSERT_TRUE_MESSAGE(isfinite(s[i].real) && isfinite(s[i].imag),
+                                 "channel produced a non-finite sample");
+    float snr = watterson_measured_snr3k(&w);
+    free(s);
+    watterson_dispose(&w);
+    return snr;
+}
+
+void test_fading_is_stable_across_sample_rates(void)
+{
+    /* Same physical channel at every rate, so the measured SNR3k must land in
+     * the same ballpark. The band is wide because a 2 s window of slow fading
+     * samples only a few fades and scatters by several dB -- it is here to
+     * catch divergence, not to pin a value. */
+    const int rates[] = { 8000, 16000, 24000, 48000, 96000 };
+    const float dopplers[] = { 0.1f, 0.5f, 1.0f, 2.0f };
+
+    for (unsigned r = 0; r < sizeof(rates)/sizeof(rates[0]); r++) {
+        for (unsigned d = 0; d < sizeof(dopplers)/sizeof(dopplers[0]); d++) {
+            float snr = measure(rates[r], dopplers[d], 1);
+            char msg[128];
+            snprintf(msg, sizeof msg,
+                     "fs=%d doppler=%.1f Hz gave SNR3k=%.2f dB (filter diverged?)",
+                     rates[r], dopplers[d], snr);
+            TEST_ASSERT_TRUE_MESSAGE(isfinite(snr), msg);
+            TEST_ASSERT_TRUE_MESSAGE(snr > -40.0f && snr < 5.0f, msg);
+        }
+    }
+}
+
+void test_single_static_path_is_rate_invariant(void)
+{
+    /* One static path is the clean cross-rate invariant: the tap is a
+     * constant, so an identical channel must measure identically whatever the
+     * sample rate. This is what makes an 8 kHz result comparable with a 48 kHz
+     * one, so it is worth pinning tightly -- measured agreement is 0.04 dB.
+     *
+     * Deliberately NOT two paths: summing a delayed copy adds a multipath
+     * interference term that genuinely does depend on the rate (~1.5 dB here),
+     * which would make this a test of interference rather than of the model's
+     * rate handling. */
+    float a = measure(8000, 0.0f, 0), b = measure(48000, 0.0f, 0);
+    TEST_ASSERT_TRUE(isfinite(a) && isfinite(b));
+    TEST_ASSERT_FLOAT_WITHIN(0.5f, a, b);
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_fading_is_stable_across_sample_rates);
+    RUN_TEST(test_single_static_path_is_rate_invariant);
+    return UNITY_END();
+}

--- a/tests/datalink_arq/test_arq_fsm.c
+++ b/tests/datalink_arq/test_arq_fsm.c
@@ -843,6 +843,42 @@ void test_listen_off_drops_live_link_without_draining(void)
     TEST_ASSERT_EQUAL_INT(0, fake_send_tx_frame_fake.call_count);
 }
 
+/* The CALL retry interval must be measured from PTT-OFF, not from the moment
+ * the CALL was queued.
+ *
+ * The CALL occupies ~3.7 s of DATAC16 airtime and the peer cannot start its
+ * ACCEPT until our transmitter releases, so anchoring the retry at enqueue
+ * spends most of the interval on our own transmission and fires the retry into
+ * the arriving ACCEPT.  fsm_accepting already anchors on TX_COMPLETE; this pins
+ * the same behaviour for CALLING.
+ *
+ * Asserts the deadline strictly ADVANCES on TX_COMPLETE -- that is the whole
+ * property, and it fails if the handler is absent. */
+void test_call_retry_deadline_anchored_to_ptt_off(void)
+{
+    arq_event_t ev = make_event(ARQ_EV_APP_LISTEN);
+    arq_fsm_dispatch(&sess, &ev);
+    ev = make_event(ARQ_EV_APP_CONNECT);
+    strncpy(ev.remote_call, "TEST1", CALLSIGN_MAX_SIZE);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CALLING, sess.conn_state);
+
+    uint64_t at_enqueue = sess.deadline_ms;
+
+    /* Time passes while the CALL is actually on the air, then PTT drops. */
+    mock_set_uptime_ms(1000 + 3700);
+    arq_event_t done = make_event(ARQ_EV_TX_COMPLETE);
+    arq_fsm_dispatch(&sess, &done);
+
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CALLING, sess.conn_state);
+    TEST_ASSERT_TRUE_MESSAGE(sess.deadline_ms > at_enqueue,
+        "CALL retry deadline must be re-anchored to PTT-OFF");
+    /* And it must be a full interval from PTT-OFF, not a partial remainder. */
+    TEST_ASSERT_EQUAL_UINT64((uint64_t)(1000 + 3700) +
+                             (uint64_t)arq_protocol_call_interval_s() * 1000ULL,
+                             sess.deadline_ms);
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -851,6 +887,7 @@ int main(void)
     RUN_TEST(test_init_mode_defaults);
     RUN_TEST(test_listen_transitions_to_listening);
     RUN_TEST(test_connect_transitions_to_calling);
+    RUN_TEST(test_call_retry_deadline_anchored_to_ptt_off);
     RUN_TEST(test_incoming_call_transitions_to_accepting);
     RUN_TEST(test_incoming_call_records_dialed_secondary);
     RUN_TEST(test_accept_transitions_to_connected);

--- a/tests/datalink_arq/test_arq_protocol.c
+++ b/tests/datalink_arq/test_arq_protocol.c
@@ -315,6 +315,64 @@ void test_mode_timing_datac16_unaffected_by_override(void)
     TEST_ASSERT_FLOAT_WITHIN(0.01f, 8.0f, t->retry_interval_s);
 }
 
+/* A callsign that does not fit the 10-byte SRC slot must be REFUSED, not
+ * truncated.  The slot holds an arithmetic code, and a truncated arithmetic
+ * code does not decode to a shortened callsign -- it decodes to a different
+ * one.  Truncating therefore puts a station on the air under a callsign that
+ * is not its own, and the peer either answers a call from a station that does
+ * not exist or drops one that does.  Refusing makes the misconfiguration
+ * visible instead.
+ *
+ * Guards both encoders: the CALL/ACCEPT payload (SRC + DST CRC16) and the CQ
+ * payload (SRC only). */
+void test_callsign_too_long_is_refused_not_truncated(void)
+{
+    uint8_t frame[INT_BUFFER_SIZE];
+
+    /* 15 chars: inside CALLSIGN_MAX_SIZE (16) so it is NOT truncated by the
+     * buffer copy, but past what ~5.25 bits/char fits in the 10-byte encoded
+     * SRC slot.  High-entropy characters so the arithmetic coder cannot pack
+     * it -- the boundary is bits, not characters, so a run of 'A's would still
+     * fit at this length. */
+    const char *too_long = "QZXJW9876543210";
+
+    TEST_ASSERT_LESS_THAN_INT(0, arq_protocol_build_call(frame, sizeof(frame),
+                                                         0x42, too_long,
+                                                         "PU2UIT-3", 2300));
+    TEST_ASSERT_LESS_THAN_INT(0, arq_protocol_build_accept(frame, sizeof(frame),
+                                                           0x42, too_long,
+                                                           "PU2UIT-3", 2300));
+    /* Not asserted for CQ: its SRC slot is 13 bytes (ARQ_CQ_SRC_MAX_ENCODED)
+     * against CALL/ACCEPT's 10, and the longest callsign that fits
+     * CALLSIGN_MAX_SIZE encodes to about 10 bytes -- so the CQ encoder cannot
+     * overflow for any input a caller can actually pass.  The refusal there is
+     * defensive, and asserting it would only pin an unreachable branch. */
+}
+
+/* Realistic callsigns must still round-trip exactly -- the refusal above must
+ * not have narrowed what legitimately fits. */
+void test_callsign_roundtrip_realistic(void)
+{
+    static const char *calls[] = { "PU2UIT", "PU2UIT-2", "DL9ABC-15",
+                                   "W1AW", "VK3ABC-9", "KO0OOO-2" };
+
+    for (unsigned i = 0; i < sizeof(calls) / sizeof(calls[0]); i++)
+    {
+        uint8_t frame[INT_BUFFER_SIZE];
+        int n = arq_protocol_build_call(frame, sizeof(frame), 0x21,
+                                        calls[i], "PU2UIT-3", 2300);
+        TEST_ASSERT_GREATER_THAN_INT(0, n);
+
+        uint8_t sid = 0;
+        char src[CALLSIGN_MAX_SIZE] = {0}, dst[CALLSIGN_MAX_SIZE] = {0};
+        int bw = 0;
+        TEST_ASSERT_GREATER_OR_EQUAL_INT(0,
+            arq_protocol_parse_call(frame, (size_t)n, &sid, src, dst, &bw));
+        TEST_ASSERT_EQUAL_UINT8(0x21, sid);
+        TEST_ASSERT_EQUAL_STRING(calls[i], src);
+    }
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -348,5 +406,8 @@ int main(void)
     RUN_TEST(test_call_interval_override);
     RUN_TEST(test_call_interval_reset);
     RUN_TEST(test_mode_timing_datac16_unaffected_by_override);
+
+    RUN_TEST(test_callsign_too_long_is_refused_not_truncated);
+    RUN_TEST(test_callsign_roundtrip_realistic);
     return UNITY_END();
 }

--- a/tests/sim/test_arq_sim.c
+++ b/tests/sim/test_arq_sim.c
@@ -320,8 +320,17 @@ void test_sim_fade_cliff_downgrades(void)
     sim_set_snr(s, -5.5);
 
     /* The floor moves ~22 user bytes per ~11 s cycle; give the remainder
-     * ample virtual time.  Before the fix this starved above the cliff. */
-    sim_run_until_idle(s, 3600000); /* up to 1 virtual hour */
+     * ample virtual time.  Before the fix this starved above the cliff.
+     *
+     * Two virtual hours, not one.  At one hour this test was fitted to
+     * seed 42: on unmodified trunk, seeds 43/44/45 all failed the integrity
+     * check with 13-15 kB of the 16 kB delivered, because 2 % frame loss over
+     * a floor that moves ~22 B per ~11 s cycle simply needs more time than the
+     * budget allowed for most draws.  Any change that shifts event timing
+     * reshuffles the channel's RNG sequence and tips it over, which makes the
+     * test read as a regression in whatever moved -- rather than as a budget
+     * that had no margin.  At two hours seeds 42-45 all pass. */
+    sim_run_until_idle(s, 7200000); /* up to 2 virtual hours */
 
     sim_verdict_t floor_v =
         sim_prop_mode_floor_reached(sim_a(s), FREEDV_MODE_DATAC15, 0);

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -8,7 +8,7 @@ ifeq ($(OS),Windows_NT)
 LDFLAGS += -lws2_32
 endif
 
-OUT = broadcast_test broadcast_diag_tx broadcast_diag_rx watterson_test acquire_vs_decode
+OUT = broadcast_test broadcast_diag_tx broadcast_diag_rx watterson_test acquire_vs_decode resampler_bench rxcost_bench
 
 # Default target
 all: $(OUT)
@@ -37,6 +37,13 @@ run: broadcast_test
 # failures from decode failures.  chanutil puts it on the project's own
 # Watterson channel so its numbers are comparable with other instruments'.
 acquire_vs_decode: acquire_vs_decode.c chanutil.c ../common/watterson.c
+	$(CC) $(CFLAGS) -o $@ $^ ../modem/freedv/libfreedvdata.a $(LDFLAGS) -lm
+
+# Perf instruments for issue #162 (idle CPU on a 48 kHz Pi 4).
+resampler_bench: resampler_bench.c ../audioio/resampler.c
+	$(CC) $(CFLAGS) -I../audioio -o $@ $^ $(LDFLAGS) -lm
+
+rxcost_bench: rxcost_bench.c
 	$(CC) $(CFLAGS) -o $@ $^ ../modem/freedv/libfreedvdata.a $(LDFLAGS) -lm
 
 .PHONY: all clean run

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -8,7 +8,16 @@ ifeq ($(OS),Windows_NT)
 LDFLAGS += -lws2_32
 endif
 
-OUT = broadcast_test broadcast_diag_tx broadcast_diag_rx watterson_test acquire_vs_decode resampler_bench rxcost_bench
+OUT = broadcast_test broadcast_diag_tx broadcast_diag_rx watterson_test acquire_vs_decode
+
+# CPU-cost instruments.  Linux/macOS only: they time with
+# clock_gettime(CLOCK_PROCESS_CPUTIME_ID), which mingw-w64 does not provide
+# (undefined reference to clock_gettime at link).  They are development tools
+# for profiling the RX path, so there is nothing to gain from porting them to
+# the Windows build -- just exclude them and keep the cross-compile green.
+ifneq ($(OS),Windows_NT)
+OUT += resampler_bench rxcost_bench
+endif
 
 # Default target
 all: $(OUT)

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -8,7 +8,7 @@ ifeq ($(OS),Windows_NT)
 LDFLAGS += -lws2_32
 endif
 
-OUT = broadcast_test broadcast_diag_tx broadcast_diag_rx watterson_test
+OUT = broadcast_test broadcast_diag_tx broadcast_diag_rx watterson_test acquire_vs_decode
 
 # Default target
 all: $(OUT)
@@ -32,5 +32,11 @@ clean:
 # Run the program
 run: broadcast_test
 	./broadcast_test 127.0.0.1 8300
+
+# Drives the real freedv OFDM modems (not a model) to separate acquisition
+# failures from decode failures.  chanutil puts it on the project's own
+# Watterson channel so its numbers are comparable with other instruments'.
+acquire_vs_decode: acquire_vs_decode.c chanutil.c ../common/watterson.c
+	$(CC) $(CFLAGS) -o $@ $^ ../modem/freedv/libfreedvdata.a $(LDFLAGS) -lm
 
 .PHONY: all clean run

--- a/utils/acquire_vs_decode.c
+++ b/utils/acquire_vs_decode.c
@@ -1,0 +1,276 @@
+/* acquire_vs_decode — for a freedv mode, is the fringe floor the PREAMBLE
+ * DETECTOR or the DECODER?
+ *
+ * The distinction decides where robustness work should go, and it is easy to
+ * assert from an energy budget and get wrong: a frame's implied Eb/N0 looks
+ * damningly high until you subtract cyclic prefix, pilot carriers,
+ * channel-estimation loss and short-code loss, each worth a dB or more.  This
+ * measures it instead.
+ *
+ * Per burst it records two independent outcomes:
+ *
+ *   acquired  - the demodulator reached FREEDV_RX_SYNC at some point
+ *   delivered - a frame came out with the CRC intact
+ *
+ * If delivered == acquired all the way down, the mode is acquisition-limited:
+ * everything that syncs decodes, and a better code buys nothing.  If bursts
+ * acquire but fail the CRC, it is decode-limited and the code (or the LLRs
+ * feeding it) is the lever.  docs/MFSK-PORT.md established the former for the
+ * MFSK mode by exactly this test; nothing had established it either way for
+ * the DATAC OFDM modes.
+ *
+ * AWGN only, and deliberately so: fading confounds the two (a fade during the
+ * preamble costs acquisition, a fade during the payload costs the decode), so
+ * the clean question is asked on the clean channel first.
+ *
+ * SNR is reported as SNR3k, the project's convention: noise power measured in
+ * a 3 kHz reference bandwidth, i.e. for real samples at fs, the full-band
+ * noise variance scaled by 3000/(fs/2).
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "freedv_api.h"
+#include "chanutil.h"
+
+#define FS 8000.0
+
+/* Peak the burst is normalised to before noise is added, leaving the rest of
+ * the int16 range as noise headroom.  ~18 dB below full scale. */
+#define HEADROOM_PEAK 4000.0
+
+static unsigned long long rng = 1357911131517ULL;
+
+static double urand(void)
+{
+    rng = rng * 6364136223846793005ULL + 1442695040888963407ULL;
+    return (double)((rng >> 11) & 0x1FFFFFFFFFFFFFULL) / (double)0x20000000000000ULL;
+}
+
+static double gauss(void)
+{
+    double u1 = urand(), u2 = urand();
+    if (u1 < 1e-300) u1 = 1e-300;
+    return sqrt(-2.0 * log(u1)) * cos(2.0 * M_PI * u2);
+}
+
+static int mode_from_name(const char *s)
+{
+    if (!strcmp(s, "DATAC16")) return FREEDV_MODE_DATAC16;
+    if (!strcmp(s, "DATAC15")) return FREEDV_MODE_DATAC15;
+    if (!strcmp(s, "DATAC13")) return FREEDV_MODE_DATAC13;
+    if (!strcmp(s, "DATAC4"))  return FREEDV_MODE_DATAC4;
+    if (!strcmp(s, "DATAC3"))  return FREEDV_MODE_DATAC3;
+    if (!strcmp(s, "DATAC1"))  return FREEDV_MODE_DATAC1;
+    if (!strcmp(s, "DATAC0"))  return FREEDV_MODE_DATAC0;
+    return -1;
+}
+
+int main(int argc, char **argv)
+{
+    const char *modename = (argc > 1) ? argv[1] : "DATAC16";
+    int    trials  = (argc > 2) ? atoi(argv[2]) : 100;
+    double snr_lo  = (argc > 3) ? atof(argv[3]) : -14.0;
+    double snr_hi  = (argc > 4) ? atof(argv[4]) : -4.0;
+    /* Optional 5th arg: a fading preset.  Under fading the delivered SNR is an
+     * OUTPUT of the channel, so the sweep axis becomes noise density and the
+     * achieved SNR3k is measured and reported per row. */
+    int    chan    = (argc > 5) ? chanutil_preset_from_name(argv[5]) : CHAN_AWGN;
+    if (chan < 0) { fprintf(stderr, "unknown channel '%s' (awgn|mpg|mpp|mpd)\n", argv[5]); return 1; }
+
+    int mode = mode_from_name(modename);
+    if (mode < 0 || trials <= 0)
+    {
+        fprintf(stderr, "usage: %s [MODE] [trials] [snr_lo] [snr_hi]\n"
+                        "  MODE: DATAC0/1/3/4/13/15/16 (default DATAC16)\n", argv[0]);
+        return 1;
+    }
+
+    struct freedv *tx = freedv_open(mode);
+    struct freedv *rx = freedv_open(mode);
+    if (!tx || !rx) { fprintf(stderr, "freedv_open failed\n"); return 1; }
+    freedv_set_frames_per_burst(tx, 1);
+    freedv_set_frames_per_burst(rx, 1);
+
+    int nbytes  = freedv_get_bits_per_modem_frame(tx) / 8;
+    int ntx     = freedv_get_n_tx_modem_samples(tx);
+    int npre    = freedv_get_n_tx_preamble_modem_samples(tx);
+    int npost   = freedv_get_n_tx_postamble_modem_samples(tx);
+    int nburst  = npre + ntx + npost;
+
+    printf("%s: %d byte frame, burst %d samples (%.2f s at %.0f Hz)\n",
+           modename, nbytes, nburst, nburst / FS, FS);
+    printf("channel: %s\n", chanutil_preset_name(chan));
+    printf("acquired = reached FREEDV_RX_SYNC;  delivered = frame out with CRC ok\n\n");
+    if (chan == CHAN_AWGN)
+        printf("  SNR3k    acquired   delivered   decoded|acquired\n");
+    else
+        printf("   No     SNR3k(meas)  acquired   delivered\n");
+
+    short *burst = malloc(sizeof(short) * (size_t)(nburst + 4));
+    unsigned char *payload = malloc((size_t)nbytes);
+    unsigned char *out     = malloc((size_t)nbytes + 8);
+    if (!burst || !payload || !out) return 1;
+
+    for (double snr = snr_lo; snr <= snr_hi + 0.01; snr += 1.0)
+    {
+        int acquired = 0, delivered = 0;
+        double snr_meas_sum = 0.0; int snr_meas_cnt = 0;
+        long clipped = 0, tot_samp = 0;
+
+        /* One channel per SNR point, warmed once, shared by every burst: the
+         * tap warm-up costs seconds of audio and doing it per burst made a
+         * sweep of this size take longer than it was worth.  It is also the
+         * more faithful model -- a real link is one continuous fading process,
+         * not an independent one per transmission. */
+        chanutil_t *ch = NULL;
+        if (chan != CHAN_AWGN)
+        {
+            ch = chanutil_open(chan, (float)snr, 1234u);
+            if (!ch) { fprintf(stderr, "chanutil_open failed\n"); return 1; }
+        }
+
+        for (int t = 0; t < trials; t++)
+        {
+            /* The raw-data API does not generate the CRC: the caller owns the
+             * last two bytes of the frame, exactly as modem.c does.  Without
+             * this every burst decodes and every burst is then rejected, which
+             * looks precisely like a mode that never delivers. */
+            for (int i = 0; i < nbytes - 2; i++)
+                payload[i] = (unsigned char)(urand() * 256.0);
+            unsigned short crc16 = freedv_gen_crc16(payload, nbytes - 2);
+            payload[nbytes - 2] = (unsigned char)(crc16 >> 8);
+            payload[nbytes - 1] = (unsigned char)(crc16 & 0xff);
+
+            int n = 0;
+            n += freedv_rawdatapreambletx(tx, burst + n);
+            freedv_rawdatatx(tx, burst + n, payload);
+            n += ntx;
+            n += freedv_rawdatapostambletx(tx, burst + n);
+
+            /* Signal power over the burst, then the noise sigma that puts the
+             * 3 kHz-referenced SNR where we want it. */
+            double ps = 0.0, pk = 0.0;
+            for (int i = 0; i < n; i++)
+            {
+                ps += (double)burst[i] * burst[i];
+                if (fabs((double)burst[i]) > pk) pk = fabs((double)burst[i]);
+            }
+            ps /= n;
+            /* SNR3k = ps / (sigma^2 * 3000/(FS/2)) */
+            double sigma = sqrt(ps / (pow(10.0, snr / 10.0) * (3000.0 / (FS / 2.0))));
+
+            /* HEADROOM.  freedv emits DATAC16 at rms ~8000 / peak ~16400, so at
+             * fringe SNRs -- where the noise rms is a couple of times the
+             * signal -- signal+noise runs straight into the int16 rail.
+             * Measured 23 % of samples clipped, which quietly delivered
+             * -7.1 dB when -9.0 was asked for, and cost more in distortion
+             * than the extra SNR gave back.
+             *
+             * Normalise the burst to a fixed low level and leave the rest of
+             * the int16 range for noise.  Deliberately NOT a gain derived from
+             * the noise level: that feeds back (the gain changes the noise
+             * setting, which changes the gain) and pinned the measured SNR
+             * regardless of what was asked for. */
+            {
+                double gnorm = (pk > 0.0) ? (HEADROOM_PEAK / pk) : 1.0;
+                for (int i = 0; i < n; i++)
+                    burst[i] = (short)lrint((double)burst[i] * gnorm);
+                ps    *= gnorm * gnorm;
+                sigma *= gnorm;
+            }
+
+            if (chan == CHAN_AWGN)
+            {
+                for (int i = 0; i < n; i++)
+                {
+                    double v = burst[i] + sigma * gauss();
+                    if (v >  32767.0) v =  32767.0;
+                    else if (v < -32768.0) v = -32768.0;
+                    else goto no_clip;
+                    clipped++;
+                no_clip:
+                    burst[i] = (short)lrint(v);
+                }
+            }
+            else
+            {
+                /* `snr` is the noise density No here; the channel adds its own
+                 * noise on top of the already-normalised burst. */
+                float meas = 0.0f;
+                chanutil_run(ch, (int16_t *)burst, n, &meas);
+                for (int i = 0; i < n; i++)
+                    if (burst[i] >= 32767 || burst[i] <= -32768) clipped++;
+                snr_meas_sum += meas;
+                snr_meas_cnt++;
+                /* The tail is plain noise at a comparable level. */
+                sigma = sqrt(ps / (pow(10.0, meas / 10.0) * (3000.0 / (FS / 2.0))));
+            }
+
+            /* Feed the burst plus a tail of pure noise, honouring nin. */
+            freedv_set_sync(rx, FREEDV_SYNC_UNSYNC);
+            int pos = 0, saw_sync = 0, got = 0;
+            int tail = nburst;                 /* let sync/decode complete */
+            while (pos < n + tail)
+            {
+                int nin = freedv_nin(rx);
+                short chunk[8192];
+                if (nin > (int)(sizeof(chunk) / sizeof(chunk[0]))) break;
+                for (int i = 0; i < nin; i++)
+                {
+                    if (pos + i < n) chunk[i] = burst[pos + i];
+                    else {
+                        double v = sigma * gauss();
+                        if (v >  32767.0) v =  32767.0;
+                        if (v < -32768.0) v = -32768.0;
+                        chunk[i] = (short)lrint(v);
+                    }
+                }
+                pos += nin;
+
+                int nb = (int)freedv_rawdatarx(rx, out, chunk);
+                int st = freedv_get_rx_status(rx);
+                /* Full sync only.  TRIAL_SYNC fires on noise at deep SNR, so
+                 * counting it reports false alarms as acquisitions and makes
+                 * the mode look acquisition-limited when it is not. */
+                if (st & FREEDV_RX_SYNC) saw_sync = 1;
+                if (nb > 0 && !(st & FREEDV_RX_BIT_ERRORS)) got = 1;
+            }
+
+            tot_samp += n;
+            if (saw_sync) acquired++;
+            if (got)      delivered++;
+        }
+
+        if (ch) chanutil_close(ch);
+
+        if (chan == CHAN_AWGN)
+        {
+            printf("  %+5.1f     %3d/%-3d     %3d/%-3d      %s  clip %.2f%%\n",
+                   snr, acquired, trials, delivered, trials,
+                   acquired ? (delivered == acquired ? "1.00 (all)" : "") : "-",
+                   tot_samp ? 100.0 * (double)clipped / (double)tot_samp : 0.0);
+            if (delivered != acquired && acquired)
+                printf("            ^ %d burst(s) acquired but failed the CRC\n",
+                       acquired - delivered);
+        }
+        else
+        {
+            printf("  %+6.1f    %+6.2f     %3d/%-3d     %3d/%-3d   clip %.2f%%\n",
+                   snr, snr_meas_cnt ? snr_meas_sum / snr_meas_cnt : 0.0,
+                   acquired, trials, delivered, trials,
+                   tot_samp ? 100.0 * (double)clipped / (double)tot_samp : 0.0);
+        }
+    }
+
+    freedv_close(tx);
+    freedv_close(rx);
+    free(burst); free(payload); free(out);
+    return 0;
+}

--- a/utils/chanutil.c
+++ b/utils/chanutil.c
@@ -1,0 +1,219 @@
+/* chanutil — see chanutil.h.
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "chanutil.h"
+#include "common/watterson.h"
+#include "modem/freedv/comp.h"
+#include "modem/freedv/ht_coeff.h"
+
+#define CHAN_FS 8000
+
+struct chanutil { watterson_t w; };
+
+int chanutil_preset_from_name(const char *s)
+{
+    if (!s) return -1;
+    if (!strcmp(s, "awgn") || !strcmp(s, "AWGN")) return CHAN_AWGN;
+    if (!strcmp(s, "mpp")  || !strcmp(s, "MPP"))  return CHAN_MPP;
+    if (!strcmp(s, "mpg")  || !strcmp(s, "MPG"))  return CHAN_MPG;
+    if (!strcmp(s, "mpd")  || !strcmp(s, "MPD"))  return CHAN_MPD;
+    if (!strcmp(s, "awgnc"))                      return CHAN_AWGN_C;
+    return -1;
+}
+
+const char *chanutil_preset_name(int preset)
+{
+    switch (preset)
+    {
+    case CHAN_AWGN:   return "AWGN";
+    case CHAN_MPP:    return "MPP (2 path, 1.0 ms, 1.0 Hz)";
+    case CHAN_MPG:    return "MPG (2 path, 0.5 ms, 0.1 Hz)";
+    case CHAN_MPD:    return "MPD (2 path, 2.0 ms, 2.0 Hz)";
+    case CHAN_AWGN_C: return "AWGN via the complex pipeline (calibration)";
+    default:          return "?";
+    }
+}
+
+static int add_paths(watterson_t *w, int preset)
+{
+    switch (preset)
+    {
+    case CHAN_AWGN:
+    case CHAN_AWGN_C:
+        /* One static unit-gain path: no fading, but keep the same code path so
+         * the AWGN and faded rows are produced by identical machinery. */
+        return watterson_add_path(w, 0.0f, 0.0f, 0.0f, 1.0f) < 0 ? -1 : 0;
+    case CHAN_MPG:
+        if (watterson_add_path(w, 0.0f, 0.1f, 0.0f, 0.7f) < 0) return -1;
+        if (watterson_add_path(w, 0.5f, 0.1f, 0.0f, 0.7f) < 0) return -1;
+        return 0;
+    case CHAN_MPP:
+        if (watterson_add_path(w, 0.0f, 1.0f, 0.0f, 0.7f) < 0) return -1;
+        if (watterson_add_path(w, 1.0f, 1.0f, 0.0f, 0.7f) < 0) return -1;
+        return 0;
+    case CHAN_MPD:
+        if (watterson_add_path(w, 0.0f, 2.0f, 0.0f, 0.7f) < 0) return -1;
+        if (watterson_add_path(w, 2.0f, 2.0f, 0.0f, 0.7f) < 0) return -1;
+        return 0;
+    default:
+        return -1;
+    }
+}
+
+/* Settle the Doppler taps before any burst is presented.
+ *
+ * watterson_init() zeroes the tap IIR state, and the taps are produced by
+ * filtering the model's own white noise -- so they START AT ZERO and ramp to
+ * their steady-state distribution over a few filter time constants.  A burst
+ * handed to a fresh channel therefore opens inside an artificial deep fade,
+ * which is exactly where its preamble is, so the damage lands on acquisition
+ * and reads as a catastrophically bad mode.  Measured: DATAC16 on MPP showed
+ * 10 % delivered at -7.3 dB against the 67 % in docs/MODES.md until the taps
+ * were warmed first.
+ *
+ * Zeros are the right warm-up input -- the tap generator does not depend on
+ * the signal -- and the measurement accumulators are reset afterwards so the
+ * warm-up's noise does not enter the reported SNR. */
+static void warm_up(watterson_t *w)
+{
+    float min_doppler = 1e9f;
+    for (int p = 0; p < w->num_paths; p++)
+        if (w->paths[p].doppler_hz > 0.0f && w->paths[p].doppler_hz < min_doppler)
+            min_doppler = w->paths[p].doppler_hz;
+
+    if (min_doppler > 1e8f) return;          /* no fading path: nothing to settle */
+
+    double warm_s = 5.0 / (double)min_doppler;
+    if (warm_s < 2.0)  warm_s = 2.0;
+    if (warm_s > 20.0) warm_s = 20.0;
+
+    int   warm_n = (int)(warm_s * CHAN_FS);
+    COMP *warm   = calloc((size_t)warm_n, sizeof(COMP));
+    if (warm)
+    {
+        watterson_process(w, warm, warm_n);
+        free(warm);
+    }
+    watterson_reset_meas(w);
+}
+
+chanutil_t *chanutil_open(int preset, float no_dbhz, unsigned seed)
+{
+    chanutil_t *c = calloc(1, sizeof(*c));
+    if (!c) return NULL;
+    if (watterson_init(&c->w, CHAN_FS) != 0) { free(c); return NULL; }
+    if (add_paths(&c->w, preset) < 0)
+    {
+        watterson_dispose(&c->w);
+        free(c);
+        return NULL;
+    }
+    watterson_set_noise(&c->w, no_dbhz);
+    watterson_reset_meas(&c->w);
+
+    /* The fading realisation is driven by the model's own RNG; seeding here
+     * makes a sweep reproducible. */
+    srand(seed);
+    warm_up(&c->w);
+    return c;
+}
+
+void chanutil_close(chanutil_t *c)
+{
+    if (!c) return;
+    watterson_dispose(&c->w);
+    free(c);
+}
+
+int chanutil_run(chanutil_t *c, int16_t *pb, int n, float *snr3k_out)
+{
+    if (!c || !pb || n <= 0) return -1;
+
+    /* The Hilbert FIR has HT_N taps and therefore a group delay of HT_N/2.
+     * Producing only n outputs for n inputs would (a) shift the burst late by
+     * that delay and (b) silently DROP its last HT_N/2 samples, whose filter
+     * response lands past the end of the buffer.  On a burst whose preamble is
+     * only 880 samples that is not a rounding error, and it lands on
+     * acquisition -- which is what sets DATAC16's floor.  So run the filter
+     * over a padded buffer and hand back the delay-compensated middle,
+     * sample-aligned with the input. */
+    const int lat   = HT_N / 2;
+    const int ext_n = n + HT_N;
+
+    COMP  *cx    = calloc((size_t)ext_n, sizeof(COMP));
+    float *htbuf = calloc((size_t)(ext_n + HT_N), sizeof(float));
+    if (!cx || !htbuf) { free(cx); free(htbuf); return -1; }
+
+    /* Real passband -> analytic signal (Hilbert), as watterson_test.c does.
+     * Feeding the real samples in as COMP{real,0} instead would apply the
+     * complex channel gain to both sidebands, which is not what a fading HF
+     * path does to an SSB signal. */
+    for (int i = 0; i < n; i++) htbuf[HT_N + i] = (float)pb[i];
+    for (int i = 0; i < ext_n; i++)
+    {
+        int   j  = HT_N + i;
+        float re = 0.0f, im = 0.0f;
+        for (int k = 0; k < HT_N; k++)
+        {
+            re += htbuf[j - k] * ht_coeff[k].real;
+            im += htbuf[j - k] * ht_coeff[k].imag;
+        }
+        cx[i].real = re;
+        cx[i].imag = im;
+    }
+
+    watterson_reset_meas(&c->w);
+    watterson_process(&c->w, cx, ext_n);
+
+    for (int i = 0; i < n; i++)
+    {
+        float s = cx[i + lat].real;
+        if (s >  32767.0f) s =  32767.0f;
+        if (s < -32768.0f) s = -32768.0f;
+        pb[i] = (int16_t)lrintf(s);
+    }
+
+    /* watterson_measured_snr3k() is 3.01 dB optimistic for a REAL-output path,
+     * and the correction is exact rather than a fudge.
+     *
+     * The model measures Psig on the signal it was handed -- the analytic
+     * signal, whose power is 2P for a real signal of power P, since
+     * E[x^2] = E[H{x}^2] = P.  We then hand the modem Re{}, which is x, of
+     * power P.  Taking the real part leaves the noise power spectral density
+     * unchanged (complex noise of power nvar over Fs has the same PSD as its
+     * real part, power nvar/2 over Fs/2), so the noise term is right and only
+     * the signal term is doubled.  Hence exactly a factor of two.
+     *
+     * Verified against the harness's own direct real-domain AWGN path, which
+     * hits its requested SNR to 0.01 dB: before this correction the same mode
+     * at the same nominal SNR read 3.00 dB apart between the two paths.
+     *
+     * Corrected here rather than in common/watterson.c on purpose -- the
+     * model's convention is right for the complex-domain use it was written
+     * and calibrated for, and changing it would silently move every other
+     * measurement that depends on it. */
+    if (snr3k_out)
+        *snr3k_out = watterson_measured_snr3k(&c->w) - 3.01f;
+
+    free(cx);
+    free(htbuf);
+    return 0;
+}
+
+int chanutil_fade(int16_t *pb, int n, int preset, float no_dbhz,
+                  unsigned seed, float *snr3k_out)
+{
+    chanutil_t *c = chanutil_open(preset, no_dbhz, seed);
+    if (!c) return -1;
+    int rc = chanutil_run(c, pb, n, snr3k_out);
+    chanutil_close(c);
+    return rc;
+}

--- a/utils/chanutil.h
+++ b/utils/chanutil.h
@@ -1,0 +1,70 @@
+/* chanutil — route a real int16 passband burst through the project's own
+ * Watterson channel (common/watterson.c), so different instruments measure
+ * different waveforms on the SAME validated channel.
+ *
+ * Every harness that rolls its own fading model produces numbers that cannot
+ * be compared with any other harness's.  This exists so the directed-pattern
+ * ACCEPT and the DATAC16 ACCEPT it would replace can be put on one axis.
+ *
+ * The signal path mirrors utils/watterson_test.c: Hilbert transform to an
+ * analytic signal, Watterson (multipath + Doppler + AWGN), then the real part.
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef MERCURY_CHANUTIL_H
+#define MERCURY_CHANUTIL_H
+
+#include <stdint.h>
+
+/* Channel presets, named as docs/MODES.md names them. */
+typedef enum {
+    CHAN_AWGN = 0,      /* no fading, AWGN only                        */
+    CHAN_MPP,           /* ITU "moderate": 2 paths, 1 ms, 1.0 Hz       */
+    CHAN_MPG,           /* ITU "good"/calm NVIS: 2 paths, 0.5 ms, 0.1 Hz */
+    CHAN_MPD,           /* ITU "disturbed": 2 paths, 2 ms, 2.0 Hz      */
+    /* Calibration only: AWGN over a single STATIC path, i.e. the same
+     * Hilbert -> Watterson -> Re{} pipeline as the fading presets but with no
+     * fading.  Compare against a harness's own direct real-domain AWGN: any
+     * difference is this pipeline's calibration error, not the channel's. */
+    CHAN_AWGN_C
+} chan_preset_t;
+
+int chanutil_preset_from_name(const char *s);   /* -1 if unknown */
+const char *chanutil_preset_name(int preset);
+
+/* Persistent channel.
+ *
+ * The one-shot call below re-initialises the model per burst, which costs a
+ * tap warm-up EVERY time (seconds of audio at low Doppler) and makes a sweep
+ * of any size infeasible: 50 trials x 7 points was ~47 minutes of warm-up
+ * before a single FFT.  It is also less realistic -- a real link presents ONE
+ * continuous fading process, not an independent one per burst.  Open a channel
+ * once, warm it once, then run every burst of the sweep through it.
+ */
+typedef struct chanutil chanutil_t;
+
+chanutil_t *chanutil_open(int preset, float no_dbhz, unsigned seed);
+void        chanutil_close(chanutil_t *c);
+
+/* Fade + noise one burst through an already-warmed channel. */
+int chanutil_run(chanutil_t *c, int16_t *pb, int n, float *snr3k_out);
+
+/* Fade + noise `pb[0..n)` in place.  Convenience wrapper: opens, warms,
+ * runs and closes.  Fine for a handful of bursts, far too slow for a sweep.
+ *
+ * `no_dbhz` is the AWGN noise density the Watterson model uses.  SNR is an
+ * OUTPUT, not an input: the achieved 3 kHz-referenced SNR is written to
+ * *snr3k_out (measured by the model from the actual faded signal and added
+ * noise powers), because under fading the delivered SNR is not something the
+ * caller can dial directly.
+ *
+ * `seed` selects the fading realisation, so a sweep can hold the channel fixed
+ * across waveforms or vary it per trial.
+ *
+ * Returns 0 on success, -1 on error. */
+int chanutil_fade(int16_t *pb, int n, int preset, float no_dbhz,
+                  unsigned seed, float *snr3k_out);
+
+#endif /* MERCURY_CHANUTIL_H */

--- a/utils/resampler_bench.c
+++ b/utils/resampler_bench.c
@@ -1,0 +1,93 @@
+/* resampler_bench — how much CPU does the 48 kHz <-> 8 kHz conversion cost?
+ *
+ * Mercury's own bench and both field stations run their sound cards at 8 kHz,
+ * where resamp_*_process() takes a memcpy fast path and costs nothing.  A USB
+ * codec locked to 48 kHz does not: every captured sample goes through a
+ * 180-tap history, and that path had never been measured.  Issue #162 reported
+ * 100 % CPU and "RX backlog exceeded ~2 s cap" on a Pi 4 with a 48 kHz codec,
+ * with the backlog starting before any client connected or any session existed
+ * -- i.e. in the idle capture path.
+ *
+ * Reports CPU time per second of audio, which is the number that matters: the
+ * capture direction must stay well under 100 % of one core on the slowest
+ * supported host or the RX ring falls behind in real time.
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <math.h>
+
+#include "resampler.h"
+
+static double now_cpu_s(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts);
+    return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
+}
+
+int main(int argc, char **argv)
+{
+    int rate    = (argc > 1) ? atoi(argv[1]) : 48000;
+    int seconds = (argc > 2) ? atoi(argv[2]) : 20;
+
+    int L = resampler_ratio_for_rate(rate);
+    if (L <= 0) { fprintf(stderr, "unsupported rate %d\n", rate); return 1; }
+
+    resampler_global_init();
+    resampler_init_down(L);
+    resampler_init_up(L);
+
+    /* One ALSA period's worth at a time, as audioio does. */
+    const int chunk_dev = rate / 100;           /* 10 ms of device-rate audio */
+    const int chunk_mod = RESAMP_MODEM_FS / 100;
+
+    int32_t *in_dev  = malloc(sizeof(int32_t) * (size_t)chunk_dev);
+    int32_t *out_mod = malloc(sizeof(int32_t) * (size_t)(chunk_dev + 64));
+    int32_t *in_mod  = malloc(sizeof(int32_t) * (size_t)chunk_mod);
+    int32_t *out_dev = malloc(sizeof(int32_t) * (size_t)(chunk_mod * L + 64));
+    if (!in_dev || !out_mod || !in_mod || !out_dev) return 1;
+
+    for (int i = 0; i < chunk_dev; i++)
+        in_dev[i] = (int32_t)(20000.0 * sin(2.0 * M_PI * 1000.0 * i / rate));
+    for (int i = 0; i < chunk_mod; i++)
+        in_mod[i] = (int32_t)(20000.0 * sin(2.0 * M_PI * 1000.0 * i / RESAMP_MODEM_FS));
+
+    printf("device rate %d Hz (L=%d, %d taps)  |  %d s of audio\n\n",
+           rate, L, L * RESAMP_TAPS_PER_PHASE, seconds);
+
+    /* ---- capture direction: device rate -> 8 kHz ---- */
+    {
+        resamp_down_t d;
+        resamp_down_reset(&d);
+        int iters = seconds * 100;
+        double t0 = now_cpu_s();
+        for (int i = 0; i < iters; i++)
+            resamp_down_process(&d, in_dev, chunk_dev, out_mod);
+        double dt = now_cpu_s() - t0;
+        printf("  capture  (down): %7.3f s CPU for %d s audio  = %6.2f %% of one core\n",
+               dt, seconds, 100.0 * dt / seconds);
+    }
+
+    /* ---- playback direction: 8 kHz -> device rate ---- */
+    {
+        resamp_up_t u;
+        resamp_up_reset(&u);
+        int iters = seconds * 100;
+        double t0 = now_cpu_s();
+        for (int i = 0; i < iters; i++)
+            resamp_up_process(&u, in_mod, chunk_mod, out_dev);
+        double dt = now_cpu_s() - t0;
+        printf("  playback (up)  : %7.3f s CPU for %d s audio  = %6.2f %% of one core\n",
+               dt, seconds, 100.0 * dt / seconds);
+    }
+
+    printf("\n  (capture runs continuously; playback only while transmitting)\n");
+    free(in_dev); free(out_mod); free(in_mod); free(out_dev);
+    return 0;
+}

--- a/utils/rxcost_bench.c
+++ b/utils/rxcost_bench.c
@@ -1,0 +1,116 @@
+/* rxcost_bench — what does the idle RX chain actually cost per second of audio?
+ *
+ * Issue #162: 100 % CPU and "RX backlog exceeded ~2 s cap" on a Pi 4, with the
+ * backlog appearing BEFORE any client connected and before any ARQ session
+ * existed.  That rules out the ARQ layer and points at whatever the capture
+ * path does on every chunk regardless of state.
+ *
+ * Mercury runs a decoder per plane when split control/data mode switching is
+ * enabled, so an idle station demodulates its control mode AND its payload
+ * mode over the same samples, continuously, searching for a preamble that is
+ * not there.  This measures that, per mode and combined, as a percentage of
+ * one core -- the figure that decides whether the RX ring keeps up in real
+ * time.
+ *
+ * Feed it noise, which is the honest idle case: a decoder that never syncs
+ * does the most search work.
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <math.h>
+
+#include "freedv_api.h"
+
+#define FS 8000
+
+static double now_cpu_s(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts);
+    return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
+}
+
+static unsigned long long rg = 7777;
+static double ur(void)
+{
+    rg = rg * 6364136223846793005ULL + 1442695040888963407ULL;
+    return (double)((rg >> 11) & 0x1FFFFFFFFFFFFFULL) / (double)0x20000000000000ULL;
+}
+
+static int mode_of(const char *s)
+{
+    if (!strcmp(s, "DATAC16")) return FREEDV_MODE_DATAC16;
+    if (!strcmp(s, "DATAC15")) return FREEDV_MODE_DATAC15;
+    if (!strcmp(s, "DATAC13")) return FREEDV_MODE_DATAC13;
+    if (!strcmp(s, "DATAC4"))  return FREEDV_MODE_DATAC4;
+    if (!strcmp(s, "DATAC3"))  return FREEDV_MODE_DATAC3;
+    if (!strcmp(s, "DATAC1"))  return FREEDV_MODE_DATAC1;
+    if (!strcmp(s, "DATAC0"))  return FREEDV_MODE_DATAC0;
+    return -1;
+}
+
+/* Seconds of CPU burned demodulating `seconds` of noise in one mode. */
+static double cost_of(const char *name, int seconds)
+{
+    int m = mode_of(name);
+    if (m < 0) { fprintf(stderr, "unknown mode %s\n", name); exit(1); }
+
+    struct freedv *f = freedv_open(m);
+    if (!f) { fprintf(stderr, "freedv_open(%s) failed\n", name); exit(1); }
+    freedv_set_frames_per_burst(f, 1);
+
+    int nbytes = freedv_get_bits_per_modem_frame(f) / 8;
+    unsigned char *out = malloc((size_t)nbytes + 16);
+    short chunk[16384];
+
+    long fed = 0;
+    long need = (long)seconds * FS;
+    double t0 = now_cpu_s();
+    while (fed < need)
+    {
+        int nin = freedv_nin(f);
+        if (nin <= 0 || nin > (int)(sizeof(chunk) / sizeof(chunk[0]))) break;
+        for (int i = 0; i < nin; i++)
+            chunk[i] = (short)((ur() - 0.5) * 6000.0);
+        freedv_rawdatarx(f, out, chunk);
+        fed += nin;
+    }
+    double dt = now_cpu_s() - t0;
+
+    free(out);
+    freedv_close(f);
+    return dt;
+}
+
+int main(int argc, char **argv)
+{
+    int seconds = (argc > 1) ? atoi(argv[1]) : 20;
+
+    static const char *modes[] = { "DATAC16", "DATAC15", "DATAC13",
+                                   "DATAC4", "DATAC3", "DATAC1" };
+
+    printf("Idle RX demod cost, %d s of noise per mode\n", seconds);
+    printf("(a decoder that never syncs does the most search work)\n\n");
+    printf("  mode       CPU s   %% of one core\n");
+
+    double c16 = 0.0, c3 = 0.0;
+    for (unsigned i = 0; i < sizeof(modes) / sizeof(modes[0]); i++)
+    {
+        double dt = cost_of(modes[i], seconds);
+        printf("  %-9s %7.3f   %8.2f %%\n", modes[i], dt, 100.0 * dt / seconds);
+        if (!strcmp(modes[i], "DATAC16")) c16 = dt;
+        if (!strcmp(modes[i], "DATAC3"))  c3  = dt;
+    }
+
+    printf("\n  dual decoder as issue #162 runs it (DATAC16 control + DATAC3 payload):\n");
+    printf("    %.2f %% of one core on THIS machine\n", 100.0 * (c16 + c3) / seconds);
+    printf("    a Pi 4 core is roughly 5-10x slower than a modern x86 core,\n"
+           "    so scale accordingly before drawing a conclusion.\n");
+    return 0;
+}


### PR DESCRIPTION
Four fixes for 1.9.12, each independently gated, no on-air format change. All
three code fixes were verified present on `mercuryv2` before being written, and
each carries a test verified to fail without it.

### 1. Silent callsign truncation (user-visible correctness)

`encode_callsign_payload` clamped an over-long arithmetic code to fit and
reported success. A truncated arithmetic code is not a shortened callsign — it
decodes to a **different** one, so the station transmits under a callsign that
is not its own and the peer answers a call from a station that does not exist,
or drops one that does. Both encoders now refuse; `send_call_accept` logs why,
so a CALL that never goes out is not silent.

Reachable boundary is narrow but real: 15 high-entropy characters (inside
`CALLSIGN_MAX_SIZE`, past what 10 bytes hold). Not asserted for CQ — its slot is
13 bytes, so that branch is unreachable for any input a caller can pass.

### 2. CALL retry anchored to PTT-OFF

`fsm_calling` had no `ARQ_EV_TX_COMPLETE` handler, so the retry interval was
measured from when the CALL was *queued*. The CALL occupies ~3.7 s of DATAC16
airtime and the peer cannot begin its ACCEPT until our transmitter releases —
so the retransmission fired at roughly the moment the ACCEPT was arriving,
keying the transmitter on top of the reply, on essentially every connect.
`fsm_accepting` already anchors on `TX_COMPLETE`; this mirrors it.

On the rewritten FSM used by the MFSK work this took clean connects from 4.0 to
3.0 frames and lifted PER-0.5 success from 10/24 to 15/24. **Those numbers are
not claimed for this FSM** — different state machine — but the collision removed
is the same, and it is systematic rather than occasional.

### 3. Watterson Doppler filter in double (simulation correctness)

The per-path Butterworth kept state and coefficients in `float`. At a high
sample rate with slow Doppler the poles sit within ~1e-4 of the unit circle,
where float resolution is enough to push one outside: the filter grows instead
of fading. Two paths at 1 Hz gave a sane −8.37 dB at 8 kHz and **+65.76 dB at
48 kHz**. Nothing on the air uses this, and Mercury's own bench runs at 8 kHz,
but it silently corrupts any fading measurement taken higher — which is where
mode comparisons come from.

### 4. `utils/acquire_vs_decode` — separates acquisition from decode

Records, per burst, whether the demodulator reached `FREEDV_RX_SYNC` and whether
a frame emerged CRC-intact. Answers a question `docs/MODES.md` only addressed for
the high-SNR plateau: **DATAC16's fringe floor is set by acquisition.**
Acquisition falls 99 → 52 → 7 per 100 between −9 and −13 dB while frames that
sync still decode 92–99 % down to −11 dB. Agrees with the independent AWGN table
already in that document (98 vs 96 at −9 dB, 78 vs 82 at −10, 48 vs 52 at −11).

`chanutil` puts it on the project's own Watterson model so instruments are
mutually comparable, and carries three measurement fixes: burst normalisation
before noise (23 % of samples were clipping, delivering −7.1 dB when −9.0 was
requested), Doppler tap warm-up (a fresh channel opens in an artificial deep
fade, right where the preamble is), and a 3.01 dB correction for real-output
paths (`watterson_measured_snr3k` measures the analytic signal's power, 2P,
while the modem receives `Re{}`, P). `CHAN_AWGN_C` exists to keep it honest: it
must agree with direct real-domain AWGN, and did not until those were fixed.

### 5. `tests/sim` fade-cliff test was fitted to one seed

Found while gating fix 2. At its 1-hour virtual budget the test passes only on
seed 42 — on **unmodified trunk**, seeds 43/44/45 all fail with 13–15 kB of
16 kB delivered. Because the channel RNG is consumed per scheduled frame, any
timing change reshuffles the draw and the test reports a length mismatch, which
reads as a regression in whatever moved. It did that here to fix 2, whose effect
cannot reach the data phase — and note the *property* assertion
(`mode_floor_reached`) still passed; only "finished inside the hour" did not.
Raised to two hours; verified seeds 42–45 all pass on unmodified trunk.

### Deliberately not included

The MFSK weak-signal backend, the delivery-driven data-plane rewrite, pattern
ACK and the 0.64 s connect confirm — ~20 k lines, changes the on-air format,
replaces OLLA, and has had no OTA run. That is major-version work, not a point
release. Its two sibling instruments (`shortframe_sweep`, `hail_suffix_sweep`)
are also excluded: they need `modem/mfsk*.c`, which does not exist here.

### Gate

`make` clean, `utils` clean, unit suite green, `go test -count=1 ./...` green
(230 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
