### PR TITLE
audioio: read OSS capture a fragment at a time

### DIFF
--- a/audioio/ffaudio/ffaudio/oss.c
+++ b/audioio/ffaudio/ffaudio/oss.c
@@ -112,6 +112,7 @@ struct ffaudio_buf {
 	int fd;
 	void *data;
 	ffsize data_cap;
+	ffuint frag_size;
 	int nonblock;
 
 	int err;
@@ -278,6 +279,7 @@ int ffoss_open(ffaudio_buf *b, ffaudio_conf *conf, ffuint flags)
 	}
 	ffuint bufsize = 16*1024;
 	if (r == 0) {
+		b->frag_size = (info.fragsize > 0) ? (ffuint)info.fragsize : 0;
 		conf->buffer_length_msec = _ffau_buf_size_to_msec(conf, info.fragstotal * info.fragsize);
 		bufsize = info.fragstotal * info.fragsize;
 	}
@@ -345,7 +347,21 @@ int ffoss_drain(ffaudio_buf *b)
 
 static int oss_readonce(ffaudio_buf *b, const void **buffer)
 {
-	int r = read(b->fd, b->data, b->data_cap);
+	/* Read one fragment, not the whole buffer.
+	 *
+	 * Asking for data_cap makes the driver hand back whatever happens to be
+	 * queued, which is almost always a ragged partial fragment -- and osscore's
+	 * copy_to_user() fails intermittently on exactly those (dmesg shows
+	 * copy_to_user(4032/3960/3408) against a 1024-byte fragment, while the one
+	 * fragment-aligned size, 4096, is the exception).  PulseAudio and the other
+	 * OSS clients ask a fragment at a time and never take that path.
+	 *
+	 * A fragment is also the granularity the driver signals at, so this costs
+	 * no latency: it returns as soon as one is ready, rather than after the
+	 * driver has scraped together a partial buffer. */
+	ffsize want = (b->frag_size != 0 && b->frag_size <= b->data_cap)
+		? b->frag_size : b->data_cap;
+	int r = read(b->fd, b->data, want);
 	if (r < 0) {
 		if (errno == EAGAIN)
 			return 0;


### PR DESCRIPTION
`oss_readonce()` asked for the whole buffer (`data_cap`), so the driver returned
whatever happened to be queued — almost always a ragged partial fragment.

4Front's own full-duplex sample, the closest analogue to what a modem does,
reads exactly one fragment and expects one back:

```c
samples/fulldup.c:568
while ((l = read (fd_in, buffer, fragsize)) == fragsize)
```

(Not universal — `audiolevel.c` and `midiin.c` read a fixed buffer — but the
full-duplex case is the one that matches us.)

A fragment is the granularity the driver signals at, so **this costs no
latency**: the read returns as soon as one fragment is ready, rather than after
the driver scrapes together a partial buffer.

## This does not fix the EFAULT, and is not offered as one

Measured: a 240 s run still faulted at +54 s, with two new `copy_to_user` lines
in dmesg.

Reading the driver source settled what the fault actually is. In
`setup/Linux/oss/build/osscore.c:653`:

```c
if ((c = copy_to_user (uio->ptr, address, nbytes)) != 0)
    oss_cmn_err (CE_CONT, "copy_to_user(%d) failed (%d)\n", nbytes, c);
```

`copy_to_user` returns **bytes not copied**, and every reported failure ends in
`(1)` — one byte, the last one. A missing page would fail on many bytes. This
is a driver-side off-by-one at the tail of the user buffer, and nothing on our
side of the syscall can repair it.

It is only *visible* when the buffer ends on a page boundary; otherwise the
stray byte lands in mapped heap unnoticed — which is plausibly why other OSS
clients seem unaffected rather than genuinely being so. Being chased separately
against the hdaudio driver.