### PR TITLE
Expose non-blocking radio and ARQ telemetry

### DIFF
--- a/docs/WEBSOCKET_STATUS.md
+++ b/docs/WEBSOCKET_STATUS.md
@@ -1,0 +1,19 @@
+# WebSocket status telemetry
+
+Mercury's `status` message preserves its established field order. New fields
+are appended after the audio-health fields:
+
+- `arq_tx_mode`: local ARQ payload mode (`DATAC1`, `DATAC3`, `DATAC4`,
+  `DATAC15`, `DATAC17`, or `QAM16C2`), or an empty string when unavailable.
+- `arq_rx_mode`: the peer payload mode used by the local decoder, independently
+  reported from the transmit mode.
+- `radio_frequency_hz`: the last successful read through Mercury's existing
+  Hamlib session, or `null` when unavailable.
+- `radio_frequency_age_ms`: age of that cached frequency, or `null`.
+
+Frequency telemetry is read-only. It never opens another CAT session, changes
+the VFO, or waits for the shared radio mutex. A busy radio causes the optional
+refresh to be skipped and the existing cache to be returned. Polls are also
+suppressed during an ARQ connection, while transmitting, and for two seconds
+after PTT release. Mercury logs each CAT read duration so slow real-world rig
+backends can be identified without putting timing guesses into the wire API.

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -43,6 +43,7 @@
 #include "../data_interfaces/tcp_interfaces.h"
 #include "../common/hermes_log.h"
 #include "../modem/freedv/modem_stats.h"
+#include "../modem/freedv/freedv_api.h"
 #include "../modem/modem.h"
 #include "../radio_io/radio_io.h"  /* RADIO_TYPE_NONE */
 #include "../radio_io/rigctl_parse.h"  /* preload_radio_list */
@@ -77,6 +78,20 @@ extern int audioio_restart(const char *capture_dev, const char *playback_dev,
 extern _Atomic bool shutdown_;
 
 #define UI_LOG_TAG "ui-comm"
+
+static const char *ui_arq_mode_name(int mode)
+{
+    switch (mode)
+    {
+    case FREEDV_MODE_DATAC1: return "DATAC1";
+    case FREEDV_MODE_DATAC3: return "DATAC3";
+    case FREEDV_MODE_DATAC4: return "DATAC4";
+    case FREEDV_MODE_DATAC15: return "DATAC15";
+    case FREEDV_MODE_DATAC17: return "DATAC17";
+    case FREEDV_MODE_QAM16C2: return "QAM16C2";
+    default: return "";
+    }
+}
 
 // Called by the WebSocket server thread when a new UI client connects.
 // Sets pending flags so the publisher sends device lists and radio list.
@@ -512,6 +527,10 @@ static void ui_gather_status(ui_ctx_t *ctx, ui_status_t *out)
         out->sync              = snap.connected ? true : false;
         out->bytes_transmitted = (long)snap.tx_bytes;
         out->bytes_received    = (long)snap.rx_bytes;
+        snprintf(out->arq_tx_mode, sizeof(out->arq_tx_mode), "%s",
+                 ui_arq_mode_name(snap.payload_mode));
+        snprintf(out->arq_rx_mode, sizeof(out->arq_rx_mode), "%s",
+                 ui_arq_mode_name(snap.peer_tx_mode));
     }
 
     int ctl_status  = net_get_status(CTL_TCP_PORT);
@@ -532,6 +551,12 @@ static void ui_gather_status(ui_ctx_t *ctx, ui_status_t *out)
      * without it the UI shows a perfectly healthy station that happens to hear
      * nothing. */
     out->audio_ok = audioio_health_ok(out->audio_error, sizeof(out->audio_error));
+
+    bool allow_frequency_poll = !(have_snap && snap.initialized &&
+                                  (snap.connected || snap.trx == 1));
+    out->radio_frequency_valid =
+        radio_io_get_frequency(allow_frequency_poll, &out->radio_frequency_hz,
+                               &out->radio_frequency_age_ms);
 }
 
 /* Copy the latest gathered status out for the embedded UI.  Returns false

--- a/gui_interface/ui_status.c
+++ b/gui_interface/ui_status.c
@@ -16,6 +16,21 @@ int ui_status_to_json(const ui_status_t *st, char *buf, size_t buflen)
     /* Field order and formatting are the established wire format — remote
      * clients parse this. Keep it byte-for-byte stable; test_ui_status.c
      * fails if it drifts. */
+    char frequency[32];
+    char age[32];
+    if (st->radio_frequency_valid)
+    {
+        snprintf(frequency, sizeof(frequency), "%llu",
+                 (unsigned long long)st->radio_frequency_hz);
+        snprintf(age, sizeof(age), "%llu",
+                 (unsigned long long)st->radio_frequency_age_ms);
+    }
+    else
+    {
+        snprintf(frequency, sizeof(frequency), "null");
+        snprintf(age, sizeof(age), "null");
+    }
+
     int n = snprintf(buf, buflen,
         "{\"type\":\"status\","
         "\"bitrate\":%d,"
@@ -31,7 +46,11 @@ int ui_status_to_json(const ui_status_t *st, char *buf, size_t buflen)
         "\"tx_peak_dbfs\":%.1f,"
         "\"waterfall\":%s,"
         "\"audio_ok\":%s,"
-        "\"audio_error\":\"%s\"}",
+        "\"audio_error\":\"%s\","
+        "\"arq_tx_mode\":\"%s\","
+        "\"arq_rx_mode\":\"%s\","
+        "\"radio_frequency_hz\":%s,"
+        "\"radio_frequency_age_ms\":%s}",
         st->bitrate_bps,
         st->snr_db,
         st->user_callsign,
@@ -45,7 +64,11 @@ int ui_status_to_json(const ui_status_t *st, char *buf, size_t buflen)
         (double)st->tx_peak_dbfs,
         st->waterfall_enabled ? "true" : "false",
         st->audio_ok ? "true" : "false",
-        st->audio_error);
+        st->audio_error,
+        st->arq_tx_mode,
+        st->arq_rx_mode,
+        frequency,
+        age);
 
     if (n < 0 || (size_t)n >= buflen)
         return -1;

--- a/gui_interface/ui_status.h
+++ b/gui_interface/ui_status.h
@@ -20,6 +20,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #include "arq.h"   /* CALLSIGN_MAX_SIZE */
 
@@ -44,6 +45,11 @@ typedef struct {
      * healthy; otherwise it carries the reason, e.g. an unsupported rate. */
     bool   audio_ok;
     char   audio_error[UI_AUDIO_ERR_MAX];
+    char   arq_tx_mode[16];     /* local ARQ payload mode                  */
+    char   arq_rx_mode[16];     /* peer payload mode used by local decoder */
+    bool   radio_frequency_valid;
+    uint64_t radio_frequency_hz;
+    uint64_t radio_frequency_age_ms;
 } ui_status_t;
 
 /* Render the snapshot as the status JSON remote clients already expect.

--- a/radio_io/radio_io.c
+++ b/radio_io/radio_io.c
@@ -22,6 +22,8 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
+#include <stdatomic.h>
 
 #ifdef HAVE_HAMLIB
 #include <hamlib/rig.h>
@@ -35,6 +37,9 @@
 #include "../common/hermes_log.h"
 
 #define RADIO_LOG_TAG "radio-io"
+#define FREQUENCY_POLL_INTERVAL_MS 5000U
+#define FREQUENCY_POST_PTT_QUIET_MS 2000U
+#define FREQUENCY_SLOW_READ_MS 100U
 
 #ifdef HAVE_HERMES_SHM
 #include "sbitx_io.h"
@@ -59,6 +64,12 @@ static ptt_config_t g_config = {
     .hamlib_log_level = 0
 };
 static const ptt_backend_t *g_backend = NULL;
+static bool g_ptt_active = false;
+static uint64_t g_last_ptt_off_ms = 0;
+static uint64_t g_frequency_attempt_ms = 0;
+static atomic_uint_fast64_t g_frequency_hz = 0;
+static atomic_uint_fast64_t g_frequency_read_ms = 0;
+static atomic_bool g_frequency_valid = false;
 
 static const char *ptt_method_name(ptt_method_t method)
 {
@@ -393,6 +404,8 @@ static void radio_io_shutdown_locked(void)
         g_backend->close();
     g_backend = NULL;
     g_config.method = PTT_METHOD_NONE;
+    g_ptt_active = false;
+    atomic_store_explicit(&g_frequency_valid, false, memory_order_release);
 }
 
 int radio_io_init(const ptt_config_t *config)
@@ -404,6 +417,13 @@ int radio_io_init(const ptt_config_t *config)
 
     if (g_backend)
         radio_io_shutdown_locked();
+
+    g_ptt_active = false;
+    g_last_ptt_off_ms = hermes_uptime_ms();
+    g_frequency_attempt_ms = 0;
+    atomic_store_explicit(&g_frequency_hz, 0, memory_order_relaxed);
+    atomic_store_explicit(&g_frequency_read_ms, 0, memory_order_relaxed);
+    atomic_store_explicit(&g_frequency_valid, false, memory_order_release);
 
     g_config = *config;
     g_config.device[sizeof(g_config.device) - 1] = '\0';
@@ -477,7 +497,20 @@ static int radio_io_key(bool on)
         pthread_mutex_unlock(&g_radio_mutex);
         return -1;
     }
+    /* Track PTT at the common dispatch point so every backend participates in
+     * the CAT quiet-window contract.  Mark ON before the potentially slow
+     * call, but undo it if the backend fails to key. */
+    if (on)
+        g_ptt_active = true;
+
     int rc = g_backend->set(on);
+    if (on && rc != 0)
+        g_ptt_active = false;
+    else if (!on)
+    {
+        g_ptt_active = false;
+        g_last_ptt_off_ms = hermes_uptime_ms();
+    }
     pthread_mutex_unlock(&g_radio_mutex);
     return rc;
 }
@@ -576,3 +609,159 @@ int radio_io_get_serial_speed(void)
     pthread_mutex_unlock(&g_radio_mutex);
     return speed;
 }
+
+static bool radio_io_copy_frequency_cache(uint64_t *frequency_hz,
+                                          uint64_t *age_ms)
+{
+    if (!atomic_load_explicit(&g_frequency_valid, memory_order_acquire))
+        return false;
+
+    uint64_t read_ms = atomic_load_explicit(&g_frequency_read_ms,
+                                             memory_order_relaxed);
+    uint64_t now = hermes_uptime_ms();
+    *frequency_hz = atomic_load_explicit(&g_frequency_hz,
+                                         memory_order_relaxed);
+    *age_ms = now >= read_ms ? now - read_ms : 0;
+    return true;
+}
+
+bool radio_io_get_frequency(bool allow_poll, uint64_t *frequency_hz,
+                            uint64_t *age_ms)
+{
+    if (!frequency_hz || !age_ms)
+        return false;
+
+    /* Optional telemetry must never queue behind PTT, shutdown, or another
+     * radio operation.  A skipped refresh is harmless because cache age is
+     * returned with the value. */
+    int lock_rc = pthread_mutex_trylock(&g_radio_mutex);
+    if (lock_rc != 0)
+    {
+        if (lock_rc != EBUSY)
+            HLOGW(RADIO_LOG_TAG, "Frequency poll lock failed: %d", lock_rc);
+        return radio_io_copy_frequency_cache(frequency_hz, age_ms);
+    }
+
+#ifdef HAVE_HAMLIB
+    uint64_t now = hermes_uptime_ms();
+    bool poll_due = g_frequency_attempt_ms == 0 ||
+                    now - g_frequency_attempt_ms >= FREQUENCY_POLL_INTERVAL_MS;
+    bool post_ptt_quiet =
+        now - g_last_ptt_off_ms < FREQUENCY_POST_PTT_QUIET_MS;
+    if (allow_poll && poll_due && !g_ptt_active && !post_ptt_quiet &&
+        g_backend == &HAMLIB_BACKEND && g_radio)
+    {
+        freq_t freq = 0;
+        uint64_t started_ms = now;
+        g_frequency_attempt_ms = now;
+        int ret = rig_get_freq(g_radio, RIG_VFO_CURR, &freq);
+        if (ret != RIG_OK)
+        {
+            vfo_t current_vfo = RIG_VFO_NONE;
+            int vfo_ret = rig_get_vfo(g_radio, &current_vfo);
+            if (vfo_ret == RIG_OK && current_vfo != RIG_VFO_NONE &&
+                current_vfo != RIG_VFO_CURR)
+            {
+                freq = 0;
+                ret = rig_get_freq(g_radio, current_vfo, &freq);
+            }
+        }
+
+        now = hermes_uptime_ms();
+        uint64_t elapsed_ms = now >= started_ms ? now - started_ms : 0;
+        if (elapsed_ms >= FREQUENCY_SLOW_READ_MS)
+            HLOGW(RADIO_LOG_TAG, "Frequency CAT read took %llu ms",
+                  (unsigned long long)elapsed_ms);
+        else
+            HLOGD(RADIO_LOG_TAG, "Frequency CAT read took %llu ms",
+                  (unsigned long long)elapsed_ms);
+
+        if (ret == RIG_OK && freq > 0)
+        {
+            atomic_store_explicit(&g_frequency_hz, (uint64_t)(freq + 0.5),
+                                  memory_order_relaxed);
+            atomic_store_explicit(&g_frequency_read_ms, now,
+                                  memory_order_relaxed);
+            atomic_store_explicit(&g_frequency_valid, true,
+                                  memory_order_release);
+        }
+        else if (ret != RIG_OK)
+        {
+            HLOGD(RADIO_LOG_TAG, "Frequency read failed (model %d): %s",
+                  g_config.hamlib_model, rigerror(ret));
+        }
+    }
+#else
+    (void)allow_poll;
+#endif
+
+    pthread_mutex_unlock(&g_radio_mutex);
+    return radio_io_copy_frequency_cache(frequency_hz, age_ms);
+}
+
+#ifdef RADIO_IO_TEST
+static int g_test_backend_result = 0;
+
+static int radio_io_test_backend_open(const ptt_config_t *config)
+{
+    (void)config;
+    return 0;
+}
+
+static int radio_io_test_backend_set(bool on)
+{
+    (void)on;
+    return g_test_backend_result;
+}
+
+static void radio_io_test_backend_close(void) { }
+
+static const ptt_backend_t RADIO_IO_TEST_BACKEND = {
+    radio_io_test_backend_open,
+    radio_io_test_backend_set,
+    radio_io_test_backend_close
+};
+
+void radio_io_test_lock(void)
+{
+    pthread_mutex_lock(&g_radio_mutex);
+}
+
+void radio_io_test_unlock(void)
+{
+    pthread_mutex_unlock(&g_radio_mutex);
+}
+
+void radio_io_test_seed_frequency(uint64_t frequency_hz, uint64_t read_ms)
+{
+    atomic_store_explicit(&g_frequency_hz, frequency_hz, memory_order_relaxed);
+    atomic_store_explicit(&g_frequency_read_ms, read_ms, memory_order_relaxed);
+    atomic_store_explicit(&g_frequency_valid, true, memory_order_release);
+}
+
+void radio_io_test_install_backend(int set_result)
+{
+    pthread_mutex_lock(&g_radio_mutex);
+    g_backend = &RADIO_IO_TEST_BACKEND;
+    g_test_backend_result = set_result;
+    g_ptt_active = false;
+    g_last_ptt_off_ms = UINT64_MAX;
+    pthread_mutex_unlock(&g_radio_mutex);
+}
+
+bool radio_io_test_ptt_active(void)
+{
+    pthread_mutex_lock(&g_radio_mutex);
+    bool active = g_ptt_active;
+    pthread_mutex_unlock(&g_radio_mutex);
+    return active;
+}
+
+uint64_t radio_io_test_last_ptt_off_ms(void)
+{
+    pthread_mutex_lock(&g_radio_mutex);
+    uint64_t off_ms = g_last_ptt_off_ms;
+    pthread_mutex_unlock(&g_radio_mutex);
+    return off_ms;
+}
+#endif

--- a/radio_io/radio_io.h
+++ b/radio_io/radio_io.h
@@ -22,6 +22,7 @@
 #define RADIO_IO_H_
 
 #include <stdbool.h>
+#include <stdint.h>
 
 /* Legacy radio_model values, retained for INI/CLI compatibility. */
 #define RADIO_TYPE_NONE (-1)
@@ -121,5 +122,11 @@ int radio_io_get_hamlib_log_level(void);
 
 /* Return the serial speed used by the current (or last) init (0 = hamlib default). */
 int radio_io_get_serial_speed(void);
+
+/* Return the last successfully read Hamlib frequency and its age.  A refresh
+ * is attempted only when allow_poll is true and the radio mutex is immediately
+ * available; telemetry never waits behind PTT or another radio operation. */
+bool radio_io_get_frequency(bool allow_poll, uint64_t *frequency_hz,
+                            uint64_t *age_ms);
 
 #endif /* RADIO_IO_H_ */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -46,7 +46,8 @@ TEST_BINS = test_ring_buffer test_arq_protocol test_arq_timing test_arq_fsm \
             test_tcp_interfaces test_resampler test_pcm24 test_arq_olla test_arq_sim \
             test_arq_conn test_cfg_utils test_arq_tnc test_channel_busy \
             test_freedv_harq test_sock_wire test_virtual_clock test_watterson \
-            test_ofdm_acq test_ui_status test_ui_devices test_tx_pacing test_radio_port
+            test_ofdm_acq test_ui_status test_ui_devices test_tx_pacing test_radio_port \
+            test_radio_io_frequency
 
 .PHONY: all test clean
 
@@ -186,6 +187,12 @@ test_tx_pacing: modem/test_tx_pacing.c $(UNITY_SRC) ../modem/tx_pacing.h
 # radio_port.h is a PREREQUISITE -- the logic under test lives in the header.
 test_radio_port: radio_io/test_radio_port.c $(UNITY_SRC) ../radio_io/radio_port.h
 	$(CC) $(CFLAGS) -I../radio_io -o $@ radio_io/test_radio_port.c $(UNITY_SRC) $(LDFLAGS)
+
+# Optional CAT telemetry must return its cache immediately while PTT or another
+# timing-sensitive radio operation owns the shared mutex.
+test_radio_io_frequency: radio_io/test_radio_io_frequency.c $(UNITY_SRC) \
+                         ../radio_io/radio_io.c ../common/hermes_log.c
+	$(CC) $(CFLAGS) -DRADIO_IO_TEST -o $@ $^ $(LDFLAGS)
 
 # UI status wire format (embedded struct vs remote JSON must not drift)
 # ui_status.h is a PREREQUISITE: the device-id widths under test are #defines

--- a/tests/gui_interface/test_ui_status.c
+++ b/tests/gui_interface/test_ui_status.c
@@ -82,6 +82,11 @@ static ui_status_t sample(void)
     st.waterfall_enabled   = true;
     st.audio_ok            = true;
     st.audio_error[0]      = '\0';
+    snprintf(st.arq_tx_mode, sizeof(st.arq_tx_mode), "DATAC3");
+    snprintf(st.arq_rx_mode, sizeof(st.arq_rx_mode), "DATAC4");
+    st.radio_frequency_valid = true;
+    st.radio_frequency_hz = 14074000;
+    st.radio_frequency_age_ms = 750;
     return st;
 }
 
@@ -107,7 +112,11 @@ void test_status_json_is_byte_exact(void)
         "\"tx_peak_dbfs\":-3.5,"
         "\"waterfall\":true,"
         "\"audio_ok\":true,"
-        "\"audio_error\":\"\"}";
+        "\"audio_error\":\"\","
+        "\"arq_tx_mode\":\"DATAC3\","
+        "\"arq_rx_mode\":\"DATAC4\","
+        "\"radio_frequency_hz\":14074000,"
+        "\"radio_frequency_age_ms\":750}";
 
     TEST_ASSERT_EQUAL_STRING(expect, buf);
     TEST_ASSERT_EQUAL_INT((int)strlen(expect), n);
@@ -181,11 +190,36 @@ void test_audio_failure_is_reported(void)
     TEST_ASSERT_NOT_NULL(strstr(buf, "44100 Hz"));
 }
 
+void test_unavailable_frequency_is_explicit_null(void)
+{
+    ui_status_t st = sample();
+    char buf[512];
+
+    st.radio_frequency_valid = false;
+    TEST_ASSERT_TRUE(ui_status_to_json(&st, buf, sizeof(buf)) > 0);
+    TEST_ASSERT_NOT_NULL(strstr(buf, "\"radio_frequency_hz\":null"));
+    TEST_ASSERT_NOT_NULL(strstr(buf, "\"radio_frequency_age_ms\":null"));
+}
+
+void test_arq_payload_modes_are_independent(void)
+{
+    ui_status_t st = sample();
+    char buf[512];
+
+    snprintf(st.arq_tx_mode, sizeof(st.arq_tx_mode), "DATAC1");
+    snprintf(st.arq_rx_mode, sizeof(st.arq_rx_mode), "DATAC15");
+    TEST_ASSERT_TRUE(ui_status_to_json(&st, buf, sizeof(buf)) > 0);
+    TEST_ASSERT_NOT_NULL(strstr(buf, "\"arq_tx_mode\":\"DATAC1\""));
+    TEST_ASSERT_NOT_NULL(strstr(buf, "\"arq_rx_mode\":\"DATAC15\""));
+}
+
 int main(void)
 {
     UNITY_BEGIN();
     RUN_TEST(test_status_json_is_byte_exact);
     RUN_TEST(test_audio_failure_is_reported);
+    RUN_TEST(test_unavailable_frequency_is_explicit_null);
+    RUN_TEST(test_arq_payload_modes_are_independent);
     RUN_TEST(test_direction_follows_ptt);
     RUN_TEST(test_booleans_render_as_json_literals);
     RUN_TEST(test_truncation_is_reported_not_emitted);

--- a/tests/radio_io/test_radio_io_frequency.c
+++ b/tests/radio_io/test_radio_io_frequency.c
@@ -1,0 +1,87 @@
+/* Read-only CAT frequency telemetry concurrency contract.
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <stdint.h>
+#include <time.h>
+
+#include "unity.h"
+#include "radio_io.h"
+
+/* Test-only seams compiled by radio_io.c under RADIO_IO_TEST. */
+void radio_io_test_lock(void);
+void radio_io_test_unlock(void);
+void radio_io_test_seed_frequency(uint64_t frequency_hz, uint64_t read_ms);
+void radio_io_test_install_backend(int set_result);
+bool radio_io_test_ptt_active(void);
+uint64_t radio_io_test_last_ptt_off_ms(void);
+
+/* radio_io.c retains all production backends in this unit build.  These stubs
+ * keep the telemetry contract test independent of serial and HID hardware. */
+int serial_ptt_open(const ptt_config_t *config) { (void)config; return -1; }
+int serial_ptt_set(bool on) { (void)on; return -1; }
+void serial_ptt_close(void) { }
+int mercury_cm108_open(const ptt_config_t *config) { (void)config; return -1; }
+int mercury_cm108_set(bool on) { (void)on; return -1; }
+void mercury_cm108_close(void) { }
+
+void setUp(void) {}
+void tearDown(void) {}
+
+static uint64_t monotonic_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000ULL +
+           (uint64_t)ts.tv_nsec / 1000000ULL;
+}
+
+void test_busy_radio_returns_cached_frequency_without_waiting(void)
+{
+    uint64_t frequency_hz = 0;
+    uint64_t age_ms = 0;
+
+    radio_io_test_seed_frequency(14074000, 0);
+    radio_io_test_lock();
+    uint64_t started_ms = monotonic_ms();
+    bool valid = radio_io_get_frequency(true, &frequency_hz, &age_ms);
+    uint64_t elapsed_ms = monotonic_ms() - started_ms;
+    radio_io_test_unlock();
+
+    TEST_ASSERT_TRUE(valid);
+    TEST_ASSERT_EQUAL_UINT64(14074000, frequency_hz);
+    TEST_ASSERT_LESS_THAN_UINT64_MESSAGE(
+        50, elapsed_ms,
+        "optional CAT telemetry waited behind a timing-sensitive radio operation");
+}
+
+void test_null_outputs_are_rejected(void)
+{
+    uint64_t value = 0;
+    TEST_ASSERT_FALSE(radio_io_get_frequency(true, NULL, &value));
+    TEST_ASSERT_FALSE(radio_io_get_frequency(true, &value, NULL));
+}
+
+void test_common_backend_dispatch_tracks_ptt_and_failed_key(void)
+{
+    radio_io_test_install_backend(0);
+    TEST_ASSERT_EQUAL_INT(0, radio_io_key_on());
+    TEST_ASSERT_TRUE(radio_io_test_ptt_active());
+
+    TEST_ASSERT_EQUAL_INT(0, radio_io_key_off());
+    TEST_ASSERT_FALSE(radio_io_test_ptt_active());
+    TEST_ASSERT_NOT_EQUAL(UINT64_MAX, radio_io_test_last_ptt_off_ms());
+
+    radio_io_test_install_backend(-1);
+    TEST_ASSERT_EQUAL_INT(-1, radio_io_key_on());
+    TEST_ASSERT_FALSE(radio_io_test_ptt_active());
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_busy_radio_returns_cached_frequency_without_waiting);
+    RUN_TEST(test_null_outputs_are_rejected);
+    RUN_TEST(test_common_backend_dispatch_tracks_ptt_and_failed_key);
+    return UNITY_END();
+}


### PR DESCRIPTION
Expose read-only radio frequency and ARQ payload-mode telemetry through Mercury's typed UI/WebSocket status for Mercury SkyPulse and other clients.

This revision incorporates Rafael's review feedback:

- rebased onto current `mercuryv2` (`8e1324a`)
- uses `pthread_mutex_trylock()` for the optional CAT poll, returning the atomic cached value immediately when radio I/O is busy
- records CAT read duration at debug level and warns for reads taking at least 100 ms, so real rigs can be measured without blocking normal status publication
- clears the local PTT-active state when `rig_set_ptt()` fails
- preserves the current `audio_ok` / `audio_error` fields and appends the new fields in stable JSON order
- removes the repository-agent file from the pull request
- moves the unrelated configured-archiver fix to #206

New status fields:

- `radio_frequency_hz`
- `radio_frequency_age_ms`
- `arq_tx_mode`
- `arq_rx_mode`

The frequency poll interval is five seconds, with a two-second quiet period after PTT. The cached frequency is invalidated during radio initialization and shutdown.

Validation performed locally on Apple Silicon macOS:

- focused UI-status and radio-frequency contract tests passed
- the radio-busy test verifies the cached read returns in under 50 ms while the radio mutex is held
- clean native Mercury build passed
- full Mercury test suite passed

The native build used `ATOMIC_LDFLAGS=` to work around the existing macOS arm64 target-detection issue that otherwise adds unavailable `-latomic`.
