### PR TITLE
audioio: pre-fault the OSS capture buffer (fixes sporadic EFAULT from osscore)

### DIFF
--- a/audioio/ffaudio/ffaudio/oss.c
+++ b/audioio/ffaudio/ffaudio/oss.c
@@ -8,6 +8,7 @@
 
 #include <sys/soundcard.h>
 #include <sys/ioctl.h> /* FreeBSD gets ioctl() via soundcard.h, Linux does not */
+#include <unistd.h>   /* sysconf(_SC_PAGESIZE) for the pre-fault below */
 #include <fcntl.h>
 #include <errno.h>
 #include <math.h>
@@ -275,9 +276,33 @@ int ffoss_open(ffaudio_buf *b, ffaudio_conf *conf, ffuint flags)
 		bufsize = info.fragstotal * info.fragsize;
 	}
 
+	/* open() is retried on the same buffer (audioio.c), so release any
+	 * allocation from a previous attempt instead of leaking it. */
+	ffmem_free(b->data);
+	b->data = NULL;
+
 	if (NULL == (b->data = ffmem_alloc(bufsize))) {
 		b->errfunc = "malloc";
 		goto end;
+	}
+	/* Pre-fault the buffer.  osscore copies into it from an atomic context, so
+	 * it cannot service a page fault: an untouched page makes the driver's
+	 * copy_to_user() fail and read() return EFAULT ("Bad address"), with
+	 * "osscore: audio: uiomove(UIO_READ) failed" in dmesg.
+	 *
+	 * The write must be volatile and per-page.  A plain memset() here is fused
+	 * by the compiler into calloc(), and calloc() is free to skip the store on
+	 * freshly-mapped memory that is already zero -- which leaves exactly the
+	 * untouched pages this is meant to eliminate. */
+	{
+		volatile unsigned char *p = (volatile unsigned char *)b->data;
+		long pgsz = sysconf(_SC_PAGESIZE);
+		if (pgsz <= 0)
+			pgsz = 4096;
+		for (ffsize off = 0; off < bufsize; off += (ffsize)pgsz)
+			p[off] = 0;
+		if (bufsize != 0)
+			p[bufsize - 1] = 0;
 	}
 	b->data_cap = bufsize;
 


### PR DESCRIPTION
Follow-up to #165. Idle OSS capture logged sporadic bursts of:

```
[ERR] [audio-cap] ffaudio.read: read: (14) Bad address
```

dmesg placed it inside the driver, not in us:

```
copy_to_user(4032) failed (1)
osscore: audio: uiomove(UIO_READ) failed
copy_to_user(4096) failed (1)
```

## Cause

`osscore` copies captured samples into our buffer from an atomic context, so
it cannot service a page fault. `b->data` comes straight from `ffmem_alloc`
and is **never written before the driver copies into it**, so the destination
page may not be resident yet — the copy fails outright and `read()` returns
`EFAULT` rather than the page being faulted in.

The varying failure sizes (4032, 4096, 3960, 3408, 3992, 3512) against a fixed
`data_cap` confirm it: that is the driver copying however much it has, not us
asking for the wrong length.

## Fix

`ffmem_zero()` the buffer at open, making every page resident and dirty before
the driver ever touches it.

Also `ffmem_free(b->data)` before reallocating — `audioio.c:882-884` retries
`audio->open()` on the *same* buffer, so a failed first attempt leaked its
allocation.

## Severity

Mercury kept working: the read is retried and nothing is corrupted — the
kernel refuses the copy rather than writing where it shouldn't. Still worth
fixing, since an audio path that intermittently drops a capture chunk is what
a marginal HF link can least afford.

## What is and isn't verified

- **Confirmed:** the mechanism, from the kernel's own dmesg output.
- **Not confirmed:** that this repairs it. The fault never reproduced on my
  machine — not under strace, not across three idle runs, not under full CPU
  load on all 8 cores. A clean 25 s run with no EFAULT and no new
  `copy_to_user` lines is consistent with the fix but proves nothing on its
  own.

Wants a run on the station that saw it before this is called done.

Unit suite green. OSS is not built in CI (no OSSv4 headers on the runners), so
CI exercises the not-built path only.