### PR TITLE
audioio: stop cutting long audio device names at 63 characters (#185)

### DIFF
--- a/audioio/audio_dev_limits.h
+++ b/audioio/audio_dev_limits.h
@@ -1,0 +1,41 @@
+/* How much room a device id / name needs.
+ *
+ * Copyright (C) 2026 Rhizomatica
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * ---------------------------------------------------------------------------
+ *
+ * Its own header, with no dependencies, because the two sides that must agree
+ * on this width cannot include each other: audioio.h pulls in ffbase, which is
+ * not on the UI's include path (hence the hand-written get_soundcard_list
+ * prototype in ui_communication.c), and audioio must not depend on the UI.
+ *
+ * Getting it wrong is not a compile error, it is a silently mangled device
+ * name -- see issue #185, where 64 cut an IC-7300's PulseAudio node
+ *
+ *   alsa_input.usb-Burr-Brown_from_TI_USB_Audio_CODEC-00.analog-stereo
+ *
+ * to 63 characters.  That truncated id was written to mercury.ini and could
+ * never match a real device again, so the backend fell back to the default
+ * card and the radio appeared deaf.
+ */
+
+#ifndef AUDIO_DEV_LIMITS_H
+#define AUDIO_DEV_LIMITS_H
+
+/* PulseAudio/PipeWire node names reach ~70 characters for a plain USB codec
+ * and longer for multi-profile cards; ALSA "plughw:CARD=..." and the WASAPI
+ * "{GUID}.{GUID}" forms are comparable.  256 leaves real headroom without
+ * making the enumeration arrays worth heap-allocating. */
+#define AUDIO_DEV_STR_MAX 256
+
+#endif /* AUDIO_DEV_LIMITS_H */

--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -160,7 +160,7 @@ bool audioio_health_ok(char *reason, size_t reasonlen)
 
 static void format_device_display(int audio_subsys, int mode, const char *id, char *out, size_t outsz);
 static int get_soundcard_list_int(int audio_system, int mode,
-                                  char ids[][64], char dev_names[][64], int max_count,
+                                  char ids[][AUDIO_DEV_STR_MAX], char dev_names[][AUDIO_DEV_STR_MAX], int max_count,
                                   bool pulse_lock_held);
 
 #define NULL_AUDIO_PERIOD_MS 20
@@ -1658,7 +1658,7 @@ finish_cap:
  * owns s_pulse_lock (audioio_restart): that mutex is NOT recursive, so
  * re-taking it here self-deadlocks the process with audio already stopped. */
 static int get_soundcard_list_int(int audio_system, int mode,
-                                  char ids[][64], char dev_names[][64], int max_count,
+                                  char ids[][AUDIO_DEV_STR_MAX], char dev_names[][AUDIO_DEV_STR_MAX], int max_count,
                                   bool pulse_lock_held)
 {
     ffaudio_interface *audio = NULL;
@@ -1739,14 +1739,14 @@ static int get_soundcard_list_int(int audio_system, int mode,
         const char *name = audio->dev_info(d, FFAUDIO_DEV_NAME);
         if (id && count < max_count)
         {
-            strncpy(ids[count], id, 63);
-            ids[count][63] = '\0';
+            strncpy(ids[count], id, AUDIO_DEV_STR_MAX - 1);
+            ids[count][AUDIO_DEV_STR_MAX - 1] = '\0';
             if (name) {
-                strncpy(dev_names[count], name, 63);
-                dev_names[count][63] = '\0';
+                strncpy(dev_names[count], name, AUDIO_DEV_STR_MAX - 1);
+                dev_names[count][AUDIO_DEV_STR_MAX - 1] = '\0';
             } else {
-                strncpy(dev_names[count], id, 63);
-                dev_names[count][63] = '\0';
+                strncpy(dev_names[count], id, AUDIO_DEV_STR_MAX - 1);
+                dev_names[count][AUDIO_DEV_STR_MAX - 1] = '\0';
             }
             count++;
         }
@@ -1763,7 +1763,7 @@ static int get_soundcard_list_int(int audio_system, int mode,
 }
 
 int get_soundcard_list(int audio_system, int mode,
-                       char ids[][64], char dev_names[][64], int max_count)
+                       char ids[][AUDIO_DEV_STR_MAX], char dev_names[][AUDIO_DEV_STR_MAX], int max_count)
 {
     return get_soundcard_list_int(audio_system, mode, ids, dev_names, max_count, false);
 }
@@ -1802,8 +1802,8 @@ static void resolve_device_string(int audio_subsys, int mode, char *buf, size_t 
         audio_subsys == AUDIO_SUBSYSTEM_FIFO || audio_subsys == AUDIO_SUBSYSTEM_SOCK)
         return;
 
-    char ids[DEVICE_RESOLVE_MAX][64];
-    char names[DEVICE_RESOLVE_MAX][64];
+    char ids[DEVICE_RESOLVE_MAX][AUDIO_DEV_STR_MAX];
+    char names[DEVICE_RESOLVE_MAX][AUDIO_DEV_STR_MAX];
     int n = get_soundcard_list_int(audio_subsys, mode, ids, names, DEVICE_RESOLVE_MAX, pulse_lock_held);
     if (n <= 0)
         return;
@@ -1871,8 +1871,8 @@ static void format_device_display(int audio_subsys, int mode, const char *id, ch
         return;
     }
 
-    char ids[DEVICE_RESOLVE_MAX][64];
-    char names[DEVICE_RESOLVE_MAX][64];
+    char ids[DEVICE_RESOLVE_MAX][AUDIO_DEV_STR_MAX];
+    char names[DEVICE_RESOLVE_MAX][AUDIO_DEV_STR_MAX];
     int n = get_soundcard_list(audio_subsys, mode, ids, names, DEVICE_RESOLVE_MAX);
     for (int i = 0; i < n; i++) {
         if (strcmp(id, ids[i]) == 0) {

--- a/audioio/audioio.h
+++ b/audioio/audioio.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <ffbase/string.h>
+#include "audio_dev_limits.h"
 
 #include <stdio.h>
 #include <sys/types.h>
@@ -92,4 +93,4 @@ void list_soundcards(int audio_system);
 // Returns the number of devices found (up to max_count).
 // Each entry in ids[] and dev_names[] will be a NUL-terminated string.
 int get_soundcard_list(int audio_system, int mode,
-                       char ids[][64], char dev_names[][64], int max_count);
+                       char ids[][AUDIO_DEV_STR_MAX], char dev_names[][AUDIO_DEV_STR_MAX], int max_count);

--- a/gui_interface/fyne-ui/link_engine.go
+++ b/gui_interface/fyne-ui/link_engine.go
@@ -217,7 +217,10 @@ const maxRadios = 513
 
 func readAudioDevices(kind C.ui_device_kind_t) ([]optionItem, string, bool) {
 	devs := make([]C.ui_device_t, maxAudioDevices)
-	sel := make([]C.char, 64)
+	// Sized from the engine's own constant: a device id that does not fit here
+	// is silently truncated, which is how issue #185 lost a PulseAudio node
+	// name and left the modem bound to the default card.
+	sel := make([]C.char, C.UI_DEV_ID_MAX)
 
 	n := C.mercury_ui_get_audio_devices(C.int(kind), &devs[0], C.int(len(devs)),
 		&sel[0], C.int(len(sel)))

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -47,8 +47,19 @@
 #include "../radio_io/radio_io.h"  /* RADIO_TYPE_NONE */
 #include "../radio_io/rigctl_parse.h"  /* preload_radio_list */
 
+#include "../audioio/audio_dev_limits.h"   /* AUDIO_DEV_STR_MAX */
+
+/* Hand-written rather than #include "audioio.h": that header pulls in ffbase,
+ * which is not on this file's include path. */
 extern int get_soundcard_list(int audio_system, int mode,
-                              char ids[][64], char dev_names[][64], int max_count);
+                              char ids[][AUDIO_DEV_STR_MAX], char dev_names[][AUDIO_DEV_STR_MAX],
+                              int max_count);
+
+/* The enumerator writes rows this wide and we copy them straight into
+ * ui_device_t; if the UI struct were ever the narrower of the two, long
+ * PulseAudio node names would be cut again exactly as in issue #185. */
+_Static_assert(AUDIO_DEV_STR_MAX >= UI_DEV_ID_MAX,
+               "device id rows must not be narrower than ui_device_t.id");
 
 /* Audio path health; see audioio.h.  Declared here rather than included for
  * the same reason audioio_restart is: audioio.h drags in ffbase. */
@@ -289,7 +300,7 @@ int ui_comm_get_audio_devices(ui_device_kind_t kind, ui_device_t *out, int max,
     /* get_soundcard_list() takes mode 1 = capture, 0 = playback. */
     int mode = (kind == UI_DEV_CAPTURE) ? 1 : 0;
 
-    char ids[32][64], names[32][64];
+    char ids[32][AUDIO_DEV_STR_MAX], names[32][AUDIO_DEV_STR_MAX];
     int cap = (max < 32) ? max : 32;
     int count = get_soundcard_list(ctx->audio_system, mode, ids, names, cap);
     if (count < 0)
@@ -513,7 +524,7 @@ void *ui_publisher_thread(void *arg)
 
             /* Same enumerator the embedded UI calls, rendered as JSON. */
             ui_device_t devs[32];
-            char sel[64];
+            char sel[UI_DEV_ID_MAX];
             char buf[8192];
 
             int cap_count = ui_comm_get_audio_devices(UI_DEV_CAPTURE, devs, 32, sel, sizeof(sel));

--- a/gui_interface/ui_communication.h
+++ b/gui_interface/ui_communication.h
@@ -75,8 +75,8 @@ struct ui_ctx {
 
     // Audio subsystem info for soundcard enumeration
     int audio_system;                // AUDIO_SUBSYSTEM_* constant
-    char selected_capture_dev[64];   // currently active capture (input) device
-    char selected_playback_dev[64];  // currently active playback (output) device
+    char selected_capture_dev[UI_DEV_ID_MAX];   // currently active capture (input) device
+    char selected_playback_dev[UI_DEV_ID_MAX];  // currently active playback (output) device
     int rx_input_channel;            // LEFT=0, RIGHT=1, STEREO=2
 
     // Radio list is sent once at startup and again after set_radio_config

--- a/gui_interface/ui_status.h
+++ b/gui_interface/ui_status.h
@@ -57,8 +57,15 @@ int ui_status_to_json(const ui_status_t *st, char *buf, size_t buflen);
  * reason as the status struct — the two must not be able to disagree about
  * what is on the list or which entry is selected. */
 
-#define UI_DEV_ID_MAX   64
-#define UI_DEV_NAME_MAX 64
+/* PulseAudio/PipeWire node names are long: an IC-7300 enumerates as
+ * "alsa_input.usb-Burr-Brown_from_TI_USB_Audio_CODEC-00.analog-stereo",
+ * 66 characters.  At 64 these were silently cut to 63, which both wrote a
+ * broken device into mercury.ini and stopped the id ever matching a real
+ * device on the next open -- so the backend fell back to the default card
+ * and the radio went deaf (issue #185).  ALSA "plughw:CARD=..." names and
+ * WASAPI GUID+description strings run long too. */
+#define UI_DEV_ID_MAX   256
+#define UI_DEV_NAME_MAX 256
 
 typedef struct {
     char id[UI_DEV_ID_MAX];     /* device id / hamlib model number as text */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -180,8 +180,13 @@ test_radio_port: radio_io/test_radio_port.c $(UNITY_SRC) ../radio_io/radio_port.
 	$(CC) $(CFLAGS) -I../radio_io -o $@ radio_io/test_radio_port.c $(UNITY_SRC) $(LDFLAGS)
 
 # UI status wire format (embedded struct vs remote JSON must not drift)
-test_ui_status: gui_interface/test_ui_status.c $(UNITY_SRC) ../gui_interface/ui_status.c
-	$(CC) $(CFLAGS) -I../gui_interface -I../datalink_arq -I../modem -I../common -o $@ $^ $(LDFLAGS)
+# ui_status.h is a PREREQUISITE: the device-id widths under test are #defines
+# in the header, so without it make will not rebuild and the test silently
+# re-runs the previous binary (which is exactly how a mutation check passes
+# when it should fail).
+test_ui_status: gui_interface/test_ui_status.c $(UNITY_SRC) ../gui_interface/ui_status.c ../gui_interface/ui_status.h
+	$(CC) $(CFLAGS) -I../gui_interface -I../datalink_arq -I../modem -I../common -o $@ \
+	    gui_interface/test_ui_status.c $(UNITY_SRC) ../gui_interface/ui_status.c $(LDFLAGS)
 
 clean:
 	rm -f $(TEST_BINS)

--- a/tests/gui_interface/test_ui_status.c
+++ b/tests/gui_interface/test_ui_status.c
@@ -14,6 +14,53 @@
 #include "unity.h"
 #include "ui_status.h"
 
+
+/* ---- long audio device ids (issue #185) --------------------------------- */
+
+/* The reporter's IC-7300 as PulseAudio names it.  66 and 67 characters: at the
+ * old 64-byte width these were cut to 63, which both wrote a broken device
+ * into mercury.ini and stopped the id matching a real device on the next open,
+ * so the modem silently fell back to the default card. */
+#define IC7300_CAPTURE  "alsa_input.usb-Burr-Brown_from_TI_USB_Audio_CODEC-00.analog-stereo"
+#define IC7300_PLAYBACK "alsa_output.usb-Burr-Brown_from_TI_USB_Audio_CODEC-00.analog-stereo"
+
+void test_pulseaudio_device_id_survives_the_ui_struct(void)
+{
+    /* The struct has to hold the name AND its NUL, or the round trip through
+     * the UI silently shortens what the operator picked. */
+    TEST_ASSERT_TRUE_MESSAGE(sizeof(((ui_device_t *)0)->id) > strlen(IC7300_CAPTURE),
+                             "ui_device_t.id too small for a plain USB codec's PulseAudio node");
+    TEST_ASSERT_TRUE_MESSAGE(sizeof(((ui_device_t *)0)->id) > strlen(IC7300_PLAYBACK),
+                             "ui_device_t.id too small for a plain USB codec's PulseAudio node");
+
+    ui_device_t d;
+    memset(&d, 0, sizeof(d));
+    snprintf(d.id, sizeof(d.id), "%s", IC7300_CAPTURE);
+    TEST_ASSERT_EQUAL_STRING(IC7300_CAPTURE, d.id);
+}
+
+/* The id has to come back out of the JSON intact too -- that is the path the
+ * web UI and the Fyne UI both read the device list through. */
+void test_long_device_id_round_trips_through_json(void)
+{
+    ui_device_t devs[2];
+    memset(devs, 0, sizeof(devs));
+    snprintf(devs[0].id,   sizeof(devs[0].id),   "%s", IC7300_CAPTURE);
+    snprintf(devs[0].name, sizeof(devs[0].name), "%s", "USB Audio CODEC Analog Stereo");
+    snprintf(devs[1].id,   sizeof(devs[1].id),   "%s", IC7300_PLAYBACK);
+    snprintf(devs[1].name, sizeof(devs[1].name), "%s", "USB Audio CODEC Analog Stereo");
+
+    char buf[2048];
+    int n = ui_device_list_to_json("capture", devs, 2, IC7300_CAPTURE, buf, sizeof(buf));
+    TEST_ASSERT_TRUE(n > 0);
+
+    /* Whole string present, not a 63-character prefix of it. */
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(buf, IC7300_CAPTURE),
+                                 "capture id truncated in the device-list JSON");
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(buf, IC7300_PLAYBACK),
+                                 "playback id truncated in the device-list JSON");
+}
+
 void setUp(void) {}
 void tearDown(void) {}
 
@@ -143,5 +190,7 @@ int main(void)
     RUN_TEST(test_booleans_render_as_json_literals);
     RUN_TEST(test_truncation_is_reported_not_emitted);
     RUN_TEST(test_null_arguments_are_rejected);
+    RUN_TEST(test_pulseaudio_device_id_survives_the_ui_struct);
+    RUN_TEST(test_long_device_id_round_trips_through_json);
     return UNITY_END();
 }


### PR DESCRIPTION
Fixes #185.

## One truncation, both reported symptoms

An IC-7300 enumerates under PulseAudio/PipeWire as

```
alsa_input.usb-Burr-Brown_from_TI_USB_Audio_CODEC-00.analog-stereo     (66 chars)
alsa_output.usb-Burr-Brown_from_TI_USB_Audio_CODEC-00.analog-stereo    (67 chars)
```

The enumerator copied ids into 64-byte rows:

```c
strncpy(ids[count], id, 63);
ids[count][63] = '\0';
```

so anything from 64 characters up lost its tail — matching the reporter's `…analog-ste` / `…analog-st` exactly.

**The two problems in the issue are one bug.** The truncated id was written to `mercury.ini`, *and* it can never match a real device again — so on the next open the backend fell back to the default card and the radio appeared deaf. That is why selecting the device in the UI "did nothing".

It also explains why hand-editing the ini worked: a full id passed straight to PulseAudio is accepted, whereas `resolve_device()` compares the configured name against these same truncated rows, so it can never match by *id* — it only recovered by falling through to a *name* match.

## The fix

Widen the whole id path to 256 (`AUDIO_DEV_STR_MAX` / `UI_DEV_ID_MAX`) — enough for PulseAudio node names, ALSA `plughw:CARD=…`, and the WASAPI GUID forms.

The websocket command struct was already 256 and `cfg_utils` 512, so the enumerator and `ui_device_t` were the only narrow points. The chain is consistent end to end now.

The constant sits in its own dependency-free header (`audioio/audio_dev_limits.h`) because the two sides that must agree cannot include each other: `audioio.h` pulls in ffbase, which is not on the UI's include path (hence the hand-written `get_soundcard_list` prototype in `ui_communication.c`), and audioio must not depend on the UI. A `_Static_assert` pins them together — getting this wrong is not a compile error, it is a silently mangled device name.

## Testing

Tests use the reporter's actual device names and check both the struct and the JSON the UI reads the device list through. **Verified to fail at the old width (2/2 failures), pass at the new one.**

That mutation check first passed *spuriously*: `tests/Makefile` did not list `ui_status.h` as a prerequisite, so make never rebuilt and the old binary re-ran. Fixed here too — same class as the `FREEDV_LIB` note a few rules above it.

- `make test` — 236 pass (2 new)
- Full build clean; Fyne UI builds (the Go side had its own hardcoded 64 for the selected-device buffer, now `C.UI_DEV_ID_MAX`)

**What I could not verify:** this development host's PulseAudio is OSS-backed and enumerates short ids (`oss_input`, `oss_output.monitor`), so I could not reproduce the truncation against real hardware — the evidence is the code path plus the reporter's exact strings in the tests. Confirmation on a machine with a real USB codec would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)