### PR TITLE
audioio: ask OSS for the buffer geometry before setting the format

### DIFF
--- a/audioio/ffaudio/ffaudio/oss.c
+++ b/audioio/ffaudio/ffaudio/oss.c
@@ -236,33 +236,40 @@ int ffoss_open(ffaudio_buf *b, ffaudio_conf *conf, ffuint flags)
 		goto end;
 	}
 
+	/* Ask for the buffer geometry BEFORE the format is set.
+	 *
+	 * OSS allocates its DMA buffer when the format/channels/rate are set, and
+	 * SNDCTL_DSP_SETFRAGMENT is silently ignored after that point.  Issuing it
+	 * afterwards -- as this did -- meant the request never took effect and the
+	 * device default was used instead: asking for 40 ms of capture returned
+	 * 4 x 1024 = 10 ms, far too little for a process doing heavy DSP, where one
+	 * scheduling delay past 10 ms drops samples.
+	 *
+	 * Size is derived from the requested format, which is what we want: the
+	 * post-hoc GETISPACE the old code used could not run this early, and its
+	 * integer division could also ask for zero fragments when the device
+	 * fragment was larger than the whole request.
+	 *
+	 * Advisory: a device that refuses the hint still works with its own
+	 * geometry, so a failure here is not fatal. */
+	if (conf->buffer_length_msec != 0) {
+		ffuint total = _ffau_buf_msec_to_size(conf, conf->buffer_length_msec);
+		ffuint frag = 1024;
+		while (frag * 8 < total && frag < 65536)
+			frag <<= 1;
+		ffuint num = total / frag;
+		if (num < 4)
+			num = 4;
+		ffuint fr = (num << 16) | (ffuint)log2((double)frag);
+		ioctl(b->fd, SNDCTL_DSP_SETFRAGMENT, &fr);
+	}
+
 	if (0 != (r = oss_set_format(b, conf))) {
 		rc = r;
 		goto end;
 	}
 
 	audio_buf_info info = {};
-	if (conf->buffer_length_msec != 0) {
-		if (capture) {
-			if (0 > ioctl(b->fd, SNDCTL_DSP_GETISPACE, &info)) {
-				b->errfunc = "ioctl(SNDCTL_DSP_GETISPACE)";
-				goto end;
-			}
-		} else {
-			if (0 > ioctl(b->fd, SNDCTL_DSP_GETOSPACE, &info)) {
-				b->errfunc = "ioctl(SNDCTL_DSP_GETOSPACE)";
-				goto end;
-			}
-		}
-
-		ffuint frag_num = _ffau_buf_msec_to_size(conf, conf->buffer_length_msec) / info.fragsize;
-		ffuint fr = (frag_num << 16) | (ffuint)log2(info.fragsize); //buf_size = frag_num * 2^n
-		if (0 > ioctl(b->fd, SNDCTL_DSP_SETFRAGMENT, &fr)) {
-			b->errfunc = "ioctl(SNDCTL_DSP_SETFRAGMENT)";
-			goto end;
-		}
-	}
-
 	ffmem_zero_obj(&info);
 	if (capture) {
 		r = ioctl(b->fd, SNDCTL_DSP_GETISPACE, &info);


### PR DESCRIPTION
`SNDCTL_DSP_SETFRAGMENT` was issued **after** `SNDCTL_DSP_SETFMT`/`CHANNELS`/
`SPEED`. OSS allocates its DMA buffer when the format is set and ignores the
fragment request from then on, so our request never took effect and the device
default was used instead.

## Measured, asking for 40 ms

```
          request      device fragment    we asked   we got
playback  15360 B      2048 x 32          7          32 x 2048 = 170 ms
capture   15360 B      1024 x  4          15          4 x 1024 =  10 ms
```

After moving the ioctl to immediately after `open()`, the request binds:

```
[audio-play] I/O playback (...) int32 / 48000Hz / 2ch / 37ms buffer   (was 170ms)
[audio-cap]  I/O capture  (...) int32 / 48000Hz / 2ch / 10ms buffer   (unchanged)
```

Playback 170 ms → 37 ms is the point: that buffer sits directly in the TX/RX
turnaround path, and lower latency is what a modem wants. Capture still lands
at 10 ms, so that side is capped by the device (`fragstotal=4`) rather than by
us — worth a separate look.

## Also fixes a latent bug in the sizing

The old computation divided the request by the *device's* fragment size:

```c
ffuint frag_num = _ffau_buf_msec_to_size(conf, conf->buffer_length_msec) / info.fragsize;
```

A device whose fragment was larger than the whole request would have yielded
`frag_num == 0` — asking for zero fragments. Size now derives from the
requested format, which is also what makes it computable before the format is
set.

The request is advisory: a device that refuses the hint keeps its own geometry,
so a failure is no longer fatal.

## Relation to the sporadic capture EFAULT (#166 / #167)

Not claimed as a fix, but worth recording, because it is the first thing that
demonstrably changed driver behaviour.

The `read: (14) Bad address` faults, with `osscore: audio: uiomove(UIO_READ)
failed` in dmesg, are still formally undiagnosed. Two earlier explanations of
mine were wrong and #166 was reverted in #167. What this change proves is that
the driver was previously **in a different state than we asked for** — the
170 → 37 ms shift shows the ioctl had been silently ignored.

That makes one hypothesis worth stating and no more: a late `SETFRAGMENT` may
leave the driver's fragment bookkeeping inconsistent with the DMA buffer it had
already allocated, so it computes copy lengths against one geometry while the
buffer is another. That would fit a driver-side `copy_to_user` failing at
varying sizes, sporadically, on capture only — and fit pulseaudio-oss never
tripping it, since PA sets fragments in the correct order.

Reported by @rafael2k as looking fixed on the machine that had the fault. That
is an observation, not a proof, and this PR does not depend on it: the ordering
is wrong per the OSS API regardless, and the latency win stands on its own.

## Testing

Built and run on a host with 4Front OSSv4. Buffer geometry as above.
OSS is not built in CI (no OSSv4 headers on the runners), so CI covers the
not-built path only.

## Still owed

The `open()`-retry leak fix (`audioio.c` retries `audio->open()` on the same
buffer, leaking the first allocation) went out with the #167 revert because it
shared a commit with the bad pre-fault. It will be re-landed separately.