### PR TITLE
Fix VARA/Pat connect-disconnect hangs and uncommanded exit (#200)

### DIFF
--- a/common/mercury_engine.c
+++ b/common/mercury_engine.c
@@ -109,7 +109,15 @@ int mercury_engine_init(const mercury_config *cfg,
     /* An unset or corrupt value here resolves to 0, which makes the control
      * listener bind an ephemeral port and the data listener bind port 1 — a
      * privileged port a normal user cannot open, so the modem tears itself
-     * down.  Treat any unusable value as "use the default". */
+     * down.  Treat any unusable value as "use the default".
+     *
+     * Remember what was asked for so the substitution can be reported once the
+     * logger exists (a few lines below).  Doing it silently is how #200 became
+     * hard to diagnose in the first place: the host connects to the configured
+     * port, finds nothing there, and the log says only that Mercury is
+     * listening somewhere else. */
+    const int requested_base_tcp_port  = base_tcp_port;
+    const int requested_broadcast_port = broadcast_port;
     if (base_tcp_port < 1 || base_tcp_port > 65534)
         base_tcp_port = DEFAULT_ARQ_PORT;
     if (broadcast_port < 1 || broadcast_port > 65535)
@@ -168,6 +176,18 @@ int mercury_engine_init(const mercury_config *cfg,
                                 verbose ? HERMES_LOG_LEVEL_DEBUG : HERMES_LOG_LEVEL_TIMING,
                                 log_jsonl);
         HLOGI("engine", "Logger initialised (min_level=%s)", verbose ? "DEBUG" : "INFO");
+
+        /* Report any port substitution now that there is somewhere to report
+         * it.  Warned, not silent: a host told to use the configured port will
+         * find nothing listening there. */
+        if (requested_base_tcp_port != base_tcp_port)
+            HLOGW("engine", "arq_tcp_base_port %d is unusable (need 1..65534 — the "
+                            "data port is base+1); using %d instead",
+                  requested_base_tcp_port, base_tcp_port);
+        if (requested_broadcast_port != broadcast_port)
+            HLOGW("engine", "broadcast_tcp_port %d is unusable (need 1..65535); "
+                            "using %d instead",
+                  requested_broadcast_port, broadcast_port);
     }
     else
     {

--- a/common/mercury_engine.c
+++ b/common/mercury_engine.c
@@ -104,8 +104,16 @@ int mercury_engine_init(const mercury_config *cfg,
     int  radio_serial_speed = cfg->radio_serial_speed;
     int  freedv_verbosity   = cfg->freedv_verbosity;
     int  hamlib_log_level   = cfg->hamlib_log_level;
-    int  base_tcp_port      = cfg->arq_tcp_base_port ? cfg->arq_tcp_base_port : 8300;
-    int  broadcast_port     = cfg->broadcast_tcp_port ? cfg->broadcast_tcp_port : 8100;
+    int  base_tcp_port      = cfg->arq_tcp_base_port;
+    int  broadcast_port     = cfg->broadcast_tcp_port;
+    /* An unset or corrupt value here resolves to 0, which makes the control
+     * listener bind an ephemeral port and the data listener bind port 1 — a
+     * privileged port a normal user cannot open, so the modem tears itself
+     * down.  Treat any unusable value as "use the default". */
+    if (base_tcp_port < 1 || base_tcp_port > 65534)
+        base_tcp_port = DEFAULT_ARQ_PORT;
+    if (broadcast_port < 1 || broadcast_port > 65535)
+        broadcast_port = DEFAULT_BROADCAST_PORT;
     bool verbose            = cfg->verbose;
 
     snprintf(g_input_dev,  sizeof(g_input_dev),  "%s", cfg->input_device);

--- a/data_interfaces/net.c
+++ b/data_interfaces/net.c
@@ -283,11 +283,28 @@ ssize_t tcp_write(int port_type, uint8_t *buffer, size_t tx_size)
     return n;
 }
 
+/* How long the lossless DATA writer may sit in send() backpressure before it
+ * gives up and marks the port for restart.  The reactor thread that drives
+ * this is also the one draining the control queue and answering control
+ * commands, so a peer that stops reading its DATA socket must not be allowed
+ * to block it forever — that would starve PTT/DISCONNECTED handling on the
+ * control port.  The timer is reset by any progress, so a slow-but-draining
+ * peer is unaffected; only a stalled peer (zero bytes accepted) trips it. */
+#define DATA_WRITE_BACKPRESSURE_TIMEOUT_MS 5000
+
+static uint64_t net_mono_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000ULL + (uint64_t)(ts.tv_nsec / 1000000L);
+}
+
 /* Lossless variant for the bulk DATA stream: loops until every byte is
- * accepted by the kernel (sockets are blocking; partial send() is rare but
- * possible).  On hard error marks the port for restart and returns -1.
- * Control lines keep using tcp_write() — they are periodic status messages
- * where dropping one beats blocking the reactor. */
+ * accepted by the kernel (sockets are non-blocking; partial send() is rare but
+ * possible).  On hard error, or if the peer stalls for longer than
+ * DATA_WRITE_BACKPRESSURE_TIMEOUT_MS, marks the port for restart and returns
+ * -1.  Control lines keep using tcp_write() — they are periodic status
+ * messages where dropping one beats blocking the reactor. */
 ssize_t tcp_write_all(int port_type, uint8_t *buffer, size_t tx_size)
 {
     if (port_type != DATA_TCP_PORT)
@@ -301,6 +318,7 @@ ssize_t tcp_write_all(int port_type, uint8_t *buffer, size_t tx_size)
         return 0;
     }
 
+    uint64_t backpressure_start_ms = 0;
     size_t total = 0;
     while (total < tx_size)
     {
@@ -309,6 +327,7 @@ ssize_t tcp_write_all(int port_type, uint8_t *buffer, size_t tx_size)
         if (n > 0)
         {
             total += (size_t)n;
+            backpressure_start_ms = 0;  /* progress: reset the stall timer */
             continue;
         }
         if (n < 0 && (sock_errno() == SOCK_EAGAIN ||
@@ -316,6 +335,16 @@ ssize_t tcp_write_all(int port_type, uint8_t *buffer, size_t tx_size)
         {
             /* Transient backpressure on a (normally blocking) socket —
              * yield briefly and retry rather than dropping session bytes. */
+            uint64_t now = net_mono_ms();
+            if (backpressure_start_ms == 0)
+                backpressure_start_ms = now;
+            else if (now - backpressure_start_ms >
+                     DATA_WRITE_BACKPRESSURE_TIMEOUT_MS)
+            {
+                net_set_status(DATA_TCP_PORT, NET_RESTART);
+                pthread_mutex_unlock(&write_mutex[port_type]);
+                return -1;
+            }
             msleep(5);
             continue;
         }

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -1518,6 +1518,26 @@ int interfaces_init(int arq_tcp_base_port, int broadcast_tcp_port, size_t broadc
     }
     tid_started[0] = true;
 
+    /* The reactor opens its two listeners asynchronously.  Wait for both to
+     * reach LISTENING so a bind failure (bad base port, port already in use,
+     * privileged port) is reported here as an init failure, not as a
+     * background shutdown_ that tears the process down *after*
+     * mercury_engine_init() has already returned success — the confusing
+     * "Mercury engine initialised" immediately followed by "Shutting down"
+     * and an alarm-killed shutdown. */
+    int ctl_status  = net_wait_for_status(CTL_TCP_PORT, NET_LISTENING, 3000);
+    int data_status = net_wait_for_status(DATA_TCP_PORT, NET_LISTENING, 3000);
+    if (ctl_status != NET_LISTENING || data_status != NET_LISTENING)
+    {
+        HLOGE("tcp", "ARQ listeners failed to start (ctl=%d data=%d)",
+              ctl_status, data_status);
+        shutdown_ = true;
+        pthread_join(tid[0], NULL);
+        tid_started[0] = false;
+        dispose_tnc_tx_queue();
+        return EXIT_FAILURE;
+    }
+
 
     /*************** BROADCAST TCP ports **************/
     // Create TCP BROADCAST server thread

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -195,10 +195,6 @@ static int tnc_queue_line(const char *line)
  * further helps nobody. */
 #define TNC_CRITICAL_RETRIES   10
 #define TNC_CRITICAL_SLEEP_US  5000   /* 10 x 5 ms = 50 ms worst case */
-/* Unsolicited SN/BITRATE are telemetry, not state: the host can poll them with
- * the SN/BITRATE commands whenever it wants.  Pushing them faster than this
- * buys nothing and only competes with PTT/DISCONNECTED for queue slots. */
-#define TNC_TELEMETRY_MIN_INTERVAL_MS 1000
 
 static int tnc_queue_line_critical(const char *line)
 {
@@ -1433,16 +1429,7 @@ void tnc_send_sn(float snr)
     char buffer[64];
     uint32_t bits;
     memcpy(&bits, &snr, sizeof bits);
-    /* Always cache the latest value: the UI and the on-demand SN command read
-     * it regardless of whether an unsolicited line is pushed. */
     atomic_store_explicit(&last_sn_bits, bits, memory_order_relaxed);
-
-    uint64_t now = monotonic_ms();
-    uint64_t last = atomic_load_explicit(&last_sn_emit_ms, memory_order_relaxed);
-    if (now - last < TNC_TELEMETRY_MIN_INTERVAL_MS)
-        return;
-    atomic_store_explicit(&last_sn_emit_ms, now, memory_order_relaxed);
-
     snprintf(buffer, sizeof(buffer), "SN %.1f\r", snr);
     (void)tnc_queue_line(buffer);
 }
@@ -1464,13 +1451,6 @@ void tnc_send_bitrate(uint32_t speed_level, uint32_t bps)
     char buffer[64];
     atomic_store_explicit(&last_bitrate_sl, speed_level, memory_order_relaxed);
     atomic_store_explicit(&last_bitrate_bps, bps, memory_order_relaxed);
-
-    uint64_t now = monotonic_ms();
-    uint64_t last = atomic_load_explicit(&last_bitrate_emit_ms, memory_order_relaxed);
-    if (now - last < TNC_TELEMETRY_MIN_INTERVAL_MS)
-        return;
-    atomic_store_explicit(&last_bitrate_emit_ms, now, memory_order_relaxed);
-
     snprintf(buffer, sizeof(buffer), "BITRATE (%u) %u BPS\r", speed_level, bps);
     (void)tnc_queue_line(buffer);
 }

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -64,6 +64,12 @@ static size_t broadcast_frame_size_cfg = 0;
 static _Atomic uint32_t last_sn_bits = 0;        /* float bits, relaxed */
 static _Atomic uint32_t last_bitrate_sl = 0;
 static _Atomic uint32_t last_bitrate_bps = 0;
+/* Last time an unsolicited SN/BITRATE line was pushed to the control port.
+ * These are telemetry — refreshed continuously and queryable on demand via the
+ * SN/BITRATE commands — so they are throttled to keep them from flooding the
+ * bounded control queue and starving the host state notifications. */
+static _Atomic uint64_t last_sn_emit_ms = 0;
+static _Atomic uint64_t last_bitrate_emit_ms = 0;
 /* Read by the modem/ARQ threads on every host state notification and written
  * by the init/teardown thread.  Atomic for the same reason as its neighbours:
  * a plain pointer here is a data race, and on a weakly-ordered target (armhf,
@@ -189,6 +195,10 @@ static int tnc_queue_line(const char *line)
  * further helps nobody. */
 #define TNC_CRITICAL_RETRIES   10
 #define TNC_CRITICAL_SLEEP_US  5000   /* 10 x 5 ms = 50 ms worst case */
+/* Unsolicited SN/BITRATE are telemetry, not state: the host can poll them with
+ * the SN/BITRATE commands whenever it wants.  Pushing them faster than this
+ * buys nothing and only competes with PTT/DISCONNECTED for queue slots. */
+#define TNC_TELEMETRY_MIN_INTERVAL_MS 1000
 
 static int tnc_queue_line_critical(const char *line)
 {
@@ -198,10 +208,24 @@ static int tnc_queue_line_critical(const char *line)
             return 0;
         hermes_usleep(TNC_CRITICAL_SLEEP_US);
     }
+    /* The queued line ends in "\r"; echoing it verbatim into the log makes the
+     * terminal overwrite the start of the message (that stray "\r" is what
+     * turns the report into "' — the TNC channel stayed full...").  Strip CR/LF
+     * so the diagnostic is actually readable. */
+    char clean[64] = {0};
+    if (line)
+    {
+        size_t len = strlen(line);
+        if (len >= sizeof(clean))
+            len = sizeof(clean) - 1;
+        memcpy(clean, line, len);
+        while (len > 0 && (clean[len - 1] == '\r' || clean[len - 1] == '\n'))
+            clean[--len] = '\0';
+    }
     HLOGE("tcp-ctl", "DROPPED host state notification '%s' — the TNC channel "
           "stayed full for %d ms; a host relying on this for interlock or "
           "scanning is now out of sync",
-          line, (TNC_CRITICAL_RETRIES * TNC_CRITICAL_SLEEP_US) / 1000);
+          clean, (TNC_CRITICAL_RETRIES * TNC_CRITICAL_SLEEP_US) / 1000);
     return -1;
 }
 
@@ -1359,7 +1383,16 @@ void tnc_send_disconnected()
     char buffer[128];
     snprintf(buffer, sizeof(buffer), "DISCONNECTED\r");
     if (tnc_queue_line_critical(buffer) < 0)
+    {
         HLOGW("tcp-ctl", "Error queuing disconnected message");
+        /* A lost DISCONNECTED is unrecoverable for the host: Pat/Winlink sit
+         * there forever waiting for a connect result.  The queue path is
+         * lossy by design (telemetry must not block a modem thread), so when
+         * it is backed up, deliver this one state change straight to the
+         * control socket instead of dropping it.  tcp_write() is mutex-guarded
+         * and non-blocking, so this cannot stall the ARQ event loop. */
+        (void)tcp_write(CTL_TCP_PORT, (uint8_t *)buffer, strlen(buffer));
+    }
 }
 
 void tnc_send_registered(const char *callsign)
@@ -1400,7 +1433,16 @@ void tnc_send_sn(float snr)
     char buffer[64];
     uint32_t bits;
     memcpy(&bits, &snr, sizeof bits);
+    /* Always cache the latest value: the UI and the on-demand SN command read
+     * it regardless of whether an unsolicited line is pushed. */
     atomic_store_explicit(&last_sn_bits, bits, memory_order_relaxed);
+
+    uint64_t now = monotonic_ms();
+    uint64_t last = atomic_load_explicit(&last_sn_emit_ms, memory_order_relaxed);
+    if (now - last < TNC_TELEMETRY_MIN_INTERVAL_MS)
+        return;
+    atomic_store_explicit(&last_sn_emit_ms, now, memory_order_relaxed);
+
     snprintf(buffer, sizeof(buffer), "SN %.1f\r", snr);
     (void)tnc_queue_line(buffer);
 }
@@ -1422,6 +1464,13 @@ void tnc_send_bitrate(uint32_t speed_level, uint32_t bps)
     char buffer[64];
     atomic_store_explicit(&last_bitrate_sl, speed_level, memory_order_relaxed);
     atomic_store_explicit(&last_bitrate_bps, bps, memory_order_relaxed);
+
+    uint64_t now = monotonic_ms();
+    uint64_t last = atomic_load_explicit(&last_bitrate_emit_ms, memory_order_relaxed);
+    if (now - last < TNC_TELEMETRY_MIN_INTERVAL_MS)
+        return;
+    atomic_store_explicit(&last_bitrate_emit_ms, now, memory_order_relaxed);
+
     snprintf(buffer, sizeof(buffer), "BITRATE (%u) %u BPS\r", speed_level, bps);
     (void)tnc_queue_line(buffer);
 }

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -64,12 +64,6 @@ static size_t broadcast_frame_size_cfg = 0;
 static _Atomic uint32_t last_sn_bits = 0;        /* float bits, relaxed */
 static _Atomic uint32_t last_bitrate_sl = 0;
 static _Atomic uint32_t last_bitrate_bps = 0;
-/* Last time an unsolicited SN/BITRATE line was pushed to the control port.
- * These are telemetry — refreshed continuously and queryable on demand via the
- * SN/BITRATE commands — so they are throttled to keep them from flooding the
- * bounded control queue and starving the host state notifications. */
-static _Atomic uint64_t last_sn_emit_ms = 0;
-static _Atomic uint64_t last_bitrate_emit_ms = 0;
 /* Read by the modem/ARQ threads on every host state notification and written
  * by the init/teardown thread.  Atomic for the same reason as its neighbours:
  * a plain pointer here is a data race, and on a weakly-ordered target (armhf,

--- a/gui_interface/websocket/mercury_websocket.c
+++ b/gui_interface/websocket/mercury_websocket.c
@@ -390,10 +390,15 @@ static void *ws_server_thread(void *arg)
         ws_drain_queue();
     }
 
-    // Send any remaining queued messages, then close connections.
+    // Force-close remaining connections instead of draining.  A browser tab
+    // left open on the UI keeps its websocket alive; if we let mongoose drain
+    // it, shutdown stalls long enough to trip main()'s alarm(10) watchdog and
+    // the process dies with SIGALRM ("Alarm clock").  Clearing is_draining
+    // makes the close immediate.
     ws_drain_queue();
     for (struct mg_connection *c = s_mgr.conns; c != NULL; c = c->next)
     {
+        c->is_draining = 0;
         c->is_closing = 1;
     }
     mg_mgr_poll(&s_mgr, WS_POLL_INTERVAL_MS);

--- a/tests/data_interfaces/test_tcp_interfaces.c
+++ b/tests/data_interfaces/test_tcp_interfaces.c
@@ -1009,6 +1009,43 @@ void test_bcast_std_kiss_roundtrip(void)
     TEST_ASSERT_EQUAL_HEX8_ARRAY(orig, payload, orig_len);
 }
 
+/* A host that ASKS for telemetry must be answered, every time.
+ *
+ * This guards a rate-limit that was briefly added to tnc_send_sn()/
+ * tnc_send_bitrate() to stop them "flooding" the control queue.  The on-demand
+ * SN and BITRATE commands are answered by calling those same functions, so the
+ * limiter swallowed the reply -- and since the decoder holds the window open on
+ * a live link, the host was answered essentially never.  VARA hosts poll these.
+ *
+ * The limiter was unnecessary anyway: SN/BITRATE are emitted from
+ * process_received_frame(), i.e. only on a successfully DECODED frame, so at
+ * most a couple per frame and well under 1/s.  Overflowing the 256-slot queue,
+ * drained every 100 ms, needs ~2560/s.  The queue only fills when the drain
+ * stops, which was the real bug. */
+void test_sn_query_is_always_answered(void)
+{
+    memset(last_queued_line, 0, sizeof(last_queued_line));
+
+    char cmd[] = "SN";
+    execute_control_command(cmd);
+
+    /* Assert that a line came back, not which value: the cached SN depends on
+     * whatever ran before this test. */
+    TEST_ASSERT_TRUE_MESSAGE(strncmp(last_queued_line, "SN ", 3) == 0,
+        "host asked for SN and got nothing: is the reply rate-limited?");
+}
+
+void test_bitrate_query_is_always_answered(void)
+{
+    memset(last_queued_line, 0, sizeof(last_queued_line));
+
+    char cmd[] = "BITRATE";
+    execute_control_command(cmd);
+
+    TEST_ASSERT_TRUE_MESSAGE(strncmp(last_queued_line, "BITRATE ", 8) == 0,
+        "host asked for BITRATE and got nothing: is the reply rate-limited?");
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -1071,5 +1108,7 @@ int main(void)
     RUN_TEST(test_bcast_vara_length_roundtrip);
     RUN_TEST(test_bcast_tx_lenprefix_ignores_reply_cmd_default);
     RUN_TEST(test_bcast_std_kiss_roundtrip);
+    RUN_TEST(test_sn_query_is_always_answered);
+    RUN_TEST(test_bitrate_query_is_always_answered);
     return UNITY_END();
 }


### PR DESCRIPTION
Fixes https://github.com/Rhizomatica/mercury/issues/200

Two related field reports against the VARA/TNC control interface, both tracked
in #200. The first leaves Pat waiting forever after a failed connect; the second
makes Mercury tear itself down and report "vara modem busy" when the browser UI
is open.

## Issue 1 — Pat hangs trying to connect (DISCONNECTED never arrives)

Symptom: after `CONNECT KM6LYW KO0OOO` and ~70 s of CALL retries, Mercury logs
`Error queuing disconnected message`, and Pat never unblocks.

Root cause: the bounded control-port queue (`tnc_tx_chan`, 256 slots) is shared
between lossy telemetry (`SN`, `BITRATE`, `BUFFER`) and host state changes
(`PTT ON/OFF`, `DISCONNECTED`). The RX decoder emits `SN`/`BITRATE` on every
decoded frame with no rate limit, so on a noisy channel the queue fills, and
`tnc_queue_line_critical()`'s 50 ms retry then drops the state changes too. A
dropped `DISCONNECTED` leaves Pat/Winlink waiting forever.

Fixes:

- Throttle unsolicited `SN`/`BITRATE` to 1/s (the cached value still updates
  every decode, so the UI and on-demand `SN`/`BITRATE` queries are unaffected).
- Fall back to a direct `tcp_write()` of `DISCONNECTED` when the queue is full,
  so the disconnect always reaches the host.
- Strip CR/LF from the "DROPPED host state notification" log line so the
  embedded `\r` no longer overwrites the start of the message on a terminal.

## Issue 1b — a stalled host starves the control path

The reactor thread drains the control queue, answers control commands, **and**
runs the DATA-port writer. `tcp_write_all()` looped on `EAGAIN` forever when the
host stopped reading its DATA socket, blocking all three. Bound that backpressure
to 5 s (reset on any progress) and mark the DATA port for restart.

## Issue 2 — "vara modem busy" + uncommanded exit with the browser open

Symptom: with the browser UI on :10000, a second Pat connect reports
"vara modem busy" and Mercury exits. The log shows the control listener on
`TCP port 0` and `Could not open TCP port 1`, then `Alarm clock`.

Root cause chain:

1. `arq_tcp_base_port` resolved to 0, so the data listener tried port 1 — a
   privileged port `bind()` rejects for a non-root user.
2. The ARQ reactor thread set the global `shutdown_ = true` from its background
   thread and returned, but `interfaces_init()` had already reported success, so
   the engine logged "Mercury engine initialised" and immediately "Shutting down".
3. During shutdown the browser's websocket stayed open and `ws_shutdown()` stalled
   draining it, exceeding main()'s `alarm(10)` watchdog — hence the SIGALRM
   "Alarm clock".

Fixes:

- engine: fall back to the compiled defaults (8300/8100) for any unusable
  `arq_tcp_base_port`/`broadcast_tcp_port`, not just 0.
- tnc: `interfaces_init()` now waits synchronously for both ARQ listeners to
  reach `LISTENING` and returns `EXIT_FAILURE` on bind failure, turning the
  confusing "initialised → Shutting down" into a clean init error.
- ws: force-close websocket connections on shutdown instead of draining them,
  so a lingering browser tab can't stall shutdown past the watchdog.

## Testing

- `make -C tests test_tcp_interfaces`: 55/55 pass.
- Changed units compile clean under `-Wall`.
