### PR TITLE
audioio/ui: move the device-enumeration arrays off the stack

### DIFF
--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -1802,23 +1802,39 @@ static void resolve_device_string(int audio_subsys, int mode, char *buf, size_t 
         audio_subsys == AUDIO_SUBSYSTEM_FIFO || audio_subsys == AUDIO_SUBSYSTEM_SOCK)
         return;
 
-    char ids[DEVICE_RESOLVE_MAX][AUDIO_DEV_STR_MAX];
-    char names[DEVICE_RESOLVE_MAX][AUDIO_DEV_STR_MAX];
-    int n = get_soundcard_list_int(audio_subsys, mode, ids, names, DEVICE_RESOLVE_MAX, pulse_lock_held);
-    if (n <= 0)
+    /* Heap, not stack: DEVICE_RESOLVE_MAX x AUDIO_DEV_STR_MAX is 16 KB per
+     * array, and this runs on secondary threads whose default stack is only
+     * 512 KB on macOS.  Two 16 KB frames are survivable but pointless -- the
+     * enumeration allocates far more internally anyway. */
+    char (*ids)[AUDIO_DEV_STR_MAX]   = malloc(sizeof(*ids)   * DEVICE_RESOLVE_MAX);
+    char (*names)[AUDIO_DEV_STR_MAX] = malloc(sizeof(*names) * DEVICE_RESOLVE_MAX);
+    if (!ids || !names) {
+        free(ids); free(names);
+        HLOGE(log_tag, "out of memory enumerating audio devices");
         return;
+    }
+    int n = get_soundcard_list_int(audio_subsys, mode, ids, names, DEVICE_RESOLVE_MAX, pulse_lock_held);
+    if (n <= 0) {
+        free(ids); free(names);
+        return;
+    }
 
     if (want_default) {
         snprintf(buf, bufsz, "%s", ids[0]);
         HLOGI(log_tag, "using default %s device '%s' (%s)",
               (mode == FFAUDIO_DEV_CAPTURE) ? "capture" : "playback", ids[0], names[0]);
-        return;
+        goto done;
     }
 
+    bool already_native = false;
     for (int i = 0; i < n; i++) {
-        if (strcmp(buf, ids[i]) == 0)
-            return;  // already a valid native id
+        if (strcmp(buf, ids[i]) == 0) {
+            already_native = true;   // already a valid native id
+            break;
+        }
     }
+    if (already_native)
+        goto done;
 
     /* Count ALL exact matches rather than stopping at the first: identical
      * display names are common (two of the same USB codec, or a card and its
@@ -1858,6 +1874,10 @@ static void resolve_device_string(int audio_subsys, int mode, char *buf, size_t 
         HLOGI(log_tag, "device '%s' is not in the enumerated list -- passing it to the "
                        "driver as given (-z lists the enumerated devices)", buf);
     }
+
+done:
+    free(ids);
+    free(names);
 }
 
 /* Format "<id> '<name>'" for a resolved native device id, for display in
@@ -1871,16 +1891,25 @@ static void format_device_display(int audio_subsys, int mode, const char *id, ch
         return;
     }
 
-    char ids[DEVICE_RESOLVE_MAX][AUDIO_DEV_STR_MAX];
-    char names[DEVICE_RESOLVE_MAX][AUDIO_DEV_STR_MAX];
+    /* Heap for the same reason as resolve_device_string() above. */
+    char (*ids)[AUDIO_DEV_STR_MAX]   = malloc(sizeof(*ids)   * DEVICE_RESOLVE_MAX);
+    char (*names)[AUDIO_DEV_STR_MAX] = malloc(sizeof(*names) * DEVICE_RESOLVE_MAX);
+    if (!ids || !names) {
+        free(ids); free(names);
+        snprintf(out, outsz, "%s", id);
+        return;
+    }
+
     int n = get_soundcard_list(audio_subsys, mode, ids, names, DEVICE_RESOLVE_MAX);
     for (int i = 0; i < n; i++) {
         if (strcmp(id, ids[i]) == 0) {
             snprintf(out, outsz, "%s '%s'", id, names[i]);
+            free(ids); free(names);
             return;
         }
     }
 
+    free(ids); free(names);
     snprintf(out, outsz, "%s", id);
 }
 

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -300,7 +300,17 @@ int ui_comm_get_audio_devices(ui_device_kind_t kind, ui_device_t *out, int max,
     /* get_soundcard_list() takes mode 1 = capture, 0 = playback. */
     int mode = (kind == UI_DEV_CAPTURE) ? 1 : 0;
 
-    char ids[32][AUDIO_DEV_STR_MAX], names[32][AUDIO_DEV_STR_MAX];
+    /* Heap: 32 rows x AUDIO_DEV_STR_MAX x 2 arrays is 16 KB, and this is
+     * called from the websocket publisher thread, whose stack is 512 KB by
+     * default on macOS. */
+    char (*ids)[AUDIO_DEV_STR_MAX]   = malloc(sizeof(*ids)   * 32);
+    char (*names)[AUDIO_DEV_STR_MAX] = malloc(sizeof(*names) * 32);
+    if (!ids || !names) {
+        free(ids); free(names);
+        HLOGE(UI_LOG_TAG, "out of memory enumerating audio devices");
+        return 0;
+    }
+
     int cap = (max < 32) ? max : 32;
     int count = get_soundcard_list(ctx->audio_system, mode, ids, names, cap);
     if (count < 0)
@@ -318,6 +328,9 @@ int ui_comm_get_audio_devices(ui_device_kind_t kind, ui_device_t *out, int max,
         snprintf(selected, sel_len, "%s",
                  (kind == UI_DEV_CAPTURE) ? ctx->selected_capture_dev
                                           : ctx->selected_playback_dev);
+
+    free(ids);
+    free(names);
     return count;
 }
 
@@ -522,20 +535,32 @@ void *ui_publisher_thread(void *arg)
         {
             ctx->soundcard_list_pending = 0;
 
-            /* Same enumerator the embedded UI calls, rendered as JSON. */
-            ui_device_t devs[32];
+            /* Same enumerator the embedded UI calls, rendered as JSON.
+             * devs[] and the JSON scratch go on the heap: 32 ui_device_t is
+             * 16 KB and buf another 8 KB, which is a lot to put on a thread
+             * stack that is 512 KB by default on macOS. */
+            ui_device_t *devs = malloc(sizeof(*devs) * 32);
+            char *buf = malloc(8192);
             char sel[UI_DEV_ID_MAX];
-            char buf[8192];
 
-            int cap_count = ui_comm_get_audio_devices(UI_DEV_CAPTURE, devs, 32, sel, sizeof(sel));
-            if (cap_count > 0 &&
-                ui_device_list_to_json("capture_dev_list", devs, cap_count, sel, buf, sizeof(buf)) > 0)
-                ws_broadcast_json(&ctx->ws, buf);
+            if (devs && buf)
+            {
+                int cap_count = ui_comm_get_audio_devices(UI_DEV_CAPTURE, devs, 32, sel, sizeof(sel));
+                if (cap_count > 0 &&
+                    ui_device_list_to_json("capture_dev_list", devs, cap_count, sel, buf, 8192) > 0)
+                    ws_broadcast_json(&ctx->ws, buf);
 
-            int pb_count = ui_comm_get_audio_devices(UI_DEV_PLAYBACK, devs, 32, sel, sizeof(sel));
-            if (pb_count > 0 &&
-                ui_device_list_to_json("playback_dev_list", devs, pb_count, sel, buf, sizeof(buf)) > 0)
-                ws_broadcast_json(&ctx->ws, buf);
+                int pb_count = ui_comm_get_audio_devices(UI_DEV_PLAYBACK, devs, 32, sel, sizeof(sel));
+                if (pb_count > 0 &&
+                    ui_device_list_to_json("playback_dev_list", devs, pb_count, sel, buf, 8192) > 0)
+                    ws_broadcast_json(&ctx->ws, buf);
+            }
+            else
+            {
+                HLOGE(UI_LOG_TAG, "out of memory building the audio device list");
+            }
+            free(devs);
+            free(buf);
 
             // Input channel selection
             const char *ch_str;


### PR DESCRIPTION
Follow-up to #186. That fix widened device ids from 64 to 256 bytes to stop the truncation in #185 — correct, but it put the growth on the **stack**, four times over:

| function | before #186 | after #186 | now |
|---|---|---|---|
| `resolve_device_string` | 8.2 KB | **32.8 KB** | heap |
| `format_device_display` | <8 KB | **32.8 KB** | heap |
| `ui_comm_get_audio_devices` | <8 KB | **16.4 KB** | heap |
| `ui_publisher_thread` | 13.0 KB | **25.5 KB** | heap |

Every one runs on a secondary thread, and **macOS gives those a 512 KB stack by default** — only the main thread gets 8 MB. None was fatal alone, but a 4× growth in worker-thread frames is not something to ship to a platform with an eighth of Linux's headroom, and these arrays have no reason to be automatic: the enumeration allocates far more internally anyway.

RAM is not the constraint (largest array is 16 KB; the target is a Pi 3 with 512 MB) — the stack is.

### Note on `resolve_device_string`

It had two bare `return`s — the `want_default` path and "already a valid native id" — that would have leaked once the arrays became heap. Converted to a single exit via `goto done` rather than sprinkling `free()` calls, so a future early return cannot silently reintroduce a leak.

### Verification

Measured with `-Wframe-larger-than=8192`: **both files now have no frame over 8 KB.** What remains above that in the tree is vendored codec2 (cohpsk, fdmdv, codec2, sine, modem_stats) and the offline utils — none new, none ours.

- `make test` — 236 pass
- **ASan+UBSan — 236 pass**, exercising the new malloc/free paths specifically
- Go integration — PASS

One pre-existing item worth recording, not touched here: `arq_event_loop_worker` is **89 KB** on a secondary thread. Comfortable inside 512 KB, but it is the largest frame we own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)