### PR TITLE
audioio: report a failed sound card instead of dying quietly

### DIFF
--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -104,6 +104,60 @@ static char s_playback_dev[256];
 static int s_buffers_initialized = 0;
 static volatile bool audio_shutdown_ = false;  // local stop flag for audio threads
 
+/* Audio path health, reported to the UI so a bad device choice is visible.
+ * Deliberately does NOT stop the process: the operator needs mercury alive to
+ * pick a different card.  See audioio.h. */
+static pthread_mutex_t s_health_lock = PTHREAD_MUTEX_INITIALIZER;
+static audio_health_t  s_cap_health  = AUDIO_HEALTH_STOPPED;
+static audio_health_t  s_play_health = AUDIO_HEALTH_STOPPED;
+static char            s_health_reason[192];
+
+static void audio_health_set(bool capture, audio_health_t st, const char *reason)
+{
+    pthread_mutex_lock(&s_health_lock);
+    if (capture) s_cap_health = st; else s_play_health = st;
+    if (st == AUDIO_HEALTH_FAILED && reason)
+        snprintf(s_health_reason, sizeof(s_health_reason), "%s: %s",
+                 capture ? "capture" : "playback", reason);
+    else if (st == AUDIO_HEALTH_RUNNING)
+        s_health_reason[0] = '\0';
+    pthread_mutex_unlock(&s_health_lock);
+}
+
+audio_health_t audioio_capture_health(void)
+{
+    pthread_mutex_lock(&s_health_lock);
+    audio_health_t v = s_cap_health;
+    pthread_mutex_unlock(&s_health_lock);
+    return v;
+}
+
+audio_health_t audioio_playback_health(void)
+{
+    pthread_mutex_lock(&s_health_lock);
+    audio_health_t v = s_play_health;
+    pthread_mutex_unlock(&s_health_lock);
+    return v;
+}
+
+void audioio_health_reason(char *buf, size_t buflen)
+{
+    if (!buf || buflen == 0) return;
+    pthread_mutex_lock(&s_health_lock);
+    snprintf(buf, buflen, "%s", s_health_reason);
+    pthread_mutex_unlock(&s_health_lock);
+}
+
+bool audioio_health_ok(char *reason, size_t reasonlen)
+{
+    pthread_mutex_lock(&s_health_lock);
+    bool ok = (s_cap_health != AUDIO_HEALTH_FAILED) &&
+              (s_play_health != AUDIO_HEALTH_FAILED);
+    if (reason && reasonlen) snprintf(reason, reasonlen, "%s", s_health_reason);
+    pthread_mutex_unlock(&s_health_lock);
+    return ok;
+}
+
 static void format_device_display(int audio_subsys, int mode, const char *id, char *out, size_t outsz);
 static int get_soundcard_list_int(int audio_system, int mode,
                                   char ids[][64], char dev_names[][64], int max_count,
@@ -891,6 +945,7 @@ void *radio_playback_thread(void *device_ptr)
     if (r != 0)
     {
         HLOGE("audio-play", "error in audio->open(): %d: %s", r, audio->error(b));
+        audio_health_set(false, AUDIO_HEALTH_FAILED, audio->error(b));
         goto cleanup_play;
     }
 
@@ -898,6 +953,7 @@ void *radio_playback_thread(void *device_ptr)
     format_device_display(audio_subsystem, FFAUDIO_DEV_PLAYBACK,
                            device_ptr ? (const char *)device_ptr : NULL,
                            play_dev_display, sizeof(play_dev_display));
+    audio_health_set(false, AUDIO_HEALTH_RUNNING, NULL);
     HLOGI("audio-play", "I/O playback (%s) %s / %dHz / %dch / %dms buffer",
           play_dev_display,
           cfg->format == FFAUDIO_F_FLOAT32 ? "float32" :
@@ -935,10 +991,14 @@ void *radio_playback_thread(void *device_ptr)
     resample_ratio = resampler_ratio_for_rate((int)cfg->sample_rate);
     if (resample_ratio == 0)
     {
-        HLOGE("audio-play",
-              "Device negotiated %u Hz, not an integer multiple of %d Hz "
-              "(supported: 8k/16k/24k/32k/48k/96k), aborting",
-              cfg->sample_rate, RESAMP_MODEM_FS);
+        char why[160];
+        snprintf(why, sizeof(why),
+                 "device negotiated %u Hz, not a multiple of %d Hz "
+                 "(supported 8k/16k/24k/32k/48k/96k) -- try plughw:X,Y instead "
+                 "of hw:X,Y so ALSA converts",
+                 cfg->sample_rate, RESAMP_MODEM_FS);
+        HLOGE("audio-play", "%s", why);
+        audio_health_set(false, AUDIO_HEALTH_FAILED, why);
         goto cleanup_play;
     }
     if (cfg->sample_rate != 48000)
@@ -1251,6 +1311,7 @@ void *radio_capture_thread(void *device_ptr)
     if (r != 0)
     {
         HLOGE("audio-cap", "error in audio->open(): %d: %s", r, audio->error(b));
+        audio_health_set(true, AUDIO_HEALTH_FAILED, audio->error(b));
         goto cleanup_cap;
     }
 
@@ -1258,6 +1319,7 @@ void *radio_capture_thread(void *device_ptr)
     format_device_display(audio_subsystem, FFAUDIO_DEV_CAPTURE,
                            device_ptr ? (const char *)device_ptr : NULL,
                            cap_dev_display, sizeof(cap_dev_display));
+    audio_health_set(true, AUDIO_HEALTH_RUNNING, NULL);
     HLOGI("audio-cap", "I/O capture (%s) %s / %dHz / %dch / %dms buffer",
           cap_dev_display,
           cfg->format == FFAUDIO_F_FLOAT32 ? "float32" :
@@ -1290,10 +1352,19 @@ void *radio_capture_thread(void *device_ptr)
     resample_ratio = resampler_ratio_for_rate((int)cfg->sample_rate);
     if (resample_ratio == 0)
     {
-        HLOGE("audio-cap",
-              "Device negotiated %u Hz, not an integer multiple of %d Hz "
-              "(supported: 8k/16k/24k/32k/48k/96k), aborting",
-              cfg->sample_rate, RESAMP_MODEM_FS);
+        /* 44100 and 22050 are the common ones here: both are what a consumer
+         * USB codec reports natively, and neither is an integer multiple of
+         * the modem rate.  Naming plughw matters -- ALSA's plug layer converts
+         * transparently and is what mercury.ini.example already recommends, so
+         * the operator's fix is a device string, not a different sound card. */
+        char why[160];
+        snprintf(why, sizeof(why),
+                 "device negotiated %u Hz, not a multiple of %d Hz "
+                 "(supported 8k/16k/24k/32k/48k/96k) -- try plughw:X,Y instead "
+                 "of hw:X,Y so ALSA converts",
+                 cfg->sample_rate, RESAMP_MODEM_FS);
+        HLOGE("audio-cap", "%s", why);
+        audio_health_set(true, AUDIO_HEALTH_FAILED, why);
         audio->free(b);
         return NULL;
     }

--- a/audioio/audioio.h
+++ b/audioio/audioio.h
@@ -44,6 +44,37 @@ int audioio_init_internal(char *capture_dev, char *playback_dev, int audio_subsy
 int audioio_init_buffers(void);
 void audioio_deinit_buffers(void);
 
+/* --- Audio path health -------------------------------------------------
+ *
+ * A bad device choice must NOT take the process down: the operator may well be
+ * about to pick a different card (audioio_restart, or the UI device list), and
+ * a mercury that exits leaves them nothing to pick with.  So the capture and
+ * playback threads report their state here instead, and the UI surfaces it.
+ *
+ * Without this the failure is invisible: the thread logs, returns, and the
+ * status the UI publishes still describes a perfectly healthy mercury while
+ * nothing is being heard or transmitted. */
+typedef enum {
+    AUDIO_HEALTH_STOPPED = 0,  /* not started, or shut down cleanly        */
+    AUDIO_HEALTH_RUNNING,      /* stream is up                             */
+    AUDIO_HEALTH_FAILED        /* could not start / died; reason is set    */
+} audio_health_t;
+
+audio_health_t audioio_capture_health(void);
+audio_health_t audioio_playback_health(void);
+
+/* Human-readable reason for the most recent failure on either path, e.g.
+ * "capture: device negotiated 44100 Hz (try plughw:...)".  Empty when
+ * nothing has failed.  Copies into buf; always NUL-terminates. */
+void audioio_health_reason(char *buf, size_t buflen);
+
+/* Convenience for status reporting: true when NEITHER path has failed.  On
+ * failure `reason` receives the message.  Primitive types only, so a caller
+ * can declare it extern rather than include this header (which drags in
+ * ffbase) -- the convention ui_communication.c already uses for
+ * audioio_restart. */
+bool audioio_health_ok(char *reason, size_t reasonlen);
+
 int audioio_restart(const char *capture_dev, const char *playback_dev,
                     int audio_subsys, int capture_channel_layout);
 

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -50,6 +50,10 @@
 extern int get_soundcard_list(int audio_system, int mode,
                               char ids[][64], char dev_names[][64], int max_count);
 
+/* Audio path health; see audioio.h.  Declared here rather than included for
+ * the same reason audioio_restart is: audioio.h drags in ffbase. */
+extern bool audioio_health_ok(char *reason, size_t reasonlen);
+
 extern int audioio_restart(const char *capture_dev, const char *playback_dev,
                            int audio_subsys, int capture_channel_layout);
 
@@ -390,6 +394,14 @@ static void ui_gather_status(ui_ctx_t *ctx, ui_status_t *out)
     out->tx_peak_dbfs = modem_get_tx_peak_dbfs();
 
     out->waterfall_enabled = ctx->waterfall_enabled ? true : false;
+
+    /* Audio health.  A card that cannot be opened, or that negotiates a rate
+     * the modem cannot use, kills only its own thread -- mercury stays up so
+     * the operator can pick a different device.  That is the right behaviour,
+     * but it means this status is the ONLY place the failure becomes visible:
+     * without it the UI shows a perfectly healthy station that happens to hear
+     * nothing. */
+    out->audio_ok = audioio_health_ok(out->audio_error, sizeof(out->audio_error));
 }
 
 /* Copy the latest gathered status out for the embedded UI.  Returns false

--- a/gui_interface/ui_status.c
+++ b/gui_interface/ui_status.c
@@ -29,7 +29,9 @@ int ui_status_to_json(const ui_status_t *st, char *buf, size_t buflen)
         "\"bytes_received\":%ld,"
         "\"tx_gain_db\":%.1f,"
         "\"tx_peak_dbfs\":%.1f,"
-        "\"waterfall\":%s}",
+        "\"waterfall\":%s,"
+        "\"audio_ok\":%s,"
+        "\"audio_error\":\"%s\"}",
         st->bitrate_bps,
         st->snr_db,
         st->user_callsign,
@@ -41,7 +43,9 @@ int ui_status_to_json(const ui_status_t *st, char *buf, size_t buflen)
         st->bytes_received,
         (double)st->tx_gain_db,
         (double)st->tx_peak_dbfs,
-        st->waterfall_enabled ? "true" : "false");
+        st->waterfall_enabled ? "true" : "false",
+        st->audio_ok ? "true" : "false",
+        st->audio_error);
 
     if (n < 0 || (size_t)n >= buflen)
         return -1;

--- a/gui_interface/ui_status.h
+++ b/gui_interface/ui_status.h
@@ -23,6 +23,8 @@
 
 #include "arq.h"   /* CALLSIGN_MAX_SIZE */
 
+#define UI_AUDIO_ERR_MAX 192
+
 typedef struct {
     int    bitrate_bps;
     double snr_db;
@@ -36,6 +38,12 @@ typedef struct {
     float  tx_gain_db;
     float  tx_peak_dbfs;
     bool   waterfall_enabled;
+    /* Audio path health.  A bad device choice does not stop mercury -- the
+     * operator needs it alive to pick another card -- so the only way they
+     * learn the card is wrong is if the UI says so.  Empty audio_error means
+     * healthy; otherwise it carries the reason, e.g. an unsupported rate. */
+    bool   audio_ok;
+    char   audio_error[UI_AUDIO_ERR_MAX];
 } ui_status_t;
 
 /* Render the snapshot as the status JSON remote clients already expect.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -46,7 +46,7 @@ TEST_BINS = test_ring_buffer test_arq_protocol test_arq_timing test_arq_fsm \
             test_tcp_interfaces test_resampler test_pcm24 test_arq_olla test_arq_sim \
             test_arq_conn test_cfg_utils test_arq_tnc test_channel_busy \
             test_freedv_harq test_sock_wire test_virtual_clock test_watterson \
-            test_ofdm_acq
+            test_ofdm_acq test_ui_status
 
 .PHONY: all test clean
 

--- a/tests/audioio/test_resampler.c
+++ b/tests/audioio/test_resampler.c
@@ -197,10 +197,23 @@ void test_ratio_for_rate_supported(void)
 
 void test_ratio_for_rate_rejected(void)
 {
-    /* 44.1 kHz is not an integer multiple of 8 kHz — it needs a rational
-     * (441/80) resampler, so it must be refused, not approximated. */
+    /* The 44.1 kHz family is not an integer multiple of 8 kHz — it needs a
+     * rational (441/80) resampler, so it must be refused, not approximated.
+     *
+     * These two are not hypothetical: 44100 and 22050 are what consumer USB
+     * codecs report natively, so this is the rejection real operators hit.
+     * Approximating with the nearest integer ratio would transmit
+     * off-frequency at the correct level and spectrally pure — the failure
+     * mode that looks like nothing is wrong until you count cycles (a 1 kHz
+     * tone measured 166.8 Hz on a device pinned to 8 kHz).  Refusing is the
+     * whole point; the operator's fix is plughw:X,Y, which lets ALSA convert.
+     *
+     * If support for these is ever wanted, it means a genuine rational
+     * resampler, not relaxing this check. */
     TEST_ASSERT_EQUAL_INT(0, resampler_ratio_for_rate(44100));
     TEST_ASSERT_EQUAL_INT(0, resampler_ratio_for_rate(22050));
+    TEST_ASSERT_EQUAL_INT(0, resampler_ratio_for_rate(11025));
+    TEST_ASSERT_EQUAL_INT(0, resampler_ratio_for_rate(88200));
     TEST_ASSERT_EQUAL_INT(0, resampler_ratio_for_rate(192000));  /* L=24 > max */
     TEST_ASSERT_EQUAL_INT(0, resampler_ratio_for_rate(0));
     TEST_ASSERT_EQUAL_INT(0, resampler_ratio_for_rate(-48000));

--- a/tests/gui_interface/test_ui_status.c
+++ b/tests/gui_interface/test_ui_status.c
@@ -33,6 +33,8 @@ static ui_status_t sample(void)
     st.tx_gain_db          = -15.0f;
     st.tx_peak_dbfs        = -3.5f;
     st.waterfall_enabled   = true;
+    st.audio_ok            = true;
+    st.audio_error[0]      = '\0';
     return st;
 }
 
@@ -56,7 +58,9 @@ void test_status_json_is_byte_exact(void)
         "\"bytes_received\":128,"
         "\"tx_gain_db\":-15.0,"
         "\"tx_peak_dbfs\":-3.5,"
-        "\"waterfall\":true}";
+        "\"waterfall\":true,"
+        "\"audio_ok\":true,"
+        "\"audio_error\":\"\"}";
 
     TEST_ASSERT_EQUAL_STRING(expect, buf);
     TEST_ASSERT_EQUAL_INT((int)strlen(expect), n);
@@ -110,10 +114,31 @@ void test_null_arguments_are_rejected(void)
     TEST_ASSERT_EQUAL_INT(-1, ui_status_to_json(&st, buf, 0));
 }
 
+/* A failed sound card must reach the operator.  Mercury deliberately stays up
+ * when a device cannot be opened or negotiates a rate the modem cannot use --
+ * the operator needs it running to pick another card -- so this status is the
+ * only channel by which they learn anything is wrong.  If audio_ok were
+ * dropped from the payload, the UI would show a healthy station that hears
+ * nothing, which is exactly the bug this field exists to prevent. */
+void test_audio_failure_is_reported(void)
+{
+    ui_status_t st = sample();
+    char buf[512];
+
+    st.audio_ok = false;
+    snprintf(st.audio_error, sizeof(st.audio_error),
+             "capture: device negotiated 44100 Hz, not a multiple of 8000 Hz");
+
+    TEST_ASSERT_TRUE(ui_status_to_json(&st, buf, sizeof(buf)) > 0);
+    TEST_ASSERT_NOT_NULL(strstr(buf, "\"audio_ok\":false"));
+    TEST_ASSERT_NOT_NULL(strstr(buf, "44100 Hz"));
+}
+
 int main(void)
 {
     UNITY_BEGIN();
     RUN_TEST(test_status_json_is_byte_exact);
+    RUN_TEST(test_audio_failure_is_reported);
     RUN_TEST(test_direction_follows_ptt);
     RUN_TEST(test_booleans_render_as_json_literals);
     RUN_TEST(test_truncation_is_reported_not_emitted);


### PR DESCRIPTION
When a capture or playback device fails to open, mercury gave no usable signal
about it — the operator sees a station that is up but deaf or mute, with
nothing in the UI to say which.

Adds an `audio_health_t` state per direction, set at the point of failure, and
plain-typed accessors (`audioio_capture_health()`, `audioio_playback_health()`,
`audioio_health_reason()`, `audioio_health_ok(char*, size_t)`) so callers need
no audioio header. Surfaced through `ui_status`.

Deliberately **does not exit**: picking the wrong sound card should let the
operator pick another one, not kill the process — per @rafael2k.

## History, for the reviewer

This is `a9effec`, written during the #162 audio work. I pushed it into #163
by mistake, where it had nothing to do with FFT acquisition; it was stripped
back out so #163 stayed single-purpose, which left this stranded in reflog.
Recovered and landed on its own here.

It cherry-picks onto trunk cleanly now — the `tests/Makefile` conflict it hit
earlier was against a trunk that predated #163's changes to the same file.

## Testing

Full build clean, unit suite green (`All Tests Passed`) from a clean tests tree
on current trunk `cb4ab1b`.

Relevant to #162: the reporter was selecting sound cards while diagnosing, which
is exactly the case where a silent failure costs the most time.