### PR TITLE
audioio: do not leak the OSS buffer when open() is retried

### DIFF
--- a/audioio/ffaudio/ffaudio/oss.c
+++ b/audioio/ffaudio/ffaudio/oss.c
@@ -284,6 +284,12 @@ int ffoss_open(ffaudio_buf *b, ffaudio_conf *conf, ffuint flags)
 		bufsize = info.fragstotal * info.fragsize;
 	}
 
+	/* audioio.c retries audio->open() on the same buffer after a failed first
+	 * attempt, which reached here a second time and overwrote b->data -- leaking
+	 * the first allocation.  Release it before allocating again. */
+	ffmem_free(b->data);
+	b->data = NULL;
+
 	if (NULL == (b->data = ffmem_alloc(bufsize))) {
 		b->errfunc = "malloc";
 		goto end;


### PR DESCRIPTION
`audioio.c` retries `audio->open()` on the same `ffaudio_buf` after a failed
first attempt:

```c
r = audio->open(b, cfg, conf.flags);
if (r != 0)
    r = audio->open(b, cfg, conf.flags);
```

`ffoss_open()` allocates `b->data` unconditionally, so the second call
overwrote the pointer and leaked the first allocation. Free it first.

Originally written alongside the EFAULT pre-fault in #166 and reverted with it
in #167, because the two shared a commit. This part was always independent of
that (wrong) diagnosis, so it comes back on its own — which is how it should
have been landed in the first place.