### PR TITLE
Revert #166: the OSS EFAULT pre-fault was based on a wrong diagnosis

### DIFF
--- a/audioio/ffaudio/ffaudio/oss.c
+++ b/audioio/ffaudio/ffaudio/oss.c
@@ -8,7 +8,6 @@
 
 #include <sys/soundcard.h>
 #include <sys/ioctl.h> /* FreeBSD gets ioctl() via soundcard.h, Linux does not */
-#include <unistd.h>   /* sysconf(_SC_PAGESIZE) for the pre-fault below */
 #include <fcntl.h>
 #include <errno.h>
 #include <math.h>
@@ -276,33 +275,9 @@ int ffoss_open(ffaudio_buf *b, ffaudio_conf *conf, ffuint flags)
 		bufsize = info.fragstotal * info.fragsize;
 	}
 
-	/* open() is retried on the same buffer (audioio.c), so release any
-	 * allocation from a previous attempt instead of leaking it. */
-	ffmem_free(b->data);
-	b->data = NULL;
-
 	if (NULL == (b->data = ffmem_alloc(bufsize))) {
 		b->errfunc = "malloc";
 		goto end;
-	}
-	/* Pre-fault the buffer.  osscore copies into it from an atomic context, so
-	 * it cannot service a page fault: an untouched page makes the driver's
-	 * copy_to_user() fail and read() return EFAULT ("Bad address"), with
-	 * "osscore: audio: uiomove(UIO_READ) failed" in dmesg.
-	 *
-	 * The write must be volatile and per-page.  A plain memset() here is fused
-	 * by the compiler into calloc(), and calloc() is free to skip the store on
-	 * freshly-mapped memory that is already zero -- which leaves exactly the
-	 * untouched pages this is meant to eliminate. */
-	{
-		volatile unsigned char *p = (volatile unsigned char *)b->data;
-		long pgsz = sysconf(_SC_PAGESIZE);
-		if (pgsz <= 0)
-			pgsz = 4096;
-		for (ffsize off = 0; off < bufsize; off += (ffsize)pgsz)
-			p[off] = 0;
-		if (bufsize != 0)
-			p[bufsize - 1] = 0;
 	}
 	b->data_cap = bufsize;
 


### PR DESCRIPTION
Reverts #166.

The `read: (14) Bad address` faults **came back on the machine that reported
them**, on the build containing this change. The fix does not work, and its
commit message asserts a cause I cannot support.

## What was wrong with the reasoning

I had one confirmed fact — the kernel's `copy_to_user` failing — and built an
explanation on top of it (untouched pages, driver copying from atomic context)
that was never tested. I couldn't reproduce the fault, so a clean 25 s run
proved nothing, and an initial "it worked" report was a quiet window I took as
confirmation.

The theory is now positively contradicted, not merely unsupported: the
buffer's pages are explicitly written at open, last byte included, so if
residency were the cause the fault could not recur.

## What the evidence actually says

@rafael2k's observation is the useful one: **pulseaudio-oss reads the same
device without ever hitting this.** That is differential evidence and it
points away from anything about page residency.

The live difference between PA and us is buffer alignment — PA's memblocks
come from `mmap` and are page-aligned; ours came from `malloc`. Our capture
buffer is exactly 4096 bytes, so a `malloc`'d one lands mid-page and **every**
read straddles two pages. A page-aligned replacement is being evaluated
separately; it is not being merged on a hunch this time.

Also ruled out, by inspection: any mercury-side race on the buffer. The stall
watchdog (`audioio.c:1355`) runs inside the capture thread's own loop, so
alloc/open/read/consume/free/reopen are strictly sequential on one thread, and
`ffoss_free` closes the fd before releasing the buffer.

## What is lost by reverting

The `open()`-retry leak fix rides along in this revert. That part was
independently correct — `audioio.c:882-884` retries `audio->open()` on the same
buffer — and will be re-landed on its own, separate from any EFAULT theory.