### PR TITLE
Notify on incompatible audio device sample rate

### DIFF
--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -158,6 +158,25 @@ bool audioio_health_ok(char *reason, size_t reasonlen)
     return ok;
 }
 
+/* Operator-facing fix for a rate the modem cannot use.  ALSA's plug layer
+ * resamples when the device is named plughw: instead of hw:, but the Windows
+ * and macOS backends have no such indirection: the device itself must be set
+ * to a supported rate in the OS sound settings. */
+static const char *audio_rate_mismatch_hint(void)
+{
+    switch (audio_subsystem)
+    {
+    case AUDIO_SUBSYSTEM_ALSA:
+        return "try plughw:X,Y instead of hw:X,Y so ALSA converts";
+    case AUDIO_SUBSYSTEM_WASAPI:
+    case AUDIO_SUBSYSTEM_DSOUND:
+    case AUDIO_SUBSYSTEM_COREAUDIO:
+        return "set the device sample rate to 48000 Hz in the OS sound settings";
+    default:
+        return "set the device sample rate to a supported value";
+    }
+}
+
 static void format_device_display(int audio_subsys, int mode, const char *id, char *out, size_t outsz);
 static int get_soundcard_list_int(int audio_system, int mode,
                                   char ids[][AUDIO_DEV_STR_MAX], char dev_names[][AUDIO_DEV_STR_MAX], int max_count,
@@ -994,9 +1013,8 @@ void *radio_playback_thread(void *device_ptr)
         char why[160];
         snprintf(why, sizeof(why),
                  "device negotiated %u Hz, not a multiple of %d Hz "
-                 "(supported 8k/16k/24k/32k/48k/96k) -- try plughw:X,Y instead "
-                 "of hw:X,Y so ALSA converts",
-                 cfg->sample_rate, RESAMP_MODEM_FS);
+                 "(supported 8k/16k/24k/32k/48k/96k) -- %s",
+                 cfg->sample_rate, RESAMP_MODEM_FS, audio_rate_mismatch_hint());
         HLOGE("audio-play", "%s", why);
         audio_health_set(false, AUDIO_HEALTH_FAILED, why);
         goto cleanup_play;
@@ -1360,9 +1378,8 @@ void *radio_capture_thread(void *device_ptr)
         char why[160];
         snprintf(why, sizeof(why),
                  "device negotiated %u Hz, not a multiple of %d Hz "
-                 "(supported 8k/16k/24k/32k/48k/96k) -- try plughw:X,Y instead "
-                 "of hw:X,Y so ALSA converts",
-                 cfg->sample_rate, RESAMP_MODEM_FS);
+                 "(supported 8k/16k/24k/32k/48k/96k) -- %s",
+                 cfg->sample_rate, RESAMP_MODEM_FS, audio_rate_mismatch_hint());
         HLOGE("audio-cap", "%s", why);
         audio_health_set(true, AUDIO_HEALTH_FAILED, why);
         audio->free(b);

--- a/gui_interface/fyne-ui/link_engine.go
+++ b/gui_interface/fyne-ui/link_engine.go
@@ -329,6 +329,8 @@ func statusFromC(cst *C.ui_status_t) telemetryState {
 		TXGainDB:           float64(cst.tx_gain_db),
 		TXPeakDBFS:         float64(cst.tx_peak_dbfs),
 		Waterfall:          bool(cst.waterfall_enabled),
+		AudioOk:            bool(cst.audio_ok),
+		AudioError:         C.GoString(&cst.audio_error[0]),
 	}
 }
 

--- a/gui_interface/fyne-ui/main.go
+++ b/gui_interface/fyne-ui/main.go
@@ -147,7 +147,7 @@ func parseStatusMessage(payload []byte) (telemetryState, error) {
 		// than nagging with a spurious "device error" popup.
 		status.AudioOk = true
 	}
-	status.AudioError = fmt.Sprint(raw["audio_error"])
+	status.AudioError = toString(raw["audio_error"])
 	return status, nil
 }
 
@@ -204,6 +204,16 @@ func toBool(v any) bool {
 	default:
 		return false
 	}
+}
+
+// toString renders a JSON value as a string, but unlike fmt.Sprint it maps a
+// missing field (nil) to "" rather than "<nil>" — the caller wants an empty
+// string when the field is absent, not a literal "<nil>" to show the operator.
+func toString(v any) string {
+	if v == nil {
+		return ""
+	}
+	return fmt.Sprint(v)
 }
 
 // runOnUI runs fn on Fyne's main goroutine. Fyne v2.6+ requires all widget

--- a/gui_interface/fyne-ui/main.go
+++ b/gui_interface/fyne-ui/main.go
@@ -79,6 +79,8 @@ type telemetryState struct {
 	TXGainDB           float64
 	TXPeakDBFS         float64
 	Waterfall          bool
+	AudioOk            bool
+	AudioError         string
 }
 
 type uiBindings struct {
@@ -138,6 +140,14 @@ func parseStatusMessage(payload []byte) (telemetryState, error) {
 	status.TXGainDB = toFloat64(raw["tx_gain_db"])
 	status.TXPeakDBFS = toFloat64(raw["tx_peak_dbfs"])
 	status.Waterfall = toBool(raw["waterfall"])
+	if v, present := raw["audio_ok"]; present {
+		status.AudioOk = toBool(v)
+	} else {
+		// An older engine does not send the field; treat it as healthy rather
+		// than nagging with a spurious "device error" popup.
+		status.AudioOk = true
+	}
+	status.AudioError = fmt.Sprint(raw["audio_error"])
 	return status, nil
 }
 
@@ -677,6 +687,12 @@ func main() {
 		})
 	}
 
+	// Audio health popup state. applyStatus runs on the single link goroutine,
+	// so plain captured booleans are safe here; they track the previous status
+	// so the dialog fires once per failure, not on every 500 ms poll.
+	var prevAudioOk bool
+	var seenStatus bool
+
 	applyStatus := func(status telemetryState) {
 		// Under the lock: the link goroutine writes this while the GL thread
 		// reads it in refreshTelemetry(). telemetryState holds strings, so an
@@ -690,6 +706,21 @@ func main() {
 		if haveSpectrum {
 			refreshSpectrum()
 		}
+
+		// A device that fails to open, or negotiates a rate the modem cannot
+		// use, otherwise leaves the UI showing a healthy station that hears
+		// nothing -- so surface it as a dialog on the transition to failure.
+		if !status.AudioOk && (!seenStatus || prevAudioOk) {
+			msg := status.AudioError
+			if msg == "" {
+				msg = "The audio device could not be started."
+			}
+			runOnUI(func() {
+				dialog.ShowInformation("Audio Device Error", msg, myWindow)
+			})
+		}
+		prevAudioOk = status.AudioOk
+		seenStatus = true
 	}
 
 	updateConnectionButton = func() {

--- a/gui_interface/fyne-ui/main_test.go
+++ b/gui_interface/fyne-ui/main_test.go
@@ -107,6 +107,23 @@ func TestParseStatusMessageMissingAudioDefaultsHealthy(t *testing.T) {
 	}
 }
 
+// audio_ok:false with no audio_error must parse to an empty string, so the
+// dialog's fallback message fires instead of showing the literal "<nil>".
+func TestParseStatusMessageAudioFailureWithoutErrorDefaultsEmpty(t *testing.T) {
+	payload := []byte(`{"type":"status","audio_ok":false}`)
+
+	status, err := parseStatusMessage(payload)
+	if err != nil {
+		t.Fatalf("parseStatusMessage returned error: %v", err)
+	}
+	if status.AudioOk {
+		t.Fatal("expected audio_ok to be false")
+	}
+	if status.AudioError != "" {
+		t.Fatalf("expected missing audio_error to parse as empty, got %q", status.AudioError)
+	}
+}
+
 func TestBuildWebSocketURLUsesWebsocketPath(t *testing.T) {
 	got := buildWebSocketURL("ws", "127.0.0.1", "10000")
 	want := "ws://127.0.0.1:10000/websocket"

--- a/gui_interface/fyne-ui/main_test.go
+++ b/gui_interface/fyne-ui/main_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"image"
 	"math"
+	"strings"
 	"testing"
 )
 
@@ -51,7 +52,7 @@ func TestConcurrentSpectrumAccessNoRace(t *testing.T) {
 }
 
 func TestParseStatusMessage(t *testing.T) {
-	payload := []byte(`{"type":"status","bitrate":1200,"snr":6.5,"sync":true,"direction":"tx","client_tcp_connected":true,"bytes_transmitted":34,"bytes_received":900,"tx_gain_db":3.5,"tx_peak_dbfs":-2.1,"waterfall":true}`)
+	payload := []byte(`{"type":"status","bitrate":1200,"snr":6.5,"sync":true,"direction":"tx","client_tcp_connected":true,"bytes_transmitted":34,"bytes_received":900,"tx_gain_db":3.5,"tx_peak_dbfs":-2.1,"waterfall":true,"audio_ok":true,"audio_error":""}`)
 
 	status, err := parseStatusMessage(payload)
 	if err != nil {
@@ -71,6 +72,38 @@ func TestParseStatusMessage(t *testing.T) {
 	}
 	if status.Waterfall != true {
 		t.Fatal("expected waterfall to be true")
+	}
+	if !status.AudioOk {
+		t.Fatal("expected audio_ok to be true")
+	}
+}
+
+func TestParseStatusMessageReportsAudioFailure(t *testing.T) {
+	payload := []byte(`{"type":"status","audio_ok":false,"audio_error":"capture: device negotiated 44100 Hz, not a multiple of 8000 Hz"}`)
+
+	status, err := parseStatusMessage(payload)
+	if err != nil {
+		t.Fatalf("parseStatusMessage returned error: %v", err)
+	}
+	if status.AudioOk {
+		t.Fatal("expected audio_ok to be false")
+	}
+	if !strings.Contains(status.AudioError, "44100 Hz") {
+		t.Fatalf("expected audio_error to mention the rate, got %q", status.AudioError)
+	}
+}
+
+// A status from an older engine without the audio fields must not be treated
+// as an audio failure (which would pop a spurious error dialog).
+func TestParseStatusMessageMissingAudioDefaultsHealthy(t *testing.T) {
+	payload := []byte(`{"type":"status","bitrate":1200}`)
+
+	status, err := parseStatusMessage(payload)
+	if err != nil {
+		t.Fatalf("parseStatusMessage returned error: %v", err)
+	}
+	if !status.AudioOk {
+		t.Fatal("expected missing audio_ok to default to healthy")
 	}
 }
 


### PR DESCRIPTION
## Problem

A sound device set to a rate that is not a multiple of 8 kHz (e.g. 44100 Hz) silently fails: the capture/playback thread logs an error and exits, but the desktop UI keeps showing a healthy station — the waterfall is just empty. No indication of the error in the UI. Reported on Issue #193 

```
[ERR] [audio-cap] device negotiated 44100 Hz, not a multiple of 8000 Hz (supported 8k/16k/24k/32k/48k/96k) -- try plughw:X,Y instead of hw:X,Y so ALSA converts
```

## Change

- Carry `audio_ok` / `audio_error` into the Fyne UI status and pop a dialog on the transition to an audio failure (once per failure, not on every poll). Status from an older engine that omits `audio_ok` defaults to healthy so it does not trigger a spurious dialog.
- Make the rate-mismatch hint subsystem-aware: ALSA keeps the `plughw` suggestion; Windows/macOS now says to set the device to a supported rate in the OS sound settings instead of the ALSA-specific fix.

## Tested

- `go test ./...`
- `go vet -tags mercury_embedded ./...`
- `gofmt -l` (clean)
- `gcc -fsyntax-only` on `audioio/audioio.c`