### PR TITLE
audioio: enable the OSS backend on Linux (OSSv4), and fix device selection around it

### DIFF
--- a/audioio/Makefile
+++ b/audioio/Makefile
@@ -29,6 +29,7 @@ else
     ifeq ($(UNAME_S),Linux)
                OBJS += ffaudio/ffaudio/pulse.o
                OBJS += ffaudio/ffaudio/alsa.o
+               OBJS += ffaudio/ffaudio/oss.o
     endif
     ifeq ($(UNAME_S),Darwin)
                OBJS=ffaudio/ffaudio/coreaudio.o
@@ -61,6 +62,9 @@ ffaudio/ffaudio/wasapi.o: ffaudio/ffaudio/wasapi.c
 
 ffaudio/ffaudio/alsa.o: ffaudio/ffaudio/alsa.c
 	$(CC) $(CFLAGS) -std=gnu11 -c ffaudio/ffaudio/alsa.c -o ffaudio/ffaudio/alsa.o
+
+ffaudio/ffaudio/oss.o: ffaudio/ffaudio/oss.c
+	$(CC) $(CFLAGS) -std=gnu11 -c ffaudio/ffaudio/oss.c -o ffaudio/ffaudio/oss.o
 
 audioio.o: audioio.c std.h $(OBJS)
 	$(CC) $(CFLAGS) -std=gnu11 -c audioio.c -o audioio.o

--- a/audioio/Makefile
+++ b/audioio/Makefile
@@ -29,7 +29,19 @@ else
     ifeq ($(UNAME_S),Linux)
                OBJS += ffaudio/ffaudio/pulse.o
                OBJS += ffaudio/ffaudio/alsa.o
+               # ffaudio's OSS backend needs the OSSv4 API (oss_audioinfo,
+               # SNDCTL_AUDIOINFO_EX, SNDCTL_DSP_HALT ...).  Stock Linux ships
+               # only the OSS3 stub in linux/soundcard.h, which lacks all of
+               # them -- oss.c cannot compile there.  The OSSv4 headers arrive
+               # with 4Front OSS (oss4-dev on Debian, which *diverts*
+               # linux/soundcard.h), so probe for the API instead of guessing
+               # from the OS.  No OSSv4 -> no OSS backend, and audioio.c
+               # reports the subsystem as unavailable at runtime.
+               HAVE_OSS4 := $(shell $(CC) -fsyntax-only oss4-probe.c >/dev/null 2>&1 && echo 1)
+        ifeq ($(HAVE_OSS4),1)
                OBJS += ffaudio/ffaudio/oss.o
+               OSS_CFLAGS = -DHAVE_OSS4
+        endif
     endif
     ifeq ($(UNAME_S),Darwin)
                OBJS=ffaudio/ffaudio/coreaudio.o
@@ -40,7 +52,7 @@ else
 endif
 
 
-CFLAGS = $(COMMON_CFLAGS) -Wno-unused -I./ffbase/ -I./ffaudio/ -I../common
+CFLAGS = $(COMMON_CFLAGS) -Wno-unused -I./ffbase/ -I./ffaudio/ -I../common $(OSS_CFLAGS)
 
 LDFLAGS=$(FFAUDIO_LINKFLAGS)
 

--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -174,7 +174,7 @@ int audioio_pick_default_subsystem(void)
     return AUDIO_SUBSYSTEM_ALSA;
 #elif defined(_WIN32)
     return AUDIO_SUBSYSTEM_WASAPI;
-#elif defined(__FREEBSD__)
+#elif defined(__FreeBSD__)
     return AUDIO_SUBSYSTEM_OSS;
 #elif defined(__APPLE__)
     return AUDIO_SUBSYSTEM_COREAUDIO;
@@ -729,7 +729,7 @@ static const char *sock_resolve_path(void)
 
 void *radio_playback_thread(void *device_ptr)
 {
-    ffaudio_interface *audio;
+    ffaudio_interface *audio = NULL;
     struct conf conf = {};
     conf.buf.app_name = "mercury_playback";
     conf.buf.format = FFAUDIO_F_INT32;
@@ -754,7 +754,17 @@ void *radio_playback_thread(void *device_ptr)
         audio = (ffaudio_interface *) &ffalsa;
     if (audio_subsystem == AUDIO_SUBSYSTEM_PULSE)
         audio = (ffaudio_interface *) &ffpulse;
-#elif defined(__FREEBSD__)
+    if (audio_subsystem == AUDIO_SUBSYSTEM_OSS)
+    {
+        /* Buffer sizing follows the backend, not the OS, so use the same
+         * request FreeBSD does.  OSS only treats this as a hint: it rounds to
+         * the driver's fragment geometry and writes back what it really got
+         * (observed here as 170 ms playback / 10 ms capture). */
+        conf.buf.buffer_length_msec = 40;
+        period_ms = conf.buf.buffer_length_msec / 4;
+        audio = (ffaudio_interface *) &ffoss;
+    }
+#elif defined(__FreeBSD__)
     conf.buf.buffer_length_msec = 40;
     period_ms = conf.buf.buffer_length_msec / 4;
     if (audio_subsystem == AUDIO_SUBSYSTEM_OSS)
@@ -775,6 +785,13 @@ void *radio_playback_thread(void *device_ptr)
         conf.buf.device_id[0] == '{' && str_to_guid(conf.buf.device_id, &play_guid) == 0)
         conf.buf.device_id = (const char *)&play_guid;
 #endif
+
+    if (audio == NULL)
+    {
+        HLOGE("audio-playback", "audio subsystem %d is not available in this build",
+              audio_subsystem);
+        return NULL;
+    }
 
     conf.flags = FFAUDIO_PLAYBACK;
     ffaudio_init_conf aconf = {};
@@ -1093,7 +1110,7 @@ finish_play:
 
 void *radio_capture_thread(void *device_ptr)
 {
-    ffaudio_interface *audio;
+    ffaudio_interface *audio = NULL;
     struct conf conf = {};
     conf.buf.app_name = "mercury_capture";
     conf.buf.format = FFAUDIO_F_INT32;
@@ -1120,7 +1137,12 @@ void *radio_capture_thread(void *device_ptr)
         audio = (ffaudio_interface *) &ffalsa;
     if (audio_subsystem == AUDIO_SUBSYSTEM_PULSE)
         audio = (ffaudio_interface *) &ffpulse;
-#elif defined(__FREEBSD__)
+    if (audio_subsystem == AUDIO_SUBSYSTEM_OSS)
+    {
+        conf.buf.buffer_length_msec = 40;
+        audio = (ffaudio_interface *) &ffoss;
+    }
+#elif defined(__FreeBSD__)
     conf.buf.buffer_length_msec = 40;
     if (audio_subsystem == AUDIO_SUBSYSTEM_OSS)
         audio = (ffaudio_interface *) &ffoss;
@@ -1138,6 +1160,13 @@ void *radio_capture_thread(void *device_ptr)
         conf.buf.device_id[0] == '{' && str_to_guid(conf.buf.device_id, &cap_guid) == 0)
         conf.buf.device_id = (const char *)&cap_guid;
 #endif
+
+    if (audio == NULL)
+    {
+        HLOGE("audio-capture", "audio subsystem %d is not available in this build",
+              audio_subsystem);
+        return NULL;
+    }
 
     /* Open non-blocking.  A blocking ffalsa_read() spins internally on
      * readonce->start->sleep forever once the device stops producing samples
@@ -1562,7 +1591,9 @@ static int get_soundcard_list_int(int audio_system, int mode,
         audio = (ffaudio_interface *) &ffalsa;
     if (audio_system == AUDIO_SUBSYSTEM_PULSE)
         audio = (ffaudio_interface *) &ffpulse;
-#elif defined(__FREEBSD__)
+    if (audio_system == AUDIO_SUBSYSTEM_OSS)
+        audio = (ffaudio_interface *) &ffoss;
+#elif defined(__FreeBSD__)
     if (audio_system == AUDIO_SUBSYSTEM_OSS)
         audio = (ffaudio_interface *) &ffoss;
 #elif defined(__APPLE__)
@@ -1783,7 +1814,12 @@ void list_soundcards(int audio_system)
     }
     if (audio_subsystem == AUDIO_SUBSYSTEM_PULSE)
         audio = (ffaudio_interface *) &ffpulse;
-#elif defined(__FREEBSD__)
+    if (audio_subsystem == AUDIO_SUBSYSTEM_OSS)
+    {
+        printf("Listing OSS soundcards:\n");
+        audio = (ffaudio_interface *) &ffoss;
+    }
+#elif defined(__FreeBSD__)
     if (audio_subsystem == AUDIO_SUBSYSTEM_OSS)
         audio = (ffaudio_interface *) &ffoss;
 #elif defined(__APPLE__)

--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -75,6 +75,18 @@ cbuf_handle_t capture_buffer;
 cbuf_handle_t playback_buffer;
 
 int audio_subsystem;
+
+/* ffaudio's OSS backend is only compiled where the OSSv4 API exists (see the
+ * HAVE_OSS4 probe in audioio/Makefile).  Stock Linux ships only the OSS3 stub,
+ * where oss.c does not compile, so &ffoss must not even be referenced there --
+ * it is declared unconditionally in ffaudio/audio.h and would fail at link.
+ * Selecting -x oss on such a build leaves `audio` NULL and is reported as an
+ * unavailable subsystem. */
+#if defined(HAVE_OSS4) || defined(__FreeBSD__)
+#define OSS_IFACE ((ffaudio_interface *) &ffoss)
+#else
+#define OSS_IFACE NULL
+#endif
 static int capture_input_channel_layout = LEFT;
 
 // Internal state for restart support
@@ -762,13 +774,13 @@ void *radio_playback_thread(void *device_ptr)
          * (observed here as 170 ms playback / 10 ms capture). */
         conf.buf.buffer_length_msec = 40;
         period_ms = conf.buf.buffer_length_msec / 4;
-        audio = (ffaudio_interface *) &ffoss;
+        audio = OSS_IFACE;
     }
 #elif defined(__FreeBSD__)
     conf.buf.buffer_length_msec = 40;
     period_ms = conf.buf.buffer_length_msec / 4;
     if (audio_subsystem == AUDIO_SUBSYSTEM_OSS)
-        audio = (ffaudio_interface *) &ffoss;
+        audio = OSS_IFACE;
 #elif defined(__APPLE__)
     conf.buf.buffer_length_msec = 40;
     period_ms = conf.buf.buffer_length_msec / 4;
@@ -1140,12 +1152,12 @@ void *radio_capture_thread(void *device_ptr)
     if (audio_subsystem == AUDIO_SUBSYSTEM_OSS)
     {
         conf.buf.buffer_length_msec = 40;
-        audio = (ffaudio_interface *) &ffoss;
+        audio = OSS_IFACE;
     }
 #elif defined(__FreeBSD__)
     conf.buf.buffer_length_msec = 40;
     if (audio_subsystem == AUDIO_SUBSYSTEM_OSS)
-        audio = (ffaudio_interface *) &ffoss;
+        audio = OSS_IFACE;
 #elif defined(__APPLE__)
     conf.buf.buffer_length_msec = 40;
     if (audio_subsystem == AUDIO_SUBSYSTEM_COREAUDIO)
@@ -1592,10 +1604,10 @@ static int get_soundcard_list_int(int audio_system, int mode,
     if (audio_system == AUDIO_SUBSYSTEM_PULSE)
         audio = (ffaudio_interface *) &ffpulse;
     if (audio_system == AUDIO_SUBSYSTEM_OSS)
-        audio = (ffaudio_interface *) &ffoss;
+        audio = OSS_IFACE;
 #elif defined(__FreeBSD__)
     if (audio_system == AUDIO_SUBSYSTEM_OSS)
-        audio = (ffaudio_interface *) &ffoss;
+        audio = OSS_IFACE;
 #elif defined(__APPLE__)
     if (audio_system == AUDIO_SUBSYSTEM_COREAUDIO)
         audio = (ffaudio_interface *) &ffcoreaudio;
@@ -1816,12 +1828,13 @@ void list_soundcards(int audio_system)
         audio = (ffaudio_interface *) &ffpulse;
     if (audio_subsystem == AUDIO_SUBSYSTEM_OSS)
     {
-        printf("Listing OSS soundcards:\n");
-        audio = (ffaudio_interface *) &ffoss;
+        audio = OSS_IFACE;
+        if (audio)
+            printf("Listing OSS soundcards:\n");
     }
 #elif defined(__FreeBSD__)
     if (audio_subsystem == AUDIO_SUBSYSTEM_OSS)
-        audio = (ffaudio_interface *) &ffoss;
+        audio = OSS_IFACE;
 #elif defined(__APPLE__)
     if (audio_subsystem == AUDIO_SUBSYSTEM_COREAUDIO)
         audio = (ffaudio_interface *) &ffcoreaudio;
@@ -1831,7 +1844,11 @@ void list_soundcards(int audio_system)
 #endif
 
     if (!audio)
+    {
+        printf("Sound system %d is not available in this build.\n",
+               audio_subsystem);
         return;
+    }
 
 #if defined(__linux__)
     if (audio_subsystem == AUDIO_SUBSYSTEM_PULSE)

--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -28,6 +28,7 @@
 
 #include "audioio.h"
 #include "hermes_log.h"
+#include "cfg_utils.h"
 #include "resampler.h"
 #include "pcm24.h"
 
@@ -800,8 +801,8 @@ void *radio_playback_thread(void *device_ptr)
 
     if (audio == NULL)
     {
-        HLOGE("audio-playback", "audio subsystem %d is not available in this build",
-              audio_subsystem);
+        HLOGE("audio-playback", "sound system '%s' is not available in this build",
+              cfg_sound_system_name(audio_subsystem));
         return NULL;
     }
 
@@ -1175,8 +1176,8 @@ void *radio_capture_thread(void *device_ptr)
 
     if (audio == NULL)
     {
-        HLOGE("audio-capture", "audio subsystem %d is not available in this build",
-              audio_subsystem);
+        HLOGE("audio-capture", "sound system '%s' is not available in this build",
+              cfg_sound_system_name(audio_subsystem));
         return NULL;
     }
 
@@ -1710,7 +1711,14 @@ int get_soundcard_list(int audio_system, int mode,
 static void resolve_device_string(int audio_subsys, int mode, char *buf, size_t bufsz,
                                   const char *log_tag, bool pulse_lock_held)
 {
-    if (buf[0] == '\0')
+    /* An empty device means "the default".  Most backends take that as NULL and
+     * choose sensibly, but OSS cannot: ffaudio falls back to /dev/dsp for BOTH
+     * directions, and on OSSv4 /dev/dsp is one node -- commonly playback-only.
+     * Capture then opens a playback device and spins on EACCES/EBUSY.  So for
+     * OSS resolve an empty device to the first one enumerated for THIS
+     * direction. */
+    bool want_default = (buf[0] == '\0');
+    if (want_default && audio_subsys != AUDIO_SUBSYSTEM_OSS)
         return;
 
     if (audio_subsys == AUDIO_SUBSYSTEM_SHM || audio_subsys == AUDIO_SUBSYSTEM_NULL ||
@@ -1722,6 +1730,13 @@ static void resolve_device_string(int audio_subsys, int mode, char *buf, size_t 
     int n = get_soundcard_list_int(audio_subsys, mode, ids, names, DEVICE_RESOLVE_MAX, pulse_lock_held);
     if (n <= 0)
         return;
+
+    if (want_default) {
+        snprintf(buf, bufsz, "%s", ids[0]);
+        HLOGI(log_tag, "using default %s device '%s' (%s)",
+              (mode == FFAUDIO_DEV_CAPTURE) ? "capture" : "playback", ids[0], names[0]);
+        return;
+    }
 
     for (int i = 0; i < n; i++) {
         if (strcmp(buf, ids[i]) == 0)
@@ -1758,8 +1773,13 @@ static void resolve_device_string(int audio_subsys, int mode, char *buf, size_t 
     } else if (matches > 1) {
         HLOGW(log_tag, "device name '%s' is ambiguous (%d matches) -- use an exact id from -z instead", buf, matches);
     } else {
-        HLOGW(log_tag, "device '%s' matches no known id or name -- passing it through as-is, "
-                       "open will likely fail; run with -z to list valid devices", buf);
+        /* Not a prediction of failure: enumeration does not see every valid
+         * node.  Every /dev/dsp* symlink is a working OSS device that never
+         * appears in SNDCTL_AUDIOINFO_EX under that name, and ALSA takes
+         * plughw:/hw: strings that are absent from the list too.  If the open
+         * really does fail, that is reported with the driver's own reason. */
+        HLOGI(log_tag, "device '%s' is not in the enumerated list -- passing it to the "
+                       "driver as given (-z lists the enumerated devices)", buf);
     }
 }
 
@@ -1845,8 +1865,8 @@ void list_soundcards(int audio_system)
 
     if (!audio)
     {
-        printf("Sound system %d is not available in this build.\n",
-               audio_subsystem);
+        printf("Sound system '%s' is not available in this build.\n",
+               cfg_sound_system_name(audio_subsystem));
         return;
     }
 

--- a/audioio/ffaudio/ffaudio/oss.c
+++ b/audioio/ffaudio/ffaudio/oss.c
@@ -7,6 +7,7 @@
 #include <ffbase/stringz.h>
 
 #include <sys/soundcard.h>
+#include <sys/ioctl.h> /* FreeBSD gets ioctl() via soundcard.h, Linux does not */
 #include <fcntl.h>
 #include <errno.h>
 #include <math.h>

--- a/audioio/oss4-probe.c
+++ b/audioio/oss4-probe.c
@@ -1,0 +1,32 @@
+/* Build-time probe: does this system have the OSSv4 API?
+ *
+ * ffaudio's oss.c enumerates devices through the OSSv4 interface.  Stock Linux
+ * ships only the OSS3 stub in linux/soundcard.h, which has none of the symbols
+ * below, so oss.c cannot compile there at all.  The OSSv4 headers arrive with
+ * 4Front OSS -- on Debian that is oss4-dev, which *diverts*
+ * linux/soundcard.h -- and on FreeBSD they are the system default.
+ *
+ * audioio/Makefile compiles this file to decide whether to build the OSS
+ * backend.  It is never linked into mercury.
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <sys/soundcard.h>
+
+int main(void)
+{
+    oss_audioinfo ai;
+    oss_sysinfo si;
+
+    (void) ai;
+    (void) si;
+    (void) SNDCTL_SYSINFO;
+    (void) SNDCTL_AUDIOINFO_EX;
+    (void) SNDCTL_DSP_HALT;
+    (void) PCM_CAP_OUTPUT;
+    (void) OPEN_READ;
+
+    return 0;
+}

--- a/common/cfg_utils.c
+++ b/common/cfg_utils.c
@@ -252,7 +252,7 @@ bool cfg_read(mercury_config *cfg, const char *ini_path)
 }
 
 /* Map an AUDIO_SUBSYSTEM_* constant back to a name string. */
-static const char *sound_system_name(int sys)
+const char *cfg_sound_system_name(int sys)
 {
     switch (sys) {
     case AUDIO_SUBSYSTEM_ALSA:      return "alsa";
@@ -321,7 +321,7 @@ bool cfg_write(const mercury_config *cfg, const char *ini_path)
     fprintf(f, "output_device = \"%s\"\n", escaped);
 
     fprintf(f, "capture_channel = %s\n",  capture_channel_name(cfg->capture_channel));
-    fprintf(f, "sound_system = %s\n",     sound_system_name(cfg->sound_system));
+    fprintf(f, "sound_system = %s\n",     cfg_sound_system_name(cfg->sound_system));
     fprintf(f, "arq_tcp_base_port = %d\n", cfg->arq_tcp_base_port);
     fprintf(f, "broadcast_tcp_port = %d\n", cfg->broadcast_tcp_port);
     fprintf(f, "verbose = %s\n",           cfg->verbose ? "true" : "false");

--- a/common/cfg_utils.h
+++ b/common/cfg_utils.h
@@ -146,4 +146,8 @@ bool cfg_write(const mercury_config *cfg, const char *ini_path);
 /* Populate |cfg| with compile/runtime defaults. Call before cfg_read(). */
 void cfg_set_defaults(mercury_config *cfg);
 
+/* Map an AUDIO_SUBSYSTEM_* constant back to its CLI name ("alsa", "oss", ...).
+ * Returns a static string; never NULL. */
+const char *cfg_sound_system_name(int sys);
+
 #endif /* CFG_UTILS_H_ */

--- a/common/mercury_cli.c
+++ b/common/mercury_cli.c
@@ -139,6 +139,12 @@ int mercury_cli_parse(int argc, char **argv,
             printf("Loaded configuration from %s\n", out->cfg_path);
     }
 
+    /* Device names are meaningful only to the sound system they came from, so
+     * remember what the config asked for before the CLI gets a chance to
+     * change it. */
+    int cfg_sound_system = out->cfg.sound_system;
+    bool cli_set_sound_system = false, cli_set_input = false, cli_set_output = false;
+
     /* Second pass: CLI arguments override config-file values. */
     optind = 1;
     while ((opt = getopt(argc, argv, optstring)) != -1)
@@ -175,11 +181,17 @@ int mercury_cli_parse(int argc, char **argv,
             break;
         case 'i':
             if (optarg)
+            {
                 snprintf(out->cfg.input_device, sizeof(out->cfg.input_device), "%s", optarg);
+                cli_set_input = true;
+            }
             break;
         case 'o':
             if (optarg)
+            {
                 snprintf(out->cfg.output_device, sizeof(out->cfg.output_device), "%s", optarg);
+                cli_set_output = true;
+            }
             break;
         case 'c':
             if (optarg)
@@ -250,6 +262,7 @@ int mercury_cli_parse(int argc, char **argv,
             }
             break;
         case 'x':
+            cli_set_sound_system = true;
             if (!strcmp(optarg, "alsa"))
                 out->cfg.sound_system = AUDIO_SUBSYSTEM_ALSA;
             if (!strcmp(optarg, "pulse"))
@@ -340,6 +353,32 @@ int mercury_cli_parse(int argc, char **argv,
         default:
             mercury_cli_print_usage(argv[0]);
             return -1;
+        }
+    }
+
+    /* -x selected a different sound system than the config file's, and the
+     * matching device was not given on the command line.  A PulseAudio sink
+     * name means nothing to OSS, so keeping it guarantees a failed open;
+     * fall back to that sound system's default device instead. */
+    if (cli_set_sound_system && out->cfg.sound_system != cfg_sound_system)
+    {
+        if (!cli_set_input && out->cfg.input_device[0])
+        {
+            printf("Ignoring input_device '%s' from %s: it belongs to sound system '%s', "
+                   "not '%s'; using the default device.\n",
+                   out->cfg.input_device, out->cfg_path,
+                   cfg_sound_system_name(cfg_sound_system),
+                   cfg_sound_system_name(out->cfg.sound_system));
+            out->cfg.input_device[0] = '\0';
+        }
+        if (!cli_set_output && out->cfg.output_device[0])
+        {
+            printf("Ignoring output_device '%s' from %s: it belongs to sound system '%s', "
+                   "not '%s'; using the default device.\n",
+                   out->cfg.output_device, out->cfg_path,
+                   cfg_sound_system_name(cfg_sound_system),
+                   cfg_sound_system_name(out->cfg.sound_system));
+            out->cfg.output_device[0] = '\0';
         }
     }
 

--- a/common/mercury_engine.c
+++ b/common/mercury_engine.c
@@ -57,8 +57,11 @@ static int apply_audio_defaults(int audio_system, char *input_dev, size_t in_siz
     case AUDIO_SUBSYSTEM_DSOUND:
         break;
     case AUDIO_SUBSYSTEM_OSS:
-        if (input_dev[0] == 0)  snprintf(input_dev, in_size, "/dev/dsp");
-        if (output_dev[0] == 0) snprintf(output_dev, out_size, "/dev/dsp");
+        /* Left empty on purpose: /dev/dsp is a single node and is often
+         * playback-only, so it cannot serve both directions.  audioio's
+         * resolve_device_string() picks the first device enumerated for each
+         * direction, and ffaudio still falls back to /dev/dsp if OSS reports
+         * no devices at all. */
         break;
     default:
         break;


### PR DESCRIPTION
`-x oss` has been accepted by the CLI and by cfg_utils all along, but it could
not work on Linux — and was not safe to ask for.

## Why it did not build

1. **`oss.c` was never compiled on Linux.** `audioio/Makefile` added it only
   under `UNAME_S=FreeBSD`, and there was no build rule for it *anywhere*, so
   even that path fell through to the implicit rule without `-std=gnu11`.
2. **It would not have compiled anyway.** `ioctl()` reaches `oss.c` through
   `<sys/soundcard.h>` on FreeBSD but not on Linux, so every `SNDCTL_*` call
   was an implicit declaration.
3. **The guards are spelled `__FREEBSD__`.** The compiler defines
   `__FreeBSD__`, so those four blocks were dead on FreeBSD too — OSS has never
   actually been selectable on any platform, which is probably why the rest
   went unnoticed.
4. **`-x oss` was undefined behaviour, not a clean failure.** With no branch
   matching, `radio_playback_thread` and `radio_capture_thread` used an
   uninitialised `ffaudio_interface *audio`.

## Build gating — the important part

ffaudio's `oss.c` needs the **OSSv4** API. Stock Linux ships only the OSS3 stub
in `linux/soundcard.h`, which has none of `oss_audioinfo`, `oss_sysinfo`,
`SNDCTL_SYSINFO`, `SNDCTL_AUDIOINFO_EX`, `SNDCTL_DSP_HALT`, `OPEN_READ`,
`PCM_CAP_OUTPUT`. Compiling against it fails outright.

My first pass compiled `oss.c` on every Linux build and would have **broken the
build almost everywhere**. It looked fine here only because this host has
4Front OSS installed and Debian's `oss4-dev` *diverts*
`/usr/include/linux/soundcard.h` — the OSSv4 header was masquerading as the
system one, with the kernel original parked at `linux/soundcard.h.oss3`.
Credit to @rafael2k for catching it.

So the backend is now **probed for, not inferred from the OS**:
`audioio/Makefile` compiles `oss4-probe.c` with `-fsyntax-only` and builds the
backend only if that succeeds. Where it fails, `oss.o` is not built and
`audioio.c` must not reference `&ffoss` either — it is declared unconditionally
in `ffaudio/audio.h`, so the reference alone would fail at link. An
`OSS_IFACE` macro resolves to `&ffoss` or `NULL`, leaving the eight dispatch
sites unchanged in shape.

Target audience is OSS4 users; a build without the OSSv4 headers simply has no
OSS backend and says so.

## Two device-selection bugs found by actually running it

- **`-x` overrode the sound system but not the device names.** A `mercury.ini`
  with `sound_system = pulse` also carries Pulse sink names, so `-x oss` handed
  OSS `alsa_input.platform-snd_aloop.0.analog-stereo`. Those names are dropped
  now when `-x` switches sound systems and `-i`/`-o` were not given. Affects
  every backend pair, not just OSS.
- **`/dev/dsp` cannot serve both directions.** `mercury_engine.c` hardcoded it
  for input *and* output, but on OSSv4 it is one node and commonly
  playback-only. Capture opened a playback device and span on `EACCES` — 2941
  errors in 15 s — or the two raced and one got `EBUSY` (which is why the
  failing direction changed between runs). An empty OSS device now resolves to
  the first device enumerated for *that* direction.

## Message cleanups

- `audio subsystem 5 is not available` → `sound system 'oss' is not available`,
  by exporting the mapping `cfg_utils.c` already had instead of duplicating it.
- `matches no known id or name — passing it through as-is, open will likely
  fail` predicted a failure it could not know about, and was wrong in the
  normal case: enumeration does not see every valid node. Now an `[INF]`
  stating what happened; a real failure is still reported with the driver's own
  reason one line later.

## Verified

On a host running **OSSv4 (4Front)**, not the `snd-pcm-oss` emulation:

| form | result |
|---|---|
| no `-i`/`-o` | capture `.../pcmin0`, playback `.../pcm0`, 0 errors |
| enumerated ids | `.../pcmin0` + `.../pcm0`, 0 errors |
| device names | `"HD Audio rec rec1-sel"` → `.../pcmin1`, 0 errors |
| raw symlink paths | `/dev/dsp2` + `/dev/dsp1`, 0 errors |
| bad device | `/dev/nope` → `open: (2) No such file or directory` |

Both build configurations, the second forced by putting the stock header ahead
of the diverted one (`make CC="gcc -I<dir with linux/soundcard.h.oss3>"`):

- **OSSv4 present** — `oss.o` in the archive, `-x oss -z` lists 5 real devices
- **OSS3 stub only** — no `oss.o`, links clean, no `ffoss` symbol, `-x oss`
  reports unavailable, `-x alsa` unaffected

Unit suite green; `make windows` builds (it passes `OS=Windows_NT`, so the
Linux branch and its probe never run).

## Not covered

The `snd-pcm-oss` ALSA emulation path is untested — I only had native OSSv4
here. The code path is identical, but fragment negotiation may land
differently. Also note OSS treats `buffer_length_msec` as a hint: 40 ms was
requested, the driver reported 170 ms playback / 10 ms capture.