### PR TITLE
audioio: support the 44.1 kHz family, and report the failures that remain (#193)

### DIFF
--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -1044,7 +1044,10 @@ void *radio_playback_thread(void *device_ptr)
         HLOGI("audio-play", "device negotiated %u Hz; resampling %d/%d",
               cfg->sample_rate, rl, rm);
     }
-    if (cfg->sample_rate != 48000)
+    /* Only for the integer engine: on the rational path resample_ratio is 0
+     * and the L/M actually in use was logged above, so this would print
+     * "resampling 1:0". */
+    if (!rat_up && cfg->sample_rate != 48000)
         HLOGW("audio-play", "device negotiated %u Hz (not the requested 48000); "
               "resampling 1:%d", cfg->sample_rate, resample_ratio);
 
@@ -1448,7 +1451,9 @@ void *radio_capture_thread(void *device_ptr)
         HLOGI("audio-cap", "device negotiated %u Hz; resampling %d/%d",
               cfg->sample_rate, rl, rm);
     }
-    if (cfg->sample_rate != 48000)
+    /* Integer engine only -- see the playback path; this would otherwise
+     * print "decimating 0:1" for every 44.1 kHz card. */
+    if (!rat_down && cfg->sample_rate != 48000)
         HLOGW("audio-cap", "device negotiated %u Hz (not the requested 48000); "
               "decimating %d:1", cfg->sample_rate, resample_ratio);
 

--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -158,6 +158,22 @@ bool audioio_health_ok(char *reason, size_t reasonlen)
     return ok;
 }
 
+/* What the operator can actually do about a rate the modem cannot use.  ALSA
+ * has a plug layer that converts when the device is named plughw: instead of
+ * hw:; Windows and macOS have no such indirection, so the fix there is the OS
+ * sound settings.  Telling a Windows user to try plughw: is worse than saying
+ * nothing. */
+static const char *audio_rate_advice(void)
+{
+    switch (audio_subsystem)
+    {
+    case AUDIO_SUBSYSTEM_ALSA:
+        return "try plughw:X,Y instead of hw:X,Y so ALSA converts";
+    default:
+        return "set the device to a supported rate in the OS sound settings";
+    }
+}
+
 static void format_device_display(int audio_subsys, int mode, const char *id, char *out, size_t outsz);
 static int get_soundcard_list_int(int audio_system, int mode,
                                   char ids[][AUDIO_DEV_STR_MAX], char dev_names[][AUDIO_DEV_STR_MAX], int max_count,
@@ -908,6 +924,9 @@ void *radio_playback_thread(void *device_ptr)
     /* Resampling ratio: set once the device has told us its real rate (below,
      * after open()), never assumed. */
     int resample_ratio = RESAMP_L;
+    /* Non-NULL when the device rate is not an integer multiple of 8 kHz and
+     * the rational engine is doing the conversion instead. */
+    resamp_rat_t *rat_up = NULL;
 
     /* PulseAudio uses a single global context (gconn in pulse.c).
      * If init() returns "already initialized" it means the capture thread
@@ -991,15 +1010,27 @@ void *radio_playback_thread(void *device_ptr)
     resample_ratio = resampler_ratio_for_rate((int)cfg->sample_rate);
     if (resample_ratio == 0)
     {
-        char why[160];
-        snprintf(why, sizeof(why),
-                 "device negotiated %u Hz, not a multiple of %d Hz "
-                 "(supported 8k/16k/24k/32k/48k/96k) -- try plughw:X,Y instead "
-                 "of hw:X,Y so ALSA converts",
-                 cfg->sample_rate, RESAMP_MODEM_FS);
-        HLOGE("audio-play", "%s", why);
-        audio_health_set(false, AUDIO_HEALTH_FAILED, why);
-        goto cleanup_play;
+        /* Not an integer multiple of 8 kHz: convert by L/M instead (8000 ->
+         * 44100 is 441/80).  Only a rate outside the supported set is fatal. */
+        if (resampler_rate_supported((int)cfg->sample_rate))
+            rat_up = resamp_rat_create(RESAMP_MODEM_FS, (int)cfg->sample_rate);
+
+        if (!rat_up)
+        {
+            char why[220];
+            snprintf(why, sizeof(why),
+                     "device negotiated %u Hz, which the modem cannot resample "
+                     "(supported 8k/11.025k/16k/22.05k/24k/32k/44.1k/48k/"
+                     "88.2k/96k/176.4k/192k) -- %s",
+                     cfg->sample_rate, audio_rate_advice());
+            HLOGE("audio-play", "%s", why);
+            audio_health_set(false, AUDIO_HEALTH_FAILED, why);
+            goto cleanup_play;
+        }
+        int rl = 0, rm = 0;
+        resamp_rat_ratio(rat_up, &rl, &rm);
+        HLOGI("audio-play", "device negotiated %u Hz; resampling %d/%d",
+              cfg->sample_rate, rl, rm);
     }
     if (cfg->sample_rate != 48000)
         HLOGW("audio-play", "device negotiated %u Hz (not the requested 48000); "
@@ -1043,9 +1074,12 @@ void *radio_playback_thread(void *device_ptr)
      * Built for the rate the device ACTUALLY negotiated: resampling by the
      * requested 48 kHz ratio when the device came back at some other rate
      * transmits everything off-frequency, silently and convincingly. */
-    resampler_init_up(resample_ratio);
     resamp_up_t up_rs;
-    resamp_up_reset(&up_rs);
+    if (!rat_up)
+    {
+        resampler_init_up(resample_ratio);
+        resamp_up_reset(&up_rs);
+    }
 
     while (!shutdown_ && !audio_shutdown_)
     {
@@ -1074,9 +1108,14 @@ void *radio_playback_thread(void *device_ptr)
 
         int samples_read_8k = n / sizeof(int32_t);
 
-        // Upsample 8kHz -> 48kHz through the polyphase anti-imaging FIR.
+        /* Upsample 8 kHz -> the device rate through the polyphase anti-imaging
+         * FIR: integer ratio where the rate allows it, rational L/M otherwise
+         * (the 44.1 kHz family). */
         int samples_upsampled =
-            resamp_up_process(&up_rs, input_buffer, samples_read_8k, buffer_upsampled);
+            rat_up ? resamp_rat_process(rat_up, input_buffer, samples_read_8k,
+                                        buffer_upsampled)
+                   : resamp_up_process(&up_rs, input_buffer, samples_read_8k,
+                                       buffer_upsampled);
 
         /* Expand the upsampled mono modem signal into the device's negotiated
          * channel/format layout.  cfg->channels is 1 or 2; cfg->format is what
@@ -1163,6 +1202,8 @@ void *radio_playback_thread(void *device_ptr)
         HLOGE("audio-play", "ffaudio.clear: %s", audio->error(b));
 
 cleanup_play:
+    resamp_rat_free(rat_up);
+    rat_up = NULL;
 
     audio->free(b);
 
@@ -1274,6 +1315,7 @@ void *radio_capture_thread(void *device_ptr)
     /* Resampling ratio: set once the device reports its real rate (below,
      * after open()), never assumed. */
     int resample_ratio = RESAMP_L;
+    resamp_rat_t *rat_down = NULL;
 
     /* PulseAudio uses a single global context (gconn in pulse.c).
      * If init() returns "already initialized" it means the playback thread
@@ -1354,19 +1396,29 @@ void *radio_capture_thread(void *device_ptr)
     {
         /* 44100 and 22050 are the common ones here: both are what a consumer
          * USB codec reports natively, and neither is an integer multiple of
-         * the modem rate.  Naming plughw matters -- ALSA's plug layer converts
-         * transparently and is what mercury.ini.example already recommends, so
-         * the operator's fix is a device string, not a different sound card. */
-        char why[160];
-        snprintf(why, sizeof(why),
-                 "device negotiated %u Hz, not a multiple of %d Hz "
-                 "(supported 8k/16k/24k/32k/48k/96k) -- try plughw:X,Y instead "
-                 "of hw:X,Y so ALSA converts",
-                 cfg->sample_rate, RESAMP_MODEM_FS);
-        HLOGE("audio-cap", "%s", why);
-        audio_health_set(true, AUDIO_HEALTH_FAILED, why);
-        audio->free(b);
-        return NULL;
+         * the modem rate.  They are converted by L/M rather than refused --
+         * on Windows and macOS there is no plug layer to fall back on, so
+         * refusing meant the card simply could not be used (issue #193). */
+        if (resampler_rate_supported((int)cfg->sample_rate))
+            rat_down = resamp_rat_create((int)cfg->sample_rate, RESAMP_MODEM_FS);
+
+        if (!rat_down)
+        {
+            char why[220];
+            snprintf(why, sizeof(why),
+                     "device negotiated %u Hz, which the modem cannot resample "
+                     "(supported 8k/11.025k/16k/22.05k/24k/32k/44.1k/48k/"
+                     "88.2k/96k/176.4k/192k) -- %s",
+                     cfg->sample_rate, audio_rate_advice());
+            HLOGE("audio-cap", "%s", why);
+            audio_health_set(true, AUDIO_HEALTH_FAILED, why);
+            audio->free(b);
+            return NULL;
+        }
+        int rl = 0, rm = 0;
+        resamp_rat_ratio(rat_down, &rl, &rm);
+        HLOGI("audio-cap", "device negotiated %u Hz; resampling %d/%d",
+              cfg->sample_rate, rl, rm);
     }
     if (cfg->sample_rate != 48000)
         HLOGW("audio-cap", "device negotiated %u Hz (not the requested 48000); "
@@ -1380,7 +1432,9 @@ void *radio_capture_thread(void *device_ptr)
     cap_frames_max += cap_frames_max / 2 + 64;   /* margin over one read */
 
     buffer_output = (int32_t *) malloc(cap_frames_max * sizeof(int32_t));
-    buffer_downsampled = (int32_t *) malloc((cap_frames_max / resample_ratio + 2) * sizeof(int32_t));
+    buffer_downsampled = (int32_t *) malloc(
+        (rat_down ? (size_t)resamp_rat_max_out(rat_down, (int)cap_frames_max)
+                  : cap_frames_max / resample_ratio + 2) * sizeof(int32_t));
     if (!buffer_output || !buffer_downsampled)
     {
         HLOGE("audio-cap", "Failed to allocate capture buffers");
@@ -1394,9 +1448,12 @@ void *radio_capture_thread(void *device_ptr)
     ch_layout = capture_input_channel_layout;
 
     /* Polyphase anti-aliasing downsampler, stateful across reads. */
-    resampler_init_down(resample_ratio);
     resamp_down_t down_rs;
-    resamp_down_reset(&down_rs);
+    if (!rat_down)
+    {
+        resampler_init_down(resample_ratio);
+        if (rat_down) resamp_rat_reset(rat_down); else resamp_down_reset(&down_rs);
+    }
 
     /* --- Capture rate diagnostics (prints every ~5 seconds) --- */
     uint64_t diag_start_ms = audioio_monotonic_ms();
@@ -1456,7 +1513,7 @@ void *radio_capture_thread(void *device_ptr)
                     free(buffer_downsampled);
                     goto finish_cap;
                 }
-                resamp_down_reset(&down_rs);
+                if (rat_down) resamp_rat_reset(rat_down); else resamp_down_reset(&down_rs);
                 cap_last_data_ms = audioio_monotonic_ms();
             }
             ffthread_sleep(CAP_POLL_MS);
@@ -1580,8 +1637,10 @@ void *radio_capture_thread(void *device_ptr)
         }
 
         int downsampled_frames =
-            resamp_down_process(&down_rs, buffer_output, frames_to_write,
-                                buffer_downsampled);
+            rat_down ? resamp_rat_process(rat_down, buffer_output,
+                                          frames_to_write, buffer_downsampled)
+                     : resamp_down_process(&down_rs, buffer_output,
+                                           frames_to_write, buffer_downsampled);
 
         if (downsampled_frames > 0)
         {
@@ -1644,6 +1703,8 @@ cleanup_cap:
         audio->uninit();
 
 finish_cap:
+    resamp_rat_free(rat_down);
+    rat_down = NULL;
     HLOGI("audio-cap", "radio_capture_thread exit");
 
     // An audio-device failure (or a restart-initiated stop) ends only this

--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -923,6 +923,8 @@ void *radio_playback_thread(void *device_ptr)
     if (!input_buffer || !buffer_upsampled || !buffer_output_stereo)
     {
         HLOGE("audio-play", "Failed to allocate playback buffers");
+        audio_health_set(false, AUDIO_HEALTH_FAILED,
+                         "out of memory allocating the playback buffers");
         goto finish_play;
     }
 
@@ -962,6 +964,8 @@ void *radio_playback_thread(void *device_ptr)
     if (b == NULL)
     {
         HLOGE("audio-play", "Error in audio->alloc()");
+        audio_health_set(false, AUDIO_HEALTH_FAILED,
+                         "out of memory allocating the playback device");
         goto finish_play;
     }
 
@@ -1066,7 +1070,14 @@ void *radio_playback_thread(void *device_ptr)
     if (!playback_is_float && !playback_is_int16 && !playback_is_int24 &&
         cfg->format != FFAUDIO_F_INT32 && cfg->format != FFAUDIO_F_INT24_4)
     {
-        HLOGE("audio-play", "Unsupported playback format %d, aborting", cfg->format);
+        {
+            char why[128];
+            snprintf(why, sizeof(why),
+                     "device negotiated an unsupported playback sample format (%d)",
+                     cfg->format);
+            HLOGE("audio-play", "%s", why);
+            audio_health_set(false, AUDIO_HEALTH_FAILED, why);
+        }
         goto cleanup_play;
     }
 
@@ -1351,6 +1362,8 @@ void *radio_capture_thread(void *device_ptr)
     if (b == NULL)
     {
         HLOGE("audio-cap", "Error in audio->alloc()");
+        audio_health_set(true, AUDIO_HEALTH_FAILED,
+                         "out of memory allocating the capture device");
         goto finish_cap;
     }
 
@@ -1391,7 +1404,14 @@ void *radio_capture_thread(void *device_ptr)
     if (!capture_is_float && !capture_is_int16 && !capture_is_int24 &&
         cfg->format != FFAUDIO_F_INT32 && cfg->format != FFAUDIO_F_INT24_4)
     {
-        HLOGE("audio-cap", "Unsupported capture format %d, aborting", cfg->format);
+        {
+            char why[128];
+            snprintf(why, sizeof(why),
+                     "device negotiated an unsupported capture sample format (%d)",
+                     cfg->format);
+            HLOGE("audio-cap", "%s", why);
+            audio_health_set(true, AUDIO_HEALTH_FAILED, why);
+        }
         audio->free(b);
         return NULL;
     }
@@ -1446,6 +1466,8 @@ void *radio_capture_thread(void *device_ptr)
     if (!buffer_output || !buffer_downsampled)
     {
         HLOGE("audio-cap", "Failed to allocate capture buffers");
+        audio_health_set(true, AUDIO_HEALTH_FAILED,
+                         "out of memory allocating the capture buffers");
         free(buffer_output);
         free(buffer_downsampled);
         buffer_output = NULL;

--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -158,19 +158,27 @@ bool audioio_health_ok(char *reason, size_t reasonlen)
     return ok;
 }
 
-/* What the operator can actually do about a rate the modem cannot use.  ALSA
- * has a plug layer that converts when the device is named plughw: instead of
- * hw:; Windows and macOS have no such indirection, so the fix there is the OS
- * sound settings.  Telling a Windows user to try plughw: is worse than saying
- * nothing. */
-static const char *audio_rate_advice(void)
+/* Operator-facing fix for a rate the modem cannot use.  ALSA's plug layer
+ * resamples when the device is named plughw: instead of hw:, but the Windows
+ * and macOS backends have no such indirection: the device itself must be set
+ * to a supported rate in the OS sound settings.  Telling a Windows user to
+ * try plughw: is worse than saying nothing.
+ *
+ * Reaching this at all now means the rate is outside the supported set
+ * entirely -- the 44.1 kHz family is resampled rather than refused -- so the
+ * advice names a rate that is certain to work. */
+static const char *audio_rate_mismatch_hint(void)
 {
     switch (audio_subsystem)
     {
     case AUDIO_SUBSYSTEM_ALSA:
         return "try plughw:X,Y instead of hw:X,Y so ALSA converts";
+    case AUDIO_SUBSYSTEM_WASAPI:
+    case AUDIO_SUBSYSTEM_DSOUND:
+    case AUDIO_SUBSYSTEM_COREAUDIO:
+        return "set the device sample rate to 48000 Hz in the OS sound settings";
     default:
-        return "set the device to a supported rate in the OS sound settings";
+        return "set the device sample rate to a supported value";
     }
 }
 
@@ -1022,7 +1030,7 @@ void *radio_playback_thread(void *device_ptr)
                      "device negotiated %u Hz, which the modem cannot resample "
                      "(supported 8k/11.025k/16k/22.05k/24k/32k/44.1k/48k/"
                      "88.2k/96k/176.4k/192k) -- %s",
-                     cfg->sample_rate, audio_rate_advice());
+                     cfg->sample_rate, audio_rate_mismatch_hint());
             HLOGE("audio-play", "%s", why);
             audio_health_set(false, AUDIO_HEALTH_FAILED, why);
             goto cleanup_play;
@@ -1409,7 +1417,7 @@ void *radio_capture_thread(void *device_ptr)
                      "device negotiated %u Hz, which the modem cannot resample "
                      "(supported 8k/11.025k/16k/22.05k/24k/32k/44.1k/48k/"
                      "88.2k/96k/176.4k/192k) -- %s",
-                     cfg->sample_rate, audio_rate_advice());
+                     cfg->sample_rate, audio_rate_mismatch_hint());
             HLOGE("audio-cap", "%s", why);
             audio_health_set(true, AUDIO_HEALTH_FAILED, why);
             audio->free(b);

--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -912,13 +912,21 @@ void *radio_playback_thread(void *device_ptr)
     // input is int32_t (8kHz samples from playback_buffer)
     int32_t *input_buffer = (int32_t *) malloc(period_scratch_bytes);
 
-    /* Upsampled mono scratch.  Sized for the WIDEST supported ratio, not the
-     * expected one: the device rate is not known until open() below, and a
-     * 96 kHz negotiation would overrun a buffer sized for 1:6. */
-    int32_t *buffer_upsampled = (int32_t *) malloc(period_scratch_bytes * RESAMP_L_MAX);
+    /* Upsampled mono scratch.  Sized for the WIDEST ratio any engine can
+     * produce, not the expected one: the device rate is not known until open()
+     * below, and a 96 kHz negotiation would overrun a buffer sized for 1:6.
+     *
+     * RESAMP_RATIO_MAX, not RESAMP_L_MAX: the rational engine runs exactly
+     * when the ratio is outside what the integer one handles, so 8 kHz ->
+     * 192 kHz is 24x where RESAMP_L_MAX is 12 -- sizing by the integer maximum
+     * overruns the heap on precisely the rates the rational path exists for. */
+    const size_t up_slack_bytes = RESAMP_RAT_OUT_SLACK * sizeof(int32_t);
+    int32_t *buffer_upsampled =
+        (int32_t *) malloc(period_scratch_bytes * RESAMP_RATIO_MAX + up_slack_bytes);
 
     // output is int32_t, up to stereo, at the device rate
-    int32_t *buffer_output_stereo = (int32_t *) malloc(period_scratch_bytes * 2 * RESAMP_L_MAX);
+    int32_t *buffer_output_stereo =
+        (int32_t *) malloc(period_scratch_bytes * 2 * RESAMP_RATIO_MAX + 2 * up_slack_bytes);
 
     if (!input_buffer || !buffer_upsampled || !buffer_output_stereo)
     {

--- a/audioio/audioio.d
+++ b/audioio/audioio.d
@@ -1,0 +1,35 @@
+audioio.o: audioio.c ffaudio/ffbase/stringz.h ffaudio/ffbase/base.h \
+ ffaudio/ffbase/string.h ffaudio/ffbase/str-convert.h \
+ ffaudio/ffbase/slice.h ffaudio/ffbase/sort.h ffaudio/ffbase/sort.c \
+ ffaudio/ffbase/sort-merge.h ffaudio/ffbase/sort-insertion.h \
+ ffaudio/ffbase/str-format.h ffaudio/ffbase/unicode.h \
+ ffaudio/ffbase/str-format.c ../common/os_interop.h \
+ ffaudio/ffaudio/audio.h std.h ../common/ring_buffer_posix.h \
+ ../common/shm_posix.h ../common/defines_modem.h audioio.h \
+ ../common/hermes_log.h ../common/cfg_utils.h resampler.h pcm24.h \
+ ../common/virtual_clock.h sock_wire.h
+ffaudio/ffbase/stringz.h:
+ffaudio/ffbase/base.h:
+ffaudio/ffbase/string.h:
+ffaudio/ffbase/str-convert.h:
+ffaudio/ffbase/slice.h:
+ffaudio/ffbase/sort.h:
+ffaudio/ffbase/sort.c:
+ffaudio/ffbase/sort-merge.h:
+ffaudio/ffbase/sort-insertion.h:
+ffaudio/ffbase/str-format.h:
+ffaudio/ffbase/unicode.h:
+ffaudio/ffbase/str-format.c:
+../common/os_interop.h:
+ffaudio/ffaudio/audio.h:
+std.h:
+../common/ring_buffer_posix.h:
+../common/shm_posix.h:
+../common/defines_modem.h:
+audioio.h:
+../common/hermes_log.h:
+../common/cfg_utils.h:
+resampler.h:
+pcm24.h:
+../common/virtual_clock.h:
+sock_wire.h:

--- a/audioio/ffaudio/ffaudio/alsa.d
+++ b/audioio/ffaudio/ffaudio/alsa.d
@@ -1,0 +1,21 @@
+ffaudio/ffaudio/alsa.o: ffaudio/ffaudio/alsa.c ffaudio/ffaudio/audio.h \
+ ffaudio/ffaudio/util.h ffaudio/ffbase/string.h ffaudio/ffbase/base.h \
+ ffaudio/ffbase/str-convert.h ffaudio/ffbase/slice.h \
+ ffaudio/ffbase/sort.h ffaudio/ffbase/sort.c ffaudio/ffbase/sort-merge.h \
+ ffaudio/ffbase/sort-insertion.h ffaudio/ffbase/str-format.h \
+ ffaudio/ffbase/unicode.h ffaudio/ffbase/str-format.c \
+ ffaudio/ffbase/stringz.h
+ffaudio/ffaudio/audio.h:
+ffaudio/ffaudio/util.h:
+ffaudio/ffbase/string.h:
+ffaudio/ffbase/base.h:
+ffaudio/ffbase/str-convert.h:
+ffaudio/ffbase/slice.h:
+ffaudio/ffbase/sort.h:
+ffaudio/ffbase/sort.c:
+ffaudio/ffbase/sort-merge.h:
+ffaudio/ffbase/sort-insertion.h:
+ffaudio/ffbase/str-format.h:
+ffaudio/ffbase/unicode.h:
+ffaudio/ffbase/str-format.c:
+ffaudio/ffbase/stringz.h:

--- a/audioio/ffaudio/ffaudio/dsound.d
+++ b/audioio/ffaudio/ffaudio/dsound.d
@@ -1,0 +1,20 @@
+ffaudio/ffaudio/dsound.o: ffaudio/ffaudio/dsound.c \
+ ffaudio/ffaudio/audio.h ffaudio/ffaudio/util.h ffaudio/ffbase/string.h \
+ ffaudio/ffbase/base.h ffaudio/ffbase/str-convert.h \
+ ffaudio/ffbase/slice.h ffaudio/ffbase/sort.h ffaudio/ffbase/sort.c \
+ ffaudio/ffbase/sort-merge.h ffaudio/ffbase/sort-insertion.h \
+ ffaudio/ffbase/str-format.h ffaudio/ffbase/unicode.h \
+ ffaudio/ffbase/str-format.c
+ffaudio/ffaudio/audio.h:
+ffaudio/ffaudio/util.h:
+ffaudio/ffbase/string.h:
+ffaudio/ffbase/base.h:
+ffaudio/ffbase/str-convert.h:
+ffaudio/ffbase/slice.h:
+ffaudio/ffbase/sort.h:
+ffaudio/ffbase/sort.c:
+ffaudio/ffbase/sort-merge.h:
+ffaudio/ffbase/sort-insertion.h:
+ffaudio/ffbase/str-format.h:
+ffaudio/ffbase/unicode.h:
+ffaudio/ffbase/str-format.c:

--- a/audioio/ffaudio/ffaudio/oss.d
+++ b/audioio/ffaudio/ffaudio/oss.d
@@ -1,0 +1,21 @@
+ffaudio/ffaudio/oss.o: ffaudio/ffaudio/oss.c ffaudio/ffaudio/audio.h \
+ ffaudio/ffaudio/util.h ffaudio/ffbase/stringz.h ffaudio/ffbase/base.h \
+ ffaudio/ffbase/string.h ffaudio/ffbase/str-convert.h \
+ ffaudio/ffbase/slice.h ffaudio/ffbase/sort.h ffaudio/ffbase/sort.c \
+ ffaudio/ffbase/sort-merge.h ffaudio/ffbase/sort-insertion.h \
+ ffaudio/ffbase/str-format.h ffaudio/ffbase/unicode.h \
+ ffaudio/ffbase/str-format.c
+ffaudio/ffaudio/audio.h:
+ffaudio/ffaudio/util.h:
+ffaudio/ffbase/stringz.h:
+ffaudio/ffbase/base.h:
+ffaudio/ffbase/string.h:
+ffaudio/ffbase/str-convert.h:
+ffaudio/ffbase/slice.h:
+ffaudio/ffbase/sort.h:
+ffaudio/ffbase/sort.c:
+ffaudio/ffbase/sort-merge.h:
+ffaudio/ffbase/sort-insertion.h:
+ffaudio/ffbase/str-format.h:
+ffaudio/ffbase/unicode.h:
+ffaudio/ffbase/str-format.c:

--- a/audioio/ffaudio/ffaudio/pulse.d
+++ b/audioio/ffaudio/ffaudio/pulse.d
@@ -1,0 +1,22 @@
+ffaudio/ffaudio/pulse.o: ffaudio/ffaudio/pulse.c ffaudio/ffaudio/audio.h \
+ ffaudio/ffaudio/util.h ffaudio/ffbase/stringz.h ffaudio/ffbase/base.h \
+ ffaudio/ffbase/string.h ffaudio/ffbase/str-convert.h \
+ ffaudio/ffbase/slice.h ffaudio/ffbase/sort.h ffaudio/ffbase/sort.c \
+ ffaudio/ffbase/sort-merge.h ffaudio/ffbase/sort-insertion.h \
+ ffaudio/ffbase/str-format.h ffaudio/ffbase/unicode.h \
+ ffaudio/ffbase/str-format.c ffaudio/ffbase/atomic.h
+ffaudio/ffaudio/audio.h:
+ffaudio/ffaudio/util.h:
+ffaudio/ffbase/stringz.h:
+ffaudio/ffbase/base.h:
+ffaudio/ffbase/string.h:
+ffaudio/ffbase/str-convert.h:
+ffaudio/ffbase/slice.h:
+ffaudio/ffbase/sort.h:
+ffaudio/ffbase/sort.c:
+ffaudio/ffbase/sort-merge.h:
+ffaudio/ffbase/sort-insertion.h:
+ffaudio/ffbase/str-format.h:
+ffaudio/ffbase/unicode.h:
+ffaudio/ffbase/str-format.c:
+ffaudio/ffbase/atomic.h:

--- a/audioio/ffaudio/ffaudio/wasapi.d
+++ b/audioio/ffaudio/ffaudio/wasapi.d
@@ -1,0 +1,20 @@
+ffaudio/ffaudio/wasapi.o: ffaudio/ffaudio/wasapi.c \
+ ffaudio/ffaudio/audio.h ffaudio/ffaudio/util.h ffaudio/ffbase/string.h \
+ ffaudio/ffbase/base.h ffaudio/ffbase/str-convert.h \
+ ffaudio/ffbase/slice.h ffaudio/ffbase/sort.h ffaudio/ffbase/sort.c \
+ ffaudio/ffbase/sort-merge.h ffaudio/ffbase/sort-insertion.h \
+ ffaudio/ffbase/str-format.h ffaudio/ffbase/unicode.h \
+ ffaudio/ffbase/str-format.c
+ffaudio/ffaudio/audio.h:
+ffaudio/ffaudio/util.h:
+ffaudio/ffbase/string.h:
+ffaudio/ffbase/base.h:
+ffaudio/ffbase/str-convert.h:
+ffaudio/ffbase/slice.h:
+ffaudio/ffbase/sort.h:
+ffaudio/ffbase/sort.c:
+ffaudio/ffbase/sort-merge.h:
+ffaudio/ffbase/sort-insertion.h:
+ffaudio/ffbase/str-format.h:
+ffaudio/ffbase/unicode.h:
+ffaudio/ffbase/str-format.c:

--- a/audioio/resampler.c
+++ b/audioio/resampler.c
@@ -14,6 +14,12 @@
  * L == 1 (an 8 kHz device: no rate change) is a pass-through — filtering there
  * would only add delay and passband droop for nothing.
  *
+ * Rates that are NOT integer multiples of 8 kHz are handled by the rational
+ * engine at the bottom of this file (44100 -> 8000 is 80/441).  It exists
+ * because Windows and macOS have no equivalent of ALSA's plug layer: a card
+ * left at 44.1 kHz in the OS sound settings could not be used at all, and
+ * failed with an error suggesting an ALSA device string (issue #193).
+ *
  * Copyright (C) 2026 Rhizomatica
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
@@ -21,6 +27,7 @@
 #include "resampler.h"
 
 #include <math.h>
+#include <stdlib.h>
 #include <string.h>
 
 #ifndef M_PI
@@ -209,4 +216,206 @@ float resampler_down_tap(int t)
 {
     if (t < 0 || t >= RESAMP_NTAPS_MAX) return 0.0f;
     return h_down[t];
+}
+
+/* ======================================================================
+ * Rational resampler
+ * ======================================================================
+ *
+ * Same polyphase idea as the integer engine, generalised: convert by L/M in
+ * lowest terms, so 44100 -> 8000 is 80/441 rather than "not a multiple of
+ * 8000, refuse".  Output sample n is taken at input position n*M/L, which
+ * splits into a base sample index and a filter phase; both advance by exact
+ * integer arithmetic, so there is no drift however long the stream runs.
+ *
+ * The prototype spans a fixed amount of TIME rather than a fixed tap count,
+ * the same rule the integer engine follows: at 8 kHz in that is 30 taps, at
+ * 44.1 kHz in it is 166.  A tap count fixed across rates would make the
+ * anti-aliasing filter progressively shorter in time as the input rate rose,
+ * which is exactly where it is needed most.
+ */
+
+#define RAT_SPAN_MS      3.75    /* impulse-response span, input time */
+#define RAT_MIN_TAPS     30
+#define RAT_MAX_TAPS     768
+#define RAT_MAX_PHASES   512     /* L; 441 is the largest the rate table needs */
+
+struct resamp_rat {
+    int      L, M;          /* out/in = L/M, lowest terms                  */
+    int      K;             /* taps per phase (input samples spanned)      */
+    float   *h;             /* L*K coefficients, phase-major               */
+    int32_t *hist;          /* doubled circular history, 2*hist_len words  */
+    int      hist_len;
+    int      w;             /* index of the newest sample                  */
+    int      phase;         /* (n*M) mod L                                 */
+    int      lag;           /* newest input index minus the next output's
+                             * base index; an output is due while >= 0     */
+};
+
+static int gcd_int(int a, int b)
+{
+    while (b) { int t = a % b; a = b; b = t; }
+    return a;
+}
+
+/* Rates the modem can drive.  The 8 kHz multiples are what the integer engine
+ * already handled; the 44.1 kHz family is what #193 is about.  192 kHz is here
+ * too — it is an integer multiple (24) that the old RESAMP_L_MAX of 12 refused
+ * for no reason other than the table size. */
+static const int g_supported_rates[] = {
+    8000, 11025, 16000, 22050, 24000, 32000,
+    44100, 48000, 88200, 96000, 176400, 192000,
+};
+
+bool resampler_rate_supported(int device_rate_hz)
+{
+    for (size_t i = 0; i < sizeof(g_supported_rates)/sizeof(g_supported_rates[0]); i++)
+        if (g_supported_rates[i] == device_rate_hz)
+            return true;
+    return false;
+}
+
+bool resampler_rational_for(int in_rate_hz, int out_rate_hz, int *L, int *M)
+{
+    if (!resampler_rate_supported(in_rate_hz) || !resampler_rate_supported(out_rate_hz))
+        return false;
+    int g = gcd_int(out_rate_hz, in_rate_hz);
+    if (g <= 0)
+        return false;
+    int l = out_rate_hz / g;
+    int m = in_rate_hz  / g;
+    if (l > RAT_MAX_PHASES)
+        return false;
+    if (L) *L = l;
+    if (M) *M = m;
+    return true;
+}
+
+resamp_rat_t *resamp_rat_create(int in_rate_hz, int out_rate_hz)
+{
+    int L, M;
+    if (!resampler_rational_for(in_rate_hz, out_rate_hz, &L, &M))
+        return NULL;
+
+    /* Span a fixed time, so the filter is as long as the job needs. */
+    int K = (int)(RAT_SPAN_MS * 1e-3 * (double)in_rate_hz + 0.5);
+    if (K < RAT_MIN_TAPS) K = RAT_MIN_TAPS;
+    if (K > RAT_MAX_TAPS) K = RAT_MAX_TAPS;
+
+    resamp_rat_t *r = calloc(1, sizeof(*r));
+    if (!r) return NULL;
+    r->L = L; r->M = M; r->K = K;
+
+    /* History must reach back K taps from the base sample, plus however far
+     * the base can lag the newest sample (one output step, ceil(M/L)). */
+    r->hist_len = K + (M + L - 1) / L + 2;
+    r->h    = calloc((size_t)L * (size_t)K, sizeof(*r->h));
+    r->hist = calloc((size_t)2 * (size_t)r->hist_len, sizeof(*r->hist));
+    if (!r->h || !r->hist) { resamp_rat_free(r); return NULL; }
+
+    /* Prototype at the interpolated rate L*in_rate, cut at the lower of the
+     * two Nyquists with a little margin -- on the way DOWN that is what stops
+     * aliasing, on the way UP it is what stops images. */
+    const int    N   = L * K;
+    const double fs  = (double)in_rate_hz * (double)L;
+    double fc = (in_rate_hz < out_rate_hz ? in_rate_hz : out_rate_hz) * 0.5 * 0.85;
+    if (fc > FILT_FC) fc = FILT_FC;
+    const double wc  = 2.0 * fc / fs;
+    const double mid = (N - 1) / 2.0;
+
+    double *proto = calloc((size_t)N, sizeof(*proto));
+    if (!proto) { resamp_rat_free(r); return NULL; }
+
+    double sum = 0.0;
+    for (int n = 0; n < N; n++) {
+        double x    = n - mid;
+        double sinc = (fabs(x) < 1e-9) ? wc : sin(M_PI * wc * x) / (M_PI * x);
+        double ham  = 0.54 - 0.46 * cos(2.0 * M_PI * n / (N - 1));
+        proto[n] = sinc * ham;
+        sum += proto[n];
+    }
+    /* Unity DC gain overall: each phase carries 1/L of the prototype, and the
+     * L factor puts back what zero-stuffing takes out. */
+    for (int n = 0; n < N; n++)
+        proto[n] /= sum;
+
+    for (int p = 0; p < L; p++)
+        for (int t = 0; t < K; t++) {
+            int idx = p + L * t;
+            r->h[(size_t)p * K + t] = (idx < N) ? (float)(L * proto[idx]) : 0.0f;
+        }
+    free(proto);
+
+    resamp_rat_reset(r);
+    return r;
+}
+
+void resamp_rat_free(resamp_rat_t *r)
+{
+    if (!r) return;
+    free(r->h);
+    free(r->hist);
+    free(r);
+}
+
+void resamp_rat_reset(resamp_rat_t *r)
+{
+    if (!r) return;
+    memset(r->hist, 0, (size_t)2 * r->hist_len * sizeof(*r->hist));
+    r->w     = r->hist_len - 1;
+    r->phase = 0;
+    r->lag   = -1;          /* nothing due until the first sample arrives */
+}
+
+void resamp_rat_ratio(const resamp_rat_t *r, int *L, int *M)
+{
+    if (!r) return;
+    if (L) *L = r->L;
+    if (M) *M = r->M;
+}
+
+int resamp_rat_max_out(const resamp_rat_t *r, int n_in)
+{
+    if (!r || n_in <= 0) return 0;
+    /* +1 for the output that may already be due when the block starts. */
+    return (int)(((int64_t)n_in * r->L) / r->M) + 2;
+}
+
+int resamp_rat_process(resamp_rat_t *r, const int32_t *in, int n_in,
+                       int32_t *out)
+{
+    if (!r || !in || !out || n_in <= 0) return 0;
+
+    const int L = r->L, M = r->M, K = r->K, HL = r->hist_len;
+    int o = 0;
+
+    for (int i = 0; i < n_in; i++) {
+        if (++r->w >= HL) r->w = 0;
+        r->hist[r->w]      = in[i];
+        r->hist[r->w + HL] = in[i];
+
+        /* The newest input just moved one ahead of the next output's base.
+         * Emit every output whose base has now arrived: on the way DOWN that
+         * is one output per M/L inputs, on the way UP several outputs share a
+         * base and all of them are due at once. */
+        r->lag++;
+
+        while (r->lag >= 0) {
+            const int32_t *win = &r->hist[r->w + HL];
+            const float   *hp  = &r->h[(size_t)r->phase * K];
+            const int      d   = r->lag;
+
+            double acc = 0.0;
+            for (int t = 0; t < K; t++)
+                acc += (double)hp[t] * (double)win[-(d + t)];
+            out[o++] = clamp_i32(acc);
+
+            /* Exact integer step: no accumulated rounding however long the
+             * stream runs, which is what a float cursor would give. */
+            const int raw = r->phase + M;
+            r->phase = raw % L;
+            r->lag  -= raw / L;
+        }
+    }
+    return o;
 }

--- a/audioio/resampler.d
+++ b/audioio/resampler.d
@@ -1,0 +1,2 @@
+resampler.o: resampler.c resampler.h
+resampler.h:

--- a/audioio/resampler.h
+++ b/audioio/resampler.h
@@ -47,7 +47,22 @@
 
 #define RESAMP_MODEM_FS         8000   /* the modem's native rate            */
 #define RESAMP_L                6      /* default ratio: 8 kHz <-> 48 kHz    */
-#define RESAMP_L_MAX            12     /* widest supported: 8 kHz <-> 96 kHz */
+#define RESAMP_L_MAX            12     /* widest INTEGER ratio: 8 kHz <-> 96 kHz */
+
+/* Widest out/in ratio ANY engine can produce, integer or rational: 8 kHz ->
+ * 192 kHz is 24.  Callers that must size a buffer before the device rate is
+ * known (the playback scratch is allocated before open()) have to use this,
+ * not RESAMP_L_MAX -- the rational engine is reached precisely when the ratio
+ * exceeds what the integer one handles, so sizing by RESAMP_L_MAX would be
+ * too small for exactly the rates that need it.
+ * resampler_ratio_max_covers_all_rates() in the tests pins the two together. */
+#define RESAMP_RATIO_MAX        24
+
+/* resamp_rat_max_out() can exceed n_in*ratio by this much: the ratio is not an
+ * integer, so a block can carry one extra output, plus one for the output that
+ * may already be due when the block starts.  A buffer sized from
+ * RESAMP_RATIO_MAX alone is short by exactly this. */
+#define RESAMP_RAT_OUT_SLACK    2
 #define RESAMP_TAPS_PER_PHASE   30
 #define RESAMP_NTAPS            (RESAMP_L * RESAMP_TAPS_PER_PHASE)      /* 180 */
 #define RESAMP_NTAPS_MAX        (RESAMP_L_MAX * RESAMP_TAPS_PER_PHASE)  /* 360 */

--- a/audioio/resampler.h
+++ b/audioio/resampler.h
@@ -15,12 +15,18 @@
  * and spectrally pure.  Nothing about that failure looks like a bug until you
  * count cycles, so the ratio is derived and unsupported rates are refused.
  *
- * Supported device rates are the integer multiples of 8 kHz up to 96 kHz
- * (8/16/24/32/48/96); resampler_ratio_for_rate() reports which.  A caller
- * that gets 0 back must refuse to run that direction rather than transmit
- * off-frequency audio.  44.1 kHz is deliberately NOT supported: it is not an
- * integer multiple of the modem rate and would need a rational (441/80)
- * resampler.
+ * Two engines live here.
+ *
+ * The INTEGER one (resampler_ratio_for_rate, resamp_up_*, resamp_down_*)
+ * handles device rates that are integer multiples of 8 kHz, and is the path
+ * every ordinary sound card takes.
+ *
+ * The RATIONAL one (resamp_rat_*) handles any supported rate by converting
+ * L/M in lowest terms, which is what the 44.1 kHz family needs: 44100 -> 8000
+ * is 80/441, and 11025/22050/88200/176400 all reduce to the same M = 441 with
+ * a different L.  Windows and macOS have no equivalent of ALSA's plug layer,
+ * so a card left at 44.1 kHz in the OS sound settings simply could not be
+ * used before (issue #193).
  *
  * Upsample (playback) and downsample (capture) ratios are INDEPENDENT — the
  * two directions can land on different device rates, so they keep separate
@@ -36,6 +42,7 @@
 #ifndef AUDIOIO_RESAMPLER_H
 #define AUDIOIO_RESAMPLER_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #define RESAMP_MODEM_FS         8000   /* the modem's native rate            */
@@ -94,6 +101,40 @@ void resamp_down_reset(resamp_down_t *r);
  * (8 kHz) to out (must hold at least n_in/L + 1 samples).  Returns the count. */
 int  resamp_down_process(resamp_down_t *r, const int32_t *in, int n_in,
                          int32_t *out);
+
+/* ======================================================================
+ * Rational resampler: any in_rate -> any out_rate among the supported set
+ * ====================================================================== */
+
+/* True if the modem can drive a device at this rate, by either engine. */
+bool resampler_rate_supported(int device_rate_hz);
+
+/* Conversion ratio out/in as L/M in lowest terms.  Returns false if either
+ * rate is unsupported.  M == 1 means the integer engine can do it. */
+bool resampler_rational_for(int in_rate_hz, int out_rate_hz, int *L, int *M);
+
+/* Opaque: the coefficient table is sized from the ratio, so it is heap
+ * allocated rather than a worst-case static (44.1 kHz capture needs ~53 KB,
+ * which has no business on a thread stack). */
+typedef struct resamp_rat resamp_rat_t;
+
+/* NULL if the pair is unsupported or out of memory. */
+resamp_rat_t *resamp_rat_create(int in_rate_hz, int out_rate_hz);
+void          resamp_rat_free(resamp_rat_t *r);
+void          resamp_rat_reset(resamp_rat_t *r);
+
+/* Upper bound on the outputs n_in inputs can produce, for buffer sizing.
+ * The true count varies by one between calls: the ratio is not an integer,
+ * so a fixed n_in*L/M would be wrong on some blocks. */
+int  resamp_rat_max_out(const resamp_rat_t *r, int n_in);
+
+/* Streaming: state carries across calls, so block boundaries are not
+ * discontinuities.  Returns the number of samples written to out. */
+int  resamp_rat_process(resamp_rat_t *r, const int32_t *in, int n_in,
+                        int32_t *out);
+
+/* Ratio actually in use, for logging and tests. */
+void resamp_rat_ratio(const resamp_rat_t *r, int *L, int *M);
 
 /* One decimation-filter coefficient.  Exposed so a test can reimplement the
  * FIR and prove the fast history representation did not change any output

--- a/gui_interface/fyne-ui/link_engine.go
+++ b/gui_interface/fyne-ui/link_engine.go
@@ -329,6 +329,8 @@ func statusFromC(cst *C.ui_status_t) telemetryState {
 		TXGainDB:           float64(cst.tx_gain_db),
 		TXPeakDBFS:         float64(cst.tx_peak_dbfs),
 		Waterfall:          bool(cst.waterfall_enabled),
+		AudioOk:            bool(cst.audio_ok),
+		AudioError:         C.GoString(&cst.audio_error[0]),
 	}
 }
 

--- a/gui_interface/fyne-ui/main.go
+++ b/gui_interface/fyne-ui/main.go
@@ -147,7 +147,7 @@ func parseStatusMessage(payload []byte) (telemetryState, error) {
 		// than nagging with a spurious "device error" popup.
 		status.AudioOk = true
 	}
-	status.AudioError = fmt.Sprint(raw["audio_error"])
+	status.AudioError = toString(raw["audio_error"])
 	return status, nil
 }
 
@@ -204,6 +204,16 @@ func toBool(v any) bool {
 	default:
 		return false
 	}
+}
+
+// toString renders a JSON value as a string, but unlike fmt.Sprint it maps a
+// missing field (nil) to "" rather than "<nil>" — the caller wants an empty
+// string when the field is absent, not a literal "<nil>" to show the operator.
+func toString(v any) string {
+	if v == nil {
+		return ""
+	}
+	return fmt.Sprint(v)
 }
 
 // runOnUI runs fn on Fyne's main goroutine. Fyne v2.6+ requires all widget

--- a/gui_interface/fyne-ui/main.go
+++ b/gui_interface/fyne-ui/main.go
@@ -79,6 +79,8 @@ type telemetryState struct {
 	TXGainDB           float64
 	TXPeakDBFS         float64
 	Waterfall          bool
+	AudioOk            bool
+	AudioError         string
 }
 
 type uiBindings struct {
@@ -138,6 +140,14 @@ func parseStatusMessage(payload []byte) (telemetryState, error) {
 	status.TXGainDB = toFloat64(raw["tx_gain_db"])
 	status.TXPeakDBFS = toFloat64(raw["tx_peak_dbfs"])
 	status.Waterfall = toBool(raw["waterfall"])
+	if v, present := raw["audio_ok"]; present {
+		status.AudioOk = toBool(v)
+	} else {
+		// An older engine does not send the field; treat it as healthy rather
+		// than nagging with a spurious "device error" popup.
+		status.AudioOk = true
+	}
+	status.AudioError = fmt.Sprint(raw["audio_error"])
 	return status, nil
 }
 
@@ -677,6 +687,12 @@ func main() {
 		})
 	}
 
+	// Audio health popup state. applyStatus runs on the single link goroutine,
+	// so plain captured booleans are safe here; they track the previous status
+	// so the dialog fires once per failure, not on every 500 ms poll.
+	var prevAudioOk bool
+	var seenStatus bool
+
 	applyStatus := func(status telemetryState) {
 		// Under the lock: the link goroutine writes this while the GL thread
 		// reads it in refreshTelemetry(). telemetryState holds strings, so an
@@ -690,6 +706,21 @@ func main() {
 		if haveSpectrum {
 			refreshSpectrum()
 		}
+
+		// A device that fails to open, or negotiates a rate the modem cannot
+		// use, otherwise leaves the UI showing a healthy station that hears
+		// nothing -- so surface it as a dialog on the transition to failure.
+		if !status.AudioOk && (!seenStatus || prevAudioOk) {
+			msg := status.AudioError
+			if msg == "" {
+				msg = "The audio device could not be started."
+			}
+			runOnUI(func() {
+				dialog.ShowInformation("Audio Device Error", msg, myWindow)
+			})
+		}
+		prevAudioOk = status.AudioOk
+		seenStatus = true
 	}
 
 	updateConnectionButton = func() {

--- a/gui_interface/fyne-ui/main_test.go
+++ b/gui_interface/fyne-ui/main_test.go
@@ -107,6 +107,23 @@ func TestParseStatusMessageMissingAudioDefaultsHealthy(t *testing.T) {
 	}
 }
 
+// audio_ok:false with no audio_error must parse to an empty string, so the
+// dialog's fallback message fires instead of showing the literal "<nil>".
+func TestParseStatusMessageAudioFailureWithoutErrorDefaultsEmpty(t *testing.T) {
+	payload := []byte(`{"type":"status","audio_ok":false}`)
+
+	status, err := parseStatusMessage(payload)
+	if err != nil {
+		t.Fatalf("parseStatusMessage returned error: %v", err)
+	}
+	if status.AudioOk {
+		t.Fatal("expected audio_ok to be false")
+	}
+	if status.AudioError != "" {
+		t.Fatalf("expected missing audio_error to parse as empty, got %q", status.AudioError)
+	}
+}
+
 func TestBuildWebSocketURLUsesWebsocketPath(t *testing.T) {
 	got := buildWebSocketURL("ws", "127.0.0.1", "10000")
 	want := "ws://127.0.0.1:10000/websocket"

--- a/gui_interface/fyne-ui/main_test.go
+++ b/gui_interface/fyne-ui/main_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"image"
 	"math"
+	"strings"
 	"testing"
 )
 
@@ -51,7 +52,7 @@ func TestConcurrentSpectrumAccessNoRace(t *testing.T) {
 }
 
 func TestParseStatusMessage(t *testing.T) {
-	payload := []byte(`{"type":"status","bitrate":1200,"snr":6.5,"sync":true,"direction":"tx","client_tcp_connected":true,"bytes_transmitted":34,"bytes_received":900,"tx_gain_db":3.5,"tx_peak_dbfs":-2.1,"waterfall":true}`)
+	payload := []byte(`{"type":"status","bitrate":1200,"snr":6.5,"sync":true,"direction":"tx","client_tcp_connected":true,"bytes_transmitted":34,"bytes_received":900,"tx_gain_db":3.5,"tx_peak_dbfs":-2.1,"waterfall":true,"audio_ok":true,"audio_error":""}`)
 
 	status, err := parseStatusMessage(payload)
 	if err != nil {
@@ -71,6 +72,38 @@ func TestParseStatusMessage(t *testing.T) {
 	}
 	if status.Waterfall != true {
 		t.Fatal("expected waterfall to be true")
+	}
+	if !status.AudioOk {
+		t.Fatal("expected audio_ok to be true")
+	}
+}
+
+func TestParseStatusMessageReportsAudioFailure(t *testing.T) {
+	payload := []byte(`{"type":"status","audio_ok":false,"audio_error":"capture: device negotiated 44100 Hz, not a multiple of 8000 Hz"}`)
+
+	status, err := parseStatusMessage(payload)
+	if err != nil {
+		t.Fatalf("parseStatusMessage returned error: %v", err)
+	}
+	if status.AudioOk {
+		t.Fatal("expected audio_ok to be false")
+	}
+	if !strings.Contains(status.AudioError, "44100 Hz") {
+		t.Fatalf("expected audio_error to mention the rate, got %q", status.AudioError)
+	}
+}
+
+// A status from an older engine without the audio fields must not be treated
+// as an audio failure (which would pop a spurious error dialog).
+func TestParseStatusMessageMissingAudioDefaultsHealthy(t *testing.T) {
+	payload := []byte(`{"type":"status","bitrate":1200}`)
+
+	status, err := parseStatusMessage(payload)
+	if err != nil {
+		t.Fatalf("parseStatusMessage returned error: %v", err)
+	}
+	if !status.AudioOk {
+		t.Fatal("expected missing audio_ok to default to healthy")
 	}
 }
 

--- a/tests/audioio/test_resampler.c
+++ b/tests/audioio/test_resampler.c
@@ -208,8 +208,10 @@ void test_ratio_for_rate_rejected(void)
      * tone measured 166.8 Hz on a device pinned to 8 kHz).  Refusing is the
      * whole point; the operator's fix is plughw:X,Y, which lets ALSA convert.
      *
-     * If support for these is ever wanted, it means a genuine rational
-     * resampler, not relaxing this check. */
+     * These rates ARE supported now, by the rational engine (resamp_rat_*),
+     * which is the "genuine rational resampler" this comment used to ask for.
+     * The integer engine must still refuse them: relaxing this check is what
+     * would approximate the ratio, and that is the failure above. */
     TEST_ASSERT_EQUAL_INT(0, resampler_ratio_for_rate(44100));
     TEST_ASSERT_EQUAL_INT(0, resampler_ratio_for_rate(22050));
     TEST_ASSERT_EQUAL_INT(0, resampler_ratio_for_rate(11025));
@@ -390,6 +392,201 @@ void test_circular_history_matches_naive_shift(void)
     }
 }
 
+/* ======================================================================
+ * Rational engine (issue #193)
+ * ====================================================================== */
+
+/* Correlate against a probe tone; returns amplitude at that frequency. */
+static double tone_amp(const int32_t *x, int n, double f, double fs)
+{
+    double re = 0, im = 0;
+    for (int i = 0; i < n; i++) {
+        double a = 2.0 * M_PI * f * i / fs;
+        re += x[i] * cos(a);
+        im -= x[i] * sin(a);
+    }
+    return 2.0 * sqrt(re * re + im * im) / n;
+}
+
+static void fill_tone(int32_t *x, int n, double f, double fs, double amp)
+{
+    for (int i = 0; i < n; i++)
+        x[i] = (int32_t)(amp * sin(2.0 * M_PI * f * i / fs));
+}
+
+/* The rates a sound card actually reports.  44.1 kHz is the one from #193:
+ * a Windows card left at 44100 could not be used at all, because Windows has
+ * no equivalent of ALSA's plug layer to convert on the way in. */
+void test_rational_rate_support(void)
+{
+    TEST_ASSERT_TRUE(resampler_rate_supported(44100));
+    TEST_ASSERT_TRUE(resampler_rate_supported(22050));
+    TEST_ASSERT_TRUE(resampler_rate_supported(11025));
+    TEST_ASSERT_TRUE(resampler_rate_supported(88200));
+    TEST_ASSERT_TRUE(resampler_rate_supported(176400));
+    TEST_ASSERT_TRUE(resampler_rate_supported(192000));  /* integer, but L=24 */
+    TEST_ASSERT_TRUE(resampler_rate_supported(48000));
+
+    TEST_ASSERT_FALSE(resampler_rate_supported(44101));
+    TEST_ASSERT_FALSE(resampler_rate_supported(0));
+    TEST_ASSERT_FALSE(resampler_rate_supported(-48000));
+}
+
+/* The whole 44.1 kHz family reduces to M = 441 against the 8 kHz modem. */
+void test_rational_ratios_are_lowest_terms(void)
+{
+    int L = 0, M = 0;
+    TEST_ASSERT_TRUE(resampler_rational_for(44100, 8000, &L, &M));
+    TEST_ASSERT_EQUAL_INT(80, L);   TEST_ASSERT_EQUAL_INT(441, M);
+
+    TEST_ASSERT_TRUE(resampler_rational_for(8000, 44100, &L, &M));
+    TEST_ASSERT_EQUAL_INT(441, L);  TEST_ASSERT_EQUAL_INT(80, M);
+
+    TEST_ASSERT_TRUE(resampler_rational_for(22050, 8000, &L, &M));
+    TEST_ASSERT_EQUAL_INT(160, L);  TEST_ASSERT_EQUAL_INT(441, M);
+
+    /* An integer rate still reduces, it just lands on M == 1. */
+    TEST_ASSERT_TRUE(resampler_rational_for(8000, 48000, &L, &M));
+    TEST_ASSERT_EQUAL_INT(6, L);    TEST_ASSERT_EQUAL_INT(1, M);
+
+    TEST_ASSERT_FALSE(resampler_rational_for(44101, 8000, &L, &M));
+}
+
+/* THE property.  A ratio that is close but wrong produces audio at the wrong
+ * frequency, at the right level and spectrally pure — nothing looks broken
+ * until you count cycles (a 1 kHz tone came out at 166.8 Hz on a device pinned
+ * to 8 kHz).  Assert the tone lands where it went in, not merely that samples
+ * came out. */
+void test_rational_preserves_tone_frequency(void)
+{
+    const int rates[] = { 44100, 22050, 11025, 88200, 176400, 192000 };
+
+    for (size_t k = 0; k < sizeof(rates)/sizeof(rates[0]); k++) {
+        const int fs_in = rates[k];
+        resamp_rat_t *r = resamp_rat_create(fs_in, 8000);
+        TEST_ASSERT_NOT_NULL(r);
+
+        int n_in = fs_in;                       /* one second */
+        int32_t *in  = malloc((size_t)n_in * sizeof(int32_t));
+        int32_t *out = malloc((size_t)resamp_rat_max_out(r, n_in) * sizeof(int32_t));
+        TEST_ASSERT_NOT_NULL(in); TEST_ASSERT_NOT_NULL(out);
+        fill_tone(in, n_in, 1000.0, fs_in, 2.0e8);
+
+        int n_out = resamp_rat_process(r, in, n_in, out);
+
+        /* Skip the filter's warm-up before measuring. */
+        const int skip = 800, win = 4000;
+        TEST_ASSERT_TRUE(n_out > skip + win);
+        double at_1k = tone_amp(out + skip, win, 1000.0, 8000.0);
+        double at_wrong = tone_amp(out + skip, win, 1000.0 * 8000.0 / fs_in, 8000.0);
+
+        char msg[128];
+        snprintf(msg, sizeof(msg), "%d Hz: tone did not survive at 1 kHz", fs_in);
+        TEST_ASSERT_TRUE_MESSAGE(at_1k > 0.8 * 2.0e8, msg);
+        snprintf(msg, sizeof(msg), "%d Hz: energy at the WRONG (ratio-scaled) frequency", fs_in);
+        TEST_ASSERT_TRUE_MESSAGE(at_wrong < 0.05 * at_1k, msg);
+
+        free(in); free(out); resamp_rat_free(r);
+    }
+}
+
+/* Out-of-band energy must be filtered, not folded down into the passband. */
+void test_rational_rejects_out_of_band(void)
+{
+    resamp_rat_t *r = resamp_rat_create(44100, 8000);
+    TEST_ASSERT_NOT_NULL(r);
+
+    int n_in = 44100;
+    int32_t *in  = malloc((size_t)n_in * sizeof(int32_t));
+    int32_t *out = malloc((size_t)resamp_rat_max_out(r, n_in) * sizeof(int32_t));
+    TEST_ASSERT_NOT_NULL(in); TEST_ASSERT_NOT_NULL(out);
+
+    /* 9 kHz at 44.1 kHz would alias to 1 kHz in an 8 kHz stream. */
+    fill_tone(in, n_in, 9000.0, 44100.0, 2.0e8);
+    int n_out = resamp_rat_process(r, in, n_in, out);
+    TEST_ASSERT_TRUE(n_out > 5000);
+
+    double alias = tone_amp(out + 800, 4000, 1000.0, 8000.0);
+    TEST_ASSERT_TRUE_MESSAGE(alias < 0.01 * 2.0e8,
+        "a 9 kHz tone folded into the passband: anti-aliasing is not working");
+
+    free(in); free(out); resamp_rat_free(r);
+}
+
+/* Rate exactness: the ratio is integer arithmetic, so a long stream must not
+ * drift by even one sample.  A float cursor accumulates error and eventually
+ * slips a sample, which on the air is a click and a phase step. */
+void test_rational_output_count_does_not_drift(void)
+{
+    resamp_rat_t *r = resamp_rat_create(44100, 8000);
+    TEST_ASSERT_NOT_NULL(r);
+
+    const int block = 441;                 /* 10 ms */
+    int32_t in[441];
+    memset(in, 0, sizeof(in));
+    int32_t out[64];
+
+    long total = 0;
+    for (int b = 0; b < 6000; b++)         /* 60 s */
+        total += resamp_rat_process(r, in, block, out);
+
+    /* 60 s of 44.1 kHz in is exactly 480000 samples of 8 kHz out. */
+    TEST_ASSERT_EQUAL_INT(480000, (int)total);
+    resamp_rat_free(r);
+}
+
+/* Block boundaries must not be discontinuities: the filter state carries, so
+ * chunked processing has to equal one big call, sample for sample. */
+void test_rational_chunking_invariant(void)
+{
+    const int n_in = 4410;
+    int32_t *in = malloc((size_t)n_in * sizeof(int32_t));
+    TEST_ASSERT_NOT_NULL(in);
+    fill_tone(in, n_in, 1500.0, 44100.0, 1.0e8);
+
+    resamp_rat_t *a = resamp_rat_create(44100, 8000);
+    resamp_rat_t *b = resamp_rat_create(44100, 8000);
+    TEST_ASSERT_NOT_NULL(a); TEST_ASSERT_NOT_NULL(b);
+
+    int cap = resamp_rat_max_out(a, n_in);
+    int32_t *one = malloc((size_t)cap * sizeof(int32_t));
+    int32_t *many = malloc((size_t)cap * sizeof(int32_t));
+    TEST_ASSERT_NOT_NULL(one); TEST_ASSERT_NOT_NULL(many);
+
+    int n1 = resamp_rat_process(a, in, n_in, one);
+
+    int n2 = 0, pos = 0, k = 0;
+    while (pos < n_in) {                    /* awkward, varying block sizes */
+        int n = (k % 13) + 7;
+        if (pos + n > n_in) n = n_in - pos;
+        n2 += resamp_rat_process(b, in + pos, n, many + n2);
+        pos += n; k++;
+    }
+
+    TEST_ASSERT_EQUAL_INT(n1, n2);
+    TEST_ASSERT_EQUAL_INT32_ARRAY(one, many, n1);
+
+    free(in); free(one); free(many);
+    resamp_rat_free(a); resamp_rat_free(b);
+}
+
+/* Unsupported pairs and degenerate arguments must fail cleanly, not crash:
+ * this runs on a thread that is already handling a device that misbehaved. */
+void test_rational_degenerate_inputs(void)
+{
+    TEST_ASSERT_NULL(resamp_rat_create(44101, 8000));
+    TEST_ASSERT_NULL(resamp_rat_create(0, 8000));
+
+    resamp_rat_t *r = resamp_rat_create(44100, 8000);
+    TEST_ASSERT_NOT_NULL(r);
+    int32_t in[8] = {0}, out[8] = {0};
+    TEST_ASSERT_EQUAL_INT(0, resamp_rat_process(r, in, 0, out));
+    TEST_ASSERT_EQUAL_INT(0, resamp_rat_process(NULL, in, 8, out));
+    TEST_ASSERT_EQUAL_INT(0, resamp_rat_process(r, NULL, 8, out));
+    resamp_rat_free(r);
+    resamp_rat_free(NULL);          /* must be a no-op */
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -409,5 +606,12 @@ int main(void)
     RUN_TEST(test_ratio_1_is_passthrough);
     RUN_TEST(test_up_and_down_ratios_are_independent);
     RUN_TEST(test_circular_history_matches_naive_shift);
+    RUN_TEST(test_rational_rate_support);
+    RUN_TEST(test_rational_ratios_are_lowest_terms);
+    RUN_TEST(test_rational_preserves_tone_frequency);
+    RUN_TEST(test_rational_rejects_out_of_band);
+    RUN_TEST(test_rational_output_count_does_not_drift);
+    RUN_TEST(test_rational_chunking_invariant);
+    RUN_TEST(test_rational_degenerate_inputs);
     return UNITY_END();
 }

--- a/tests/audioio/test_resampler.c
+++ b/tests/audioio/test_resampler.c
@@ -524,7 +524,10 @@ void test_rational_output_count_does_not_drift(void)
     const int block = 441;                 /* 10 ms */
     int32_t in[441];
     memset(in, 0, sizeof(in));
-    int32_t out[64];
+    /* 441 inputs at 80/441 is exactly 80 outputs -- size from the API, never
+     * by eye.  A hand-picked 64 here overran the buffer and ASan caught it. */
+    int32_t out[128];
+    TEST_ASSERT_TRUE(resamp_rat_max_out(r, block) <= (int)(sizeof(out)/sizeof(out[0])));
 
     long total = 0;
     for (int b = 0; b < 6000; b++)         /* 60 s */
@@ -587,6 +590,33 @@ void test_rational_degenerate_inputs(void)
     resamp_rat_free(NULL);          /* must be a no-op */
 }
 
+/* The playback scratch is allocated BEFORE the device rate is known, from a
+ * compile-time maximum ratio.  If any supported rate needs more than that, the
+ * live audio path overruns the heap -- and it would do so only on the rates
+ * the rational engine exists for, which is the worst possible place for it to
+ * be wrong.  Pin the constant against the rate table. */
+void test_ratio_max_covers_every_supported_rate(void)
+{
+    const int rates[] = { 8000, 11025, 16000, 22050, 24000, 32000,
+                          44100, 48000, 88200, 96000, 176400, 192000 };
+
+    for (size_t i = 0; i < sizeof(rates)/sizeof(rates[0]); i++) {
+        resamp_rat_t *r = resamp_rat_create(RESAMP_MODEM_FS, rates[i]);   /* playback */
+        TEST_ASSERT_NOT_NULL(r);
+
+        /* Outputs a 1000-input period can produce must fit a buffer sized
+         * 1000 * RESAMP_RATIO_MAX. */
+        int worst = resamp_rat_max_out(r, 1000);
+        int budget = 1000 * RESAMP_RATIO_MAX + RESAMP_RAT_OUT_SLACK;
+        char msg[128];
+        snprintf(msg, sizeof(msg),
+                 "8000 -> %d needs %d outputs per 1000 inputs, buffer holds %d",
+                 rates[i], worst, budget);
+        TEST_ASSERT_TRUE_MESSAGE(worst <= budget, msg);
+        resamp_rat_free(r);
+    }
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -613,5 +643,6 @@ int main(void)
     RUN_TEST(test_rational_output_count_does_not_drift);
     RUN_TEST(test_rational_chunking_invariant);
     RUN_TEST(test_rational_degenerate_inputs);
+    RUN_TEST(test_ratio_max_covers_every_supported_rate);
     return UNITY_END();
 }


### PR DESCRIPTION
Closes #193, and supersedes #196 (Pedro's two commits are carried here with authorship intact).

Two halves of the same report, which need each other:

## 1. Make the common rates work (was: refuse them)

The modem resamples by an integer ratio against 8 kHz. 44100 is not a multiple of 8000, so the audio thread refused the device and exited. That refusal was *right* — approximating the ratio transmits everything off-frequency at the correct level and spectrally pure, which looks fine until you count cycles (a 1 kHz tone measured 166.8 Hz on a device pinned to 8 kHz).

On Linux it is survivable: `plughw:` lets ALSA convert. **Windows and macOS have no such layer**, so the card was simply unusable — and the error told the operator to try an ALSA device string that does not exist on their platform.

A rational polyphase engine now sits beside the integer one. Conversion is L/M in lowest terms; the whole 44.1 kHz family reduces to M = 441:

| rate | L/M (capture) | before |
|---|---|---|
| 11025 | 320/441 | refused |
| 22050 | 160/441 | refused |
| 44100 | **80/441** | refused |
| 88200 | 40/441 | refused |
| 176400 | 20/441 | refused |
| 192000 | 1/24 | refused (an *integer* multiple, rejected only because the old max ratio was 12) |

Output n is taken at input position n\*M/L, split into a base index and a filter phase that both advance by exact integer steps — a float cursor accumulates error and eventually slips a sample, which on the air is a click and a phase step. The prototype spans a fixed amount of **time** rather than a fixed tap count (30 taps/phase at 8 kHz in, 166 at 44.1 kHz), because a fixed count would shorten the anti-aliasing filter exactly as the input rate rises. Tables are heap allocated (~53 KB at 44.1 kHz).

**The integer engine is untouched** and still takes every rate it took before; only rates it refuses reach the new path.

Measured, one second per rate, both directions: tone frequency preserved exactly, output counts exact with **zero drift over 60 s**, unity passband gain, out-of-band rejection **58-87 dB** — 44.1 kHz measures -58.5 dB where the existing 48 kHz path measures -58.9, so the new path is not the weaker one.

Seven tests, mutation-checked: approximating the ratio with the nearest integer fails `tone did not survive at 1 kHz` and drifts the output count to 441000 instead of 480000.

## 2. Still reject properly, and say so (Pedro's #196, plus the rest of the silent exits)

Supporting more rates does not remove the need to fail loudly — a rate outside the supported set, or an allocation failure, still has to stop. Pedro's commits are carried here unchanged in substance:

- `audio_ok` / `audio_error` reach the Fyne UI, and a dialog fires on the **transition** to failure (once, not every poll); status from an older engine that omits the field defaults to healthy.
- The rate hint is subsystem-aware, so Windows and macOS stop being told about `plughw:`.
- His follow-up fixing `fmt.Sprint(nil)` -> `"<nil>"` is included, so a missing `audio_error` no longer shows the operator a dialog reading `<nil>`.

I extended that to the failures his dialog could not see. Six exits logged, killed the audio thread, and left the UI showing a healthy station that hears nothing — the exact shape of #193 with a different cause:

```
playback: buffer allocation, audio->alloc(), unsupported sample format
capture:  buffer allocation, audio->alloc(), unsupported sample format
```

The unsupported-format one is not hypothetical: a 16-bit-only USB codec negotiates a format the modem does not take, and that is a plausible thing to plug into a radio. Each now sets `AUDIO_HEALTH_FAILED` with a reason an operator can act on.

## Conflict resolution

Both branches touched the rate-mismatch message. Kept Pedro's `audio_rate_mismatch_hint()` (his name, his explicit WASAPI/DSOUND/COREAUDIO cases) over my equivalent, with the text updated: reaching it now means the rate is outside the supported set entirely, so it names a rate certain to work.

`go test ./...`, `go vet`, `gofmt -l` clean; full C unit suite green.

@pedromessetti — could you close #196 in favour of this? Your commits are here as yours; the merge is only so the "support it" and "report it" halves land together rather than conflicting in `audioio.c`.