### PR TITLE
gui: tell two identical-looking sound cards apart (#189)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ MERCURY_LINK_INPUTS = \
 	datalink_broadcast/broadcast.o datalink_broadcast/kiss.o modem/modem.o modem/framer.o modem/channel_busy.o modem/freedv/libfreedvdata.a \
 	audioio/audioio.a common/os_interop.o common/ring_buffer_posix.o common/shm_posix.o common/crc6.o common/hermes_log.o common/virtual_clock.o \
 	common/chan.o common/queue.o common/mercury_engine.o common/mercury_cli.o data_interfaces/tcp_interfaces.o data_interfaces/net.o \
-	gui_interface/ui_communication.o gui_interface/ui_status.o \
+	gui_interface/ui_communication.o gui_interface/ui_status.o gui_interface/ui_devices.o \
 	gui_interface/websocket/mongoose.o gui_interface/websocket/mercury_websocket.o \
 	radio_io/radio_io.o
 
@@ -200,7 +200,7 @@ MERCURY_CORE_OBJS = \
 	common/os_interop.o common/ring_buffer_posix.o common/shm_posix.o common/crc6.o common/hermes_log.o common/virtual_clock.o \
 	common/chan.o common/queue.o common/mercury_engine.o common/mercury_cli.o \
 	data_interfaces/tcp_interfaces.o data_interfaces/net.o \
-	gui_interface/ui_communication.o gui_interface/ui_status.o \
+	gui_interface/ui_communication.o gui_interface/ui_status.o gui_interface/ui_devices.o \
 	gui_interface/websocket/mongoose.o gui_interface/websocket/mercury_websocket.o \
 	radio_io/radio_io.o
 

--- a/gui_interface/Makefile
+++ b/gui_interface/Makefile
@@ -28,13 +28,16 @@ CFLAGS_COMMON = $(COMMON_CFLAGS) -Wno-stringop-truncation -I../datalink_arq -I..
 WS_CFLAGS = $(COMMON_CFLAGS) -Iwebsocket -DMG_TLS=MG_TLS_BUILTIN
 
 # Objects
-OBJS = ui_communication.o ui_status.o
+OBJS = ui_communication.o ui_status.o ui_devices.o
 WS_OBJS = websocket/mongoose.o websocket/mercury_websocket.o
 
 all: $(OBJS) $(WS_OBJS)
 
 ui_communication.o: ui_communication.c ui_communication.h ui_status.h
 	$(CC) $(CFLAGS_COMMON) -c ui_communication.c -o ui_communication.o
+
+ui_devices.o: ui_devices.c ui_communication.h ui_status.h
+	$(CC) $(CFLAGS_COMMON) -c ui_devices.c -o ui_devices.o
 
 ui_status.o: ui_status.c ui_status.h
 	$(CC) $(CFLAGS_COMMON) -c ui_status.c -o ui_status.o

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -542,38 +542,20 @@ void *ui_publisher_thread(void *arg)
              * 16 KB and buf another 8 KB, which is a lot to put on a thread
              * stack that is 512 KB by default on macOS. */
             ui_device_t *devs = malloc(sizeof(*devs) * 32);
-            /* Big enough that 32 rows cannot overflow it even at the widest
-             * name and id the struct allows, plus the JSON scaffolding.  It
-             * used to be 8 KB, which was comfortable only while names were
-             * short: ui_devices_disambiguate() appends the id to any name two
-             * devices share, and ui_device_list_to_json() refuses to emit
-             * truncated JSON — so an overflow does not corrupt the list, it
-             * silently publishes no list at all. */
-            const size_t json_cap = 32 * (UI_DEV_NAME_MAX + UI_DEV_ID_MAX + 32) + 256;
-            char *buf = malloc(json_cap);
+            char *buf = malloc(8192);
             char sel[UI_DEV_ID_MAX];
 
             if (devs && buf)
             {
                 int cap_count = ui_comm_get_audio_devices(UI_DEV_CAPTURE, devs, 32, sel, sizeof(sel));
-                if (cap_count > 0)
-                {
-                    if (ui_device_list_to_json("capture_dev_list", devs, cap_count, sel, buf, json_cap) > 0)
-                        ws_broadcast_json(&ctx->ws, buf);
-                    else
-                        HLOGW(UI_LOG_TAG, "capture device list did not fit its JSON buffer "
-                                          "(%d devices) — not published", cap_count);
-                }
+                if (cap_count > 0 &&
+                    ui_device_list_to_json("capture_dev_list", devs, cap_count, sel, buf, 8192) > 0)
+                    ws_broadcast_json(&ctx->ws, buf);
 
                 int pb_count = ui_comm_get_audio_devices(UI_DEV_PLAYBACK, devs, 32, sel, sizeof(sel));
-                if (pb_count > 0)
-                {
-                    if (ui_device_list_to_json("playback_dev_list", devs, pb_count, sel, buf, json_cap) > 0)
-                        ws_broadcast_json(&ctx->ws, buf);
-                    else
-                        HLOGW(UI_LOG_TAG, "playback device list did not fit its JSON buffer "
-                                          "(%d devices) — not published", pb_count);
-                }
+                if (pb_count > 0 &&
+                    ui_device_list_to_json("playback_dev_list", devs, pb_count, sel, buf, 8192) > 0)
+                    ws_broadcast_json(&ctx->ws, buf);
             }
             else
             {

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -542,20 +542,38 @@ void *ui_publisher_thread(void *arg)
              * 16 KB and buf another 8 KB, which is a lot to put on a thread
              * stack that is 512 KB by default on macOS. */
             ui_device_t *devs = malloc(sizeof(*devs) * 32);
-            char *buf = malloc(8192);
+            /* Big enough that 32 rows cannot overflow it even at the widest
+             * name and id the struct allows, plus the JSON scaffolding.  It
+             * used to be 8 KB, which was comfortable only while names were
+             * short: ui_devices_disambiguate() appends the id to any name two
+             * devices share, and ui_device_list_to_json() refuses to emit
+             * truncated JSON — so an overflow does not corrupt the list, it
+             * silently publishes no list at all. */
+            const size_t json_cap = 32 * (UI_DEV_NAME_MAX + UI_DEV_ID_MAX + 32) + 256;
+            char *buf = malloc(json_cap);
             char sel[UI_DEV_ID_MAX];
 
             if (devs && buf)
             {
                 int cap_count = ui_comm_get_audio_devices(UI_DEV_CAPTURE, devs, 32, sel, sizeof(sel));
-                if (cap_count > 0 &&
-                    ui_device_list_to_json("capture_dev_list", devs, cap_count, sel, buf, 8192) > 0)
-                    ws_broadcast_json(&ctx->ws, buf);
+                if (cap_count > 0)
+                {
+                    if (ui_device_list_to_json("capture_dev_list", devs, cap_count, sel, buf, json_cap) > 0)
+                        ws_broadcast_json(&ctx->ws, buf);
+                    else
+                        HLOGW(UI_LOG_TAG, "capture device list did not fit its JSON buffer "
+                                          "(%d devices) — not published", cap_count);
+                }
 
                 int pb_count = ui_comm_get_audio_devices(UI_DEV_PLAYBACK, devs, 32, sel, sizeof(sel));
-                if (pb_count > 0 &&
-                    ui_device_list_to_json("playback_dev_list", devs, pb_count, sel, buf, 8192) > 0)
-                    ws_broadcast_json(&ctx->ws, buf);
+                if (pb_count > 0)
+                {
+                    if (ui_device_list_to_json("playback_dev_list", devs, pb_count, sel, buf, json_cap) > 0)
+                        ws_broadcast_json(&ctx->ws, buf);
+                    else
+                        HLOGW(UI_LOG_TAG, "playback device list did not fit its JSON buffer "
+                                          "(%d devices) — not published", pb_count);
+                }
             }
             else
             {

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -324,6 +324,8 @@ int ui_comm_get_audio_devices(ui_device_kind_t kind, ui_device_t *out, int max,
         snprintf(out[i].name, sizeof(out[i].name), "%.*s", (int)sizeof(names[i]) - 1, names[i]);
     }
 
+    ui_devices_disambiguate(out, count);
+
     if (selected && sel_len)
         snprintf(selected, sel_len, "%s",
                  (kind == UI_DEV_CAPTURE) ? ctx->selected_capture_dev

--- a/gui_interface/ui_communication.h
+++ b/gui_interface/ui_communication.h
@@ -143,6 +143,11 @@ bool ui_comm_get_status(ui_status_t *out);
 
 /* Enumerate audio devices of one kind.  Returns how many were written and, if
  * `selected` is non-NULL, the id currently in use. */
+/* Append the device id to any display name shared by more than one device, so
+ * a label-driven UI can tell two identical-looking sound cards apart.  Names
+ * that do not collide are left alone. */
+void ui_devices_disambiguate(ui_device_t *devs, int count);
+
 int  ui_comm_get_audio_devices(ui_device_kind_t kind, ui_device_t *out, int max,
                                char *selected, size_t sel_len);
 

--- a/gui_interface/ui_devices.c
+++ b/gui_interface/ui_devices.c
@@ -1,0 +1,72 @@
+/* HERMES Modem — UI device-list helpers
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Kept in its own translation unit so the logic can be unit-tested without
+ * linking the websocket server and the whole UI context.
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ui_status.h"
+#include "ui_communication.h"
+
+/* Make every display name in the list distinguishable.
+ *
+ * Two of the same USB codec present identical human-readable names — a
+ * PCM2901 in an IC-7300 and another in an IC-9700 are both "PCM2901 Audio
+ * Codec Analog Stereo" — while their ids differ.  Every UI here is
+ * label-driven: the dropdown shows names, and the selection is mapped back to
+ * an id by matching the label.  With duplicate labels the operator cannot tell
+ * the two radios apart, and whichever they pick resolves to the first match,
+ * so one of the two devices is unreachable (issue #189).
+ *
+ * Only names that actually collide get the id appended, so the ordinary
+ * one-radio case still reads as plain English.  Doing it here rather than in
+ * each UI keeps the embedded, web and remote lists showing the same labels. */
+void ui_devices_disambiguate(ui_device_t *devs, int count)
+{
+    if (!devs || count <= 1)
+        return;
+
+    /* Decide everything against the ORIGINAL names before touching any of
+     * them.  Renaming inside the scan makes each device stop matching the one
+     * it collided with, so only the first of a colliding group is ever
+     * labelled and its partner keeps the bare name — which is the same bug
+     * from the other side. */
+    bool *needs_id = calloc((size_t)count, sizeof(*needs_id));
+    if (!needs_id)
+        return;   /* leave the list readable rather than half-relabelled */
+
+    for (int i = 0; i < count; i++)
+    {
+        for (int j = i + 1; j < count; j++)
+        {
+            if (strcmp(devs[i].name, devs[j].name) == 0)
+            {
+                needs_id[i] = true;
+                needs_id[j] = true;
+            }
+        }
+    }
+
+    for (int i = 0; i < count; i++)
+    {
+        /* A device with no id cannot be told apart; an empty "[]" would just
+         * be noise. */
+        if (!needs_id[i] || devs[i].id[0] == '\0')
+            continue;
+
+        /* Distinct ids can share a long prefix, so the id goes on whole and
+         * snprintf bounds it. */
+        char label[UI_DEV_NAME_MAX];
+        snprintf(label, sizeof(label), "%s [%s]", devs[i].name, devs[i].id);
+        snprintf(devs[i].name, sizeof(devs[i].name), "%s", label);
+    }
+
+    free(needs_id);
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -46,7 +46,7 @@ TEST_BINS = test_ring_buffer test_arq_protocol test_arq_timing test_arq_fsm \
             test_tcp_interfaces test_resampler test_pcm24 test_arq_olla test_arq_sim \
             test_arq_conn test_cfg_utils test_arq_tnc test_channel_busy \
             test_freedv_harq test_sock_wire test_virtual_clock test_watterson \
-            test_ofdm_acq test_ui_status test_tx_pacing test_radio_port
+            test_ofdm_acq test_ui_status test_ui_devices test_tx_pacing test_radio_port
 
 .PHONY: all test clean
 
@@ -187,6 +187,16 @@ test_radio_port: radio_io/test_radio_port.c $(UNITY_SRC) ../radio_io/radio_port.
 test_ui_status: gui_interface/test_ui_status.c $(UNITY_SRC) ../gui_interface/ui_status.c ../gui_interface/ui_status.h
 	$(CC) $(CFLAGS) -I../gui_interface -I../datalink_arq -I../modem -I../common -o $@ \
 	    gui_interface/test_ui_status.c $(UNITY_SRC) ../gui_interface/ui_status.c $(LDFLAGS)
+
+# UI device labelling (issue #189: two identical-looking USB codecs).
+# ui_communication.h/ui_status.h are PREREQUISITES: the behaviour under test is
+# in ui_devices.c but the types are in the headers, and without them make will
+# not relink and a mutation check silently re-runs the previous binary.
+test_ui_devices: gui_interface/test_ui_devices.c $(UNITY_SRC) \
+                 ../gui_interface/ui_devices.c ../gui_interface/ui_communication.h \
+                 ../gui_interface/ui_status.h
+	$(CC) $(CFLAGS) -I../gui_interface -I../datalink_arq -I../modem -I../common -o $@ \
+	    gui_interface/test_ui_devices.c $(UNITY_SRC) ../gui_interface/ui_devices.c $(LDFLAGS)
 
 clean:
 	rm -f $(TEST_BINS)

--- a/tests/gui_interface/test_ui_devices.c
+++ b/tests/gui_interface/test_ui_devices.c
@@ -1,0 +1,126 @@
+/*
+ * UI device-list labelling
+ *
+ * Issue #189: an operator with an IC-7300 and an IC-9700 sees two sound cards
+ * that both call themselves "PCM2901 Audio Codec Analog Stereo".  Every UI
+ * here is label-driven — the dropdown lists names and maps the chosen label
+ * back to a device id — so identical labels make one of the two radios
+ * unreachable no matter which entry is picked.
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <string.h>
+
+#include "unity.h"
+#include "ui_status.h"
+#include "ui_communication.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+static void set_dev(ui_device_t *d, const char *id, const char *name)
+{
+    memset(d, 0, sizeof(*d));
+    snprintf(d->id, sizeof(d->id), "%s", id);
+    snprintf(d->name, sizeof(d->name), "%s", name);
+}
+
+/* Every label must be unique, or the UI cannot express the choice. */
+void test_colliding_names_become_distinguishable(void)
+{
+    ui_device_t devs[2];
+    set_dev(&devs[0], "alsa_input.usb-Burr-Brown_from_TI_USB_Audio_CODEC-00.analog-stereo",
+            "PCM2901 Audio Codec Analog Stereo");
+    set_dev(&devs[1], "alsa_input.usb-Burr-Brown_from_TI_USB_Audio_CODEC-00.2.analog-stereo",
+            "PCM2901 Audio Codec Analog Stereo");
+
+    ui_devices_disambiguate(devs, 2);
+
+    TEST_ASSERT_TRUE_MESSAGE(strcmp(devs[0].name, devs[1].name) != 0,
+        "two devices still share a label: the operator cannot pick between them");
+}
+
+/* The distinguishing part has to be the id, and it has to survive whole —
+ * these ids share a 51-character prefix, so a truncated one would still tie. */
+void test_label_carries_the_full_id(void)
+{
+    ui_device_t devs[2];
+    set_dev(&devs[0], "alsa_input.usb-Burr-Brown_from_TI_USB_Audio_CODEC-00.analog-stereo",
+            "PCM2901 Audio Codec Analog Stereo");
+    set_dev(&devs[1], "alsa_input.usb-Burr-Brown_from_TI_USB_Audio_CODEC-00.2.analog-stereo",
+            "PCM2901 Audio Codec Analog Stereo");
+
+    ui_devices_disambiguate(devs, 2);
+
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(devs[0].name, devs[0].id),
+                                 "label does not carry its own device id");
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(devs[1].name, devs[1].id),
+                                 "label does not carry its own device id");
+}
+
+/* The ordinary one-radio case must still read as plain English. */
+void test_unique_names_are_left_alone(void)
+{
+    ui_device_t devs[2];
+    set_dev(&devs[0], "alsa_input.usb-ICOM_IC-7300", "IC-7300 Analog Stereo");
+    set_dev(&devs[1], "alsa_input.pci-0000_00_1f.3", "Built-in Audio Analog Stereo");
+
+    ui_devices_disambiguate(devs, 2);
+
+    TEST_ASSERT_EQUAL_STRING("IC-7300 Analog Stereo", devs[0].name);
+    TEST_ASSERT_EQUAL_STRING("Built-in Audio Analog Stereo", devs[1].name);
+}
+
+/* Three of a kind: all three must end up distinct, not just the first pair. */
+void test_three_way_collision(void)
+{
+    ui_device_t devs[3];
+    set_dev(&devs[0], "id-a", "USB Audio CODEC");
+    set_dev(&devs[1], "id-b", "USB Audio CODEC");
+    set_dev(&devs[2], "id-c", "USB Audio CODEC");
+
+    ui_devices_disambiguate(devs, 3);
+
+    TEST_ASSERT_TRUE(strcmp(devs[0].name, devs[1].name) != 0);
+    TEST_ASSERT_TRUE(strcmp(devs[0].name, devs[2].name) != 0);
+    TEST_ASSERT_TRUE(strcmp(devs[1].name, devs[2].name) != 0);
+}
+
+/* Degenerate inputs must not crash: called on every list refresh. */
+void test_degenerate_inputs(void)
+{
+    ui_device_t one;
+    set_dev(&one, "id", "Only Device");
+    ui_devices_disambiguate(NULL, 5);
+    ui_devices_disambiguate(&one, 0);
+    ui_devices_disambiguate(&one, 1);
+    TEST_ASSERT_EQUAL_STRING("Only Device", one.name);
+}
+
+/* A device with no id cannot be disambiguated; it must be left as-is rather
+ * than gaining an empty "[]" suffix. */
+void test_missing_id_is_left_alone(void)
+{
+    ui_device_t devs[2];
+    set_dev(&devs[0], "", "Same Name");
+    set_dev(&devs[1], "real-id", "Same Name");
+
+    ui_devices_disambiguate(devs, 2);
+
+    TEST_ASSERT_EQUAL_STRING("Same Name", devs[0].name);
+    TEST_ASSERT_NOT_NULL(strstr(devs[1].name, "real-id"));
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_colliding_names_become_distinguishable);
+    RUN_TEST(test_label_carries_the_full_id);
+    RUN_TEST(test_unique_names_are_left_alone);
+    RUN_TEST(test_three_way_collision);
+    RUN_TEST(test_degenerate_inputs);
+    RUN_TEST(test_missing_id_is_left_alone);
+    return UNITY_END();
+}


### PR DESCRIPTION
Fixes #189.

## The problem

Two USB codecs of the same model report the same human-readable name — an IC-7300 and an IC-9700 both present "PCM2901 Audio Codec Analog Stereo". Their ids differ:

```
alsa_input.usb-Burr-Brown_from_TI_USB_Audio_CODEC-00.analog-stereo
alsa_input.usb-Burr-Brown_from_TI_USB_Audio_CODEC-00.2.analog-stereo
```

but nothing the operator can see does.

Every UI here is label-driven: the dropdown lists **names**, and the chosen label is mapped back to a device **id** by matching it against the list (`selectedID()` in `fyne-ui/main.go`). With duplicate labels that lookup returns the first match, so both entries resolve to the same card and the second radio is unreachable — exactly the reported "no matter which one I choose, it always picks the `.2` variants".

Worth noting the backend was never at fault: `resolve_device_string()` returns immediately on an exact native id and refuses to guess when a *name* is ambiguous. The choice was destroyed before it got there.

## The fix

Append the device id to any name shared by more than one device. Names that don't collide are untouched, so a one-radio setup still reads as plain English:

```
PCM2901 Audio Codec Analog Stereo [alsa_input.usb-…CODEC-00.analog-stereo]
PCM2901 Audio Codec Analog Stereo [alsa_input.usb-…CODEC-00.2.analog-stereo]
```

Done once in `ui_comm_get_audio_devices()` rather than per front end, so the embedded UI and the websocket list show the same labels. Both already send the id back.

## Testing

`ui_devices.c` is its own translation unit so the logic is testable without linking the websocket server. Six cases in `tests/gui_interface/test_ui_devices.c`, all failing against the unfixed code (5 of 6 fail with the relabel disabled).

The tests earned their keep immediately: the first version renamed devices *while* scanning for collisions, so each renamed device stopped matching the partner it collided with and only the first of a group was ever labelled. Collisions are now decided against the original names before anything is rewritten.

## Not truncation

Distinct from #185 — these ids differ within the first 64 characters, and `UI_DEV_ID_MAX` has been 256 since that fix.

Full unit suite green.