### PR TITLE
release: bank the signed zip before attempting the installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,29 @@ jobs:
             osslsigncode verify "$f" || { echo "::error::Signature verification failed for $f"; exit 1; }
           done
 
+      # The zip is finished and banked BEFORE the installer is attempted.  The
+      # two are independent (the installer stage reads mercury.exe and the
+      # hamlib DLLs, never the zip or dist/), and the installer half is by far
+      # the more fragile: it needs wine, a downloaded Inno tree and a second
+      # use of the signing session.  Ordered this way, a failed installer
+      # leaves a downloadable signed zip to release by hand instead of taking
+      # the whole run's output down with it.
+      - name: Re-pack signed zip
+        run: |
+          ZIP=$(ls mercury-${{ inputs.version }}-w64-*.zip | head -1)
+          mkdir -p dist/mercury-${{ inputs.version }}
+          cp mercury.exe dist/mercury-${{ inputs.version }}/
+          cp windows-installer/mercury-ui.exe dist/mercury-${{ inputs.version }}/
+          cp mercury.ini.example dist/mercury-${{ inputs.version }}/
+          cd dist && zip -9r "../${ZIP}" "mercury-${{ inputs.version }}" && cd ..
+          rm -rf dist
+
+      - name: Upload signed zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-signed
+          path: mercury-${{ inputs.version }}-w64-*.zip
+
       # ---- Installer: pack the SIGNED payloads, then sign the installer ----
       # Order matters. ISCC packs whatever is staged, so signing only the
       # finished Setup.exe would ship a signed installer that installs unsigned
@@ -267,22 +290,6 @@ jobs:
         with:
           name: windows-installer-signed
           path: Mercury_*_Setup.exe
-
-      - name: Re-pack signed zip
-        run: |
-          ZIP=$(ls mercury-${{ inputs.version }}-w64-*.zip | head -1)
-          mkdir -p dist/mercury-${{ inputs.version }}
-          cp mercury.exe dist/mercury-${{ inputs.version }}/
-          cp windows-installer/mercury-ui.exe dist/mercury-${{ inputs.version }}/
-          cp mercury.ini.example dist/mercury-${{ inputs.version }}/
-          cd dist && zip -9r "../${ZIP}" "mercury-${{ inputs.version }}" && cd ..
-          rm -rf dist
-
-      - name: Upload signed zip
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-signed
-          path: mercury-${{ inputs.version }}-w64-*.zip
 
       # One login per job means one logout, and it has to happen even when a
       # step above failed -- otherwise a failed run leaves the cloud session


### PR DESCRIPTION
Pure step reordering inside the `sign` job: `Re-pack signed zip` + `Upload signed zip` now run immediately after `Verify signatures`, ahead of the Inno/wine/installer steps.

## Why

The installer half is the fragile one — wine32, a downloaded Inno tree, and a second use of the SimplySign session. It failed on three of the four 1.9.12 dispatches. Because the re-pack sat *after* it, each of those failures also discarded a signed zip that only needed uploading.

## Safety

The two halves are independent:

- `Re-pack signed zip` reads `mercury.exe`, `windows-installer/mercury-ui.exe`, `mercury.ini.example` and the zip from the build job — all present right after `Verify signatures`. It creates and removes its own `dist/`.
- `windows-installer-stage` (Makefile:623) reads `mercury.exe`, `mercury.ini.example` and the hamlib DLLs. It never reads the zip or `dist/`.

No step contents change. The only new coupling is that the artifact upload now sits between the SimplySign login and the installer signing; that session already survives an `apt-get install wine32` plus a `wineboot`, so a 15 MB upload is not a meaningful addition.

## What this does not change

An installer failure still fails the `sign` job, so the `release` job (`needs: sign`) is still skipped — no release is created automatically. The gain is that the signed zip artifact survives, so it can be released by hand. Making a release ship zip-only on installer failure would need `continue-on-error` plus a tolerant download step, which is a semantics change and deliberately not done here.

Verified: YAML parses, step order confirmed.