### PR TITLE
gui: keep the device id whole when the label will not fit (#189 follow-up)

### DIFF
--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -539,7 +539,7 @@ void *ui_publisher_thread(void *arg)
 
             /* Same enumerator the embedded UI calls, rendered as JSON.
              * devs[] and the JSON scratch go on the heap: 32 ui_device_t is
-             * 16 KB and buf another 8 KB, which is a lot to put on a thread
+             * 16 KB and buf another 18 KB, which is far too much for a thread
              * stack that is 512 KB by default on macOS. */
             ui_device_t *devs = malloc(sizeof(*devs) * 32);
             /* Big enough that 32 rows cannot overflow it even at the widest

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -542,20 +542,38 @@ void *ui_publisher_thread(void *arg)
              * 16 KB and buf another 8 KB, which is a lot to put on a thread
              * stack that is 512 KB by default on macOS. */
             ui_device_t *devs = malloc(sizeof(*devs) * 32);
-            char *buf = malloc(8192);
+            /* Big enough that 32 rows cannot overflow it even at the widest
+             * name and id the struct allows, plus the JSON scaffolding.  It
+             * used to be 8 KB, which was comfortable only while names were
+             * short: ui_devices_disambiguate() appends the id to any name two
+             * devices share, and ui_device_list_to_json() refuses to emit
+             * truncated JSON — so an overflow does not corrupt the list, it
+             * silently publishes no list at all. */
+            const size_t json_cap = 32 * (UI_DEV_NAME_MAX + UI_DEV_ID_MAX + 32) + 256;
+            char *buf = malloc(json_cap);
             char sel[UI_DEV_ID_MAX];
 
             if (devs && buf)
             {
                 int cap_count = ui_comm_get_audio_devices(UI_DEV_CAPTURE, devs, 32, sel, sizeof(sel));
-                if (cap_count > 0 &&
-                    ui_device_list_to_json("capture_dev_list", devs, cap_count, sel, buf, 8192) > 0)
-                    ws_broadcast_json(&ctx->ws, buf);
+                if (cap_count > 0)
+                {
+                    if (ui_device_list_to_json("capture_dev_list", devs, cap_count, sel, buf, json_cap) > 0)
+                        ws_broadcast_json(&ctx->ws, buf);
+                    else
+                        HLOGW(UI_LOG_TAG, "capture device list did not fit its JSON buffer "
+                                          "(%d devices) — not published", cap_count);
+                }
 
                 int pb_count = ui_comm_get_audio_devices(UI_DEV_PLAYBACK, devs, 32, sel, sizeof(sel));
-                if (pb_count > 0 &&
-                    ui_device_list_to_json("playback_dev_list", devs, pb_count, sel, buf, 8192) > 0)
-                    ws_broadcast_json(&ctx->ws, buf);
+                if (pb_count > 0)
+                {
+                    if (ui_device_list_to_json("playback_dev_list", devs, pb_count, sel, buf, json_cap) > 0)
+                        ws_broadcast_json(&ctx->ws, buf);
+                    else
+                        HLOGW(UI_LOG_TAG, "playback device list did not fit its JSON buffer "
+                                          "(%d devices) — not published", pb_count);
+                }
             }
             else
             {

--- a/gui_interface/ui_devices.c
+++ b/gui_interface/ui_devices.c
@@ -61,10 +61,29 @@ void ui_devices_disambiguate(ui_device_t *devs, int count)
         if (!needs_id[i] || devs[i].id[0] == '\0')
             continue;
 
-        /* Distinct ids can share a long prefix, so the id goes on whole and
-         * snprintf bounds it. */
+        /* The id is the part that distinguishes these entries, so it is the
+         * part that must survive.  Appending it and letting snprintf trim the
+         * result would truncate from the RIGHT, cutting the id — and two ids
+         * that differ only past the cut then produce byte-identical labels
+         * again, silently undoing this whole function.  Give the id its full
+         * width and spend whatever is left on the name. */
         char label[UI_DEV_NAME_MAX];
-        snprintf(label, sizeof(label), "%s [%s]", devs[i].name, devs[i].id);
+        const size_t cap = sizeof(label);          /* includes the NUL */
+        const size_t idl = strlen(devs[i].id);
+        const size_t deco = 3;                      /* " [" and "]" */
+
+        if (idl + deco + 1 <= cap)
+        {
+            snprintf(label, cap, "%.*s [%s]",
+                     (int)(cap - 1 - deco - idl), devs[i].name, devs[i].id);
+        }
+        else
+        {
+            /* Pathological: the id alone overflows the field.  Drop the name
+             * entirely and keep the id's TAIL — a truncated head is what ids
+             * share, a tail is where they differ. */
+            snprintf(label, cap, "[%s]", devs[i].id + (idl - (cap - deco)));
+        }
         snprintf(devs[i].name, sizeof(devs[i].name), "%s", label);
     }
 

--- a/tests/gui_interface/test_ui_devices.c
+++ b/tests/gui_interface/test_ui_devices.c
@@ -113,6 +113,50 @@ void test_missing_id_is_left_alone(void)
     TEST_ASSERT_NOT_NULL(strstr(devs[1].name, "real-id"));
 }
 
+/* Long names must not eat the id.  UI_DEV_NAME_MAX is 256 and the label is
+ * "<name> [<id>]", so a wordy product string plus a long PulseAudio node name
+ * overflows the field.  Truncating from the right cuts the id, and two ids
+ * that differ only past the cut collapse to the same label — the fix undoing
+ * itself, silently.  The id has to survive; the name is what gives way. */
+void test_long_name_does_not_truncate_the_id(void)
+{
+    char longname[200];
+    memset(longname, 'X', sizeof(longname) - 1);
+    longname[sizeof(longname) - 1] = '\0';
+    memcpy(longname, "USB Audio CODEC ", 16);
+
+    char id1[240], id2[242];
+    snprintf(id1, sizeof(id1), "alsa_input.usb-vendor_%0*d-00.analog-stereo", 200, 0);
+    snprintf(id2, sizeof(id2), "alsa_input.usb-vendor_%0*d-00.2.analog-stereo", 200, 0);
+
+    ui_device_t devs[2];
+    set_dev(&devs[0], id1, longname);
+    set_dev(&devs[1], id2, longname);
+
+    ui_devices_disambiguate(devs, 2);
+
+    TEST_ASSERT_TRUE_MESSAGE(strcmp(devs[0].name, devs[1].name) != 0,
+        "labels collapsed to the same string: the id was truncated away");
+}
+
+/* Whatever happens, the label must stay inside the field and NUL-terminated. */
+void test_label_always_fits_the_field(void)
+{
+    char maxid[UI_DEV_ID_MAX];
+    memset(maxid, 'z', sizeof(maxid) - 1);
+    maxid[sizeof(maxid) - 1] = '\0';
+
+    ui_device_t devs[2];
+    set_dev(&devs[0], maxid, "Same Name");
+    maxid[0] = 'a';
+    set_dev(&devs[1], maxid, "Same Name");
+
+    ui_devices_disambiguate(devs, 2);
+
+    TEST_ASSERT_TRUE(strlen(devs[0].name) < UI_DEV_NAME_MAX);
+    TEST_ASSERT_TRUE(strlen(devs[1].name) < UI_DEV_NAME_MAX);
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -122,5 +166,7 @@ int main(void)
     RUN_TEST(test_three_way_collision);
     RUN_TEST(test_degenerate_inputs);
     RUN_TEST(test_missing_id_is_left_alone);
+    RUN_TEST(test_long_name_does_not_truncate_the_id);
+    RUN_TEST(test_label_always_fits_the_field);
     return UNITY_END();
 }


### PR DESCRIPTION
Two follow-ups to #195, both from checking the actual values of `UI_DEV_NAME_MAX` and `UI_DEV_ID_MAX` — they are **256 each**.

## 1. The disambiguation could silently undo itself

#195 builds `"<name> [<id>]"` into a `UI_DEV_NAME_MAX` field. With both parts up to 256 bytes the label can be **513 characters into a 256-byte field**, and `snprintf` trims from the *right* — cutting the id. Two ids differing only past the cut then produce byte-identical labels, which is precisely the bug the function exists to prevent, now failing silently.

Demonstrated: a 196-char product name with two ~240-char PulseAudio ids differing at `-00.` vs `-00.2.` collapses to one label.

The id is the distinguishing part, so it now gets its full width and the name spends what is left. If even the id alone overflows, its **tail** is kept — a shared head is what makes ids look alike; the tail is where they differ.

The new test fails against the naive append; a second pins that the label stays inside the field and NUL-terminated whatever the inputs.

## 2. The JSON buffer, with the arithmetic done properly

I added this to #195, then reverted it as speculative on the grounds that the 8 KB buffer only got tight around 32 devices. That number was wrong. A row is up to `UI_DEV_NAME_MAX + UI_DEV_ID_MAX + 20` = **532 bytes**, so 8 KB holds **fifteen** — reachable on a desktop with a couple of USB codecs, HDMI outputs and a loopback.

Typical PulseAudio rows are ~130 bytes, so about sixty would fit; this is not the reported bug. It is a silent cliff: `ui_device_list_to_json()` refuses to emit truncated JSON, so an overflow publishes *no* device list at all. Sized from the struct's own limits, plus a log line if a list is ever dropped.

Full unit suite green (8 cases in `test_ui_devices`).