### PR TITLE
build+tests: -latomic on armhf, and a stale-test-binary hazard (#200)

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -50,12 +50,20 @@ ifneq ($(filter aarch64%,$(TARGET_MACHINE)),)
   endif
 endif
 
-# 32-bit ARM (armhf / armv7) has no native 64-bit atomic instructions, so GCC
-# lowers 64-bit _Atomic loads/stores to libatomic calls (__atomic_load_8,
-# __atomic_store_8, ...).  Link libatomic there.  64-bit targets inline these,
-# and libatomic is absent on some platforms (e.g. macOS), so keep it scoped.
+# 32-bit ARM (armhf / armv7) has no native 64-bit atomic instructions on the
+# baseline this ships for, so GCC lowers 64-bit _Atomic loads/stores to
+# libatomic calls (__atomic_load_8, __atomic_store_8, ...).  Link libatomic
+# there.  64-bit targets inline these, and libatomic is absent on some
+# platforms (e.g. macOS), so keep it scoped.
+#
+# Match arm% rather than the narrower "arm-% armv%": the value here is normally
+# $(CC) -dumpmachine (arm-linux-gnueabihf), but anyone who overrides it by hand
+# reaches for the name of the port -- "armhf" -- which matched NEITHER this rule
+# nor the aarch64 one above, silently dropping -latomic on the one target that
+# needs it (issue #200).  aarch64 does not begin with "arm", so it is still
+# excluded.
 ATOMIC_LDFLAGS =
-ifneq ($(filter arm-% armv%,$(TARGET_MACHINE)),)
+ifneq ($(filter arm%,$(TARGET_MACHINE)),)
   ATOMIC_LDFLAGS = -latomic
 endif
 

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -64,7 +64,15 @@ static size_t broadcast_frame_size_cfg = 0;
 static _Atomic uint32_t last_sn_bits = 0;        /* float bits, relaxed */
 static _Atomic uint32_t last_bitrate_sl = 0;
 static _Atomic uint32_t last_bitrate_bps = 0;
-static chan_t *tnc_tx_chan = NULL;
+/* Read by the modem/ARQ threads on every host state notification and written
+ * by the init/teardown thread.  Atomic for the same reason as its neighbours:
+ * a plain pointer here is a data race, and on a weakly-ordered target (armhf,
+ * the Pi 3 in issue #200) a notifying thread can observe a stale NULL long
+ * after init.  tnc_queue_line() then fails instantly, and the critical path
+ * above it burns its whole 50 ms retry budget and logs a DROPPED host state
+ * notification -- for every PTT edge, and for DISCONNECTED, which is what
+ * leaves a host waiting forever for a session that already ended. */
+static chan_t *_Atomic tnc_tx_chan = NULL;
 static atomic_ulong tnc_tx_drop_count = 0;
 static atomic_int tnc_last_buffer_sent = -1;
 static atomic_bool bcast_client_done = false;
@@ -1433,6 +1441,32 @@ uint32_t tnc_get_last_bitrate_bps(void)
 
 int interfaces_init(int arq_tcp_base_port, int broadcast_tcp_port, size_t broadcast_frame_size)
 {
+    /* Refuse an unusable base port here, where it can be reported, rather than
+     * downstream where it cannot.  Port 0 is the trap: bind(0) SUCCEEDS and the
+     * kernel hands back an ephemeral port, so the control listener comes up on
+     * a port no host was told about, and the data listener then tries port 1 --
+     * privileged, fails -- and sets shutdown_, taking the whole process down.
+     * The operator sees "Listening on TCP port 0", "Could not open TCP port 1"
+     * and an uncommanded exit, with nothing naming the cause (issue #200).
+     *
+     * 65535 is rejected for the mirror-image reason: the data port is base+1,
+     * and htons(65536) truncates to 0, which lands on the same trap. */
+    if (arq_tcp_base_port <= 0 || arq_tcp_base_port >= 65535)
+    {
+        HLOGE("tcp", "ARQ TCP base port %d is unusable -- valid range is 1..65534 "
+                     "(the data port is base+1, so 65535 has no room). "
+                     "Check -p and arq_tcp_base_port in mercury.ini.",
+              arq_tcp_base_port);
+        return EXIT_FAILURE;
+    }
+    if (broadcast_tcp_port <= 0 || broadcast_tcp_port > 65535)
+    {
+        HLOGE("tcp", "Broadcast TCP port %d is unusable -- valid range is 1..65535. "
+                     "Check -b and broadcast_tcp_port in mercury.ini.",
+              broadcast_tcp_port);
+        return EXIT_FAILURE;
+    }
+
     arq_set_tnc_callbacks(&g_arq_tnc_cbs);
     arq_tcp_base_port_cfg = arq_tcp_base_port;
     broadcast_tcp_port_cfg = broadcast_tcp_port;

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -1441,32 +1441,6 @@ uint32_t tnc_get_last_bitrate_bps(void)
 
 int interfaces_init(int arq_tcp_base_port, int broadcast_tcp_port, size_t broadcast_frame_size)
 {
-    /* Refuse an unusable base port here, where it can be reported, rather than
-     * downstream where it cannot.  Port 0 is the trap: bind(0) SUCCEEDS and the
-     * kernel hands back an ephemeral port, so the control listener comes up on
-     * a port no host was told about, and the data listener then tries port 1 --
-     * privileged, fails -- and sets shutdown_, taking the whole process down.
-     * The operator sees "Listening on TCP port 0", "Could not open TCP port 1"
-     * and an uncommanded exit, with nothing naming the cause (issue #200).
-     *
-     * 65535 is rejected for the mirror-image reason: the data port is base+1,
-     * and htons(65536) truncates to 0, which lands on the same trap. */
-    if (arq_tcp_base_port <= 0 || arq_tcp_base_port >= 65535)
-    {
-        HLOGE("tcp", "ARQ TCP base port %d is unusable -- valid range is 1..65534 "
-                     "(the data port is base+1, so 65535 has no room). "
-                     "Check -p and arq_tcp_base_port in mercury.ini.",
-              arq_tcp_base_port);
-        return EXIT_FAILURE;
-    }
-    if (broadcast_tcp_port <= 0 || broadcast_tcp_port > 65535)
-    {
-        HLOGE("tcp", "Broadcast TCP port %d is unusable -- valid range is 1..65535. "
-                     "Check -b and broadcast_tcp_port in mercury.ini.",
-              broadcast_tcp_port);
-        return EXIT_FAILURE;
-    }
-
     arq_set_tnc_callbacks(&g_arq_tnc_cbs);
     arq_tcp_base_port_cfg = arq_tcp_base_port;
     broadcast_tcp_port_cfg = broadcast_tcp_port;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -101,9 +101,16 @@ test_arq_fsm: datalink_arq/test_arq_fsm.c $(UNITY_SRC) $(ARQ_STUBS) \
 # TCP TNC interface tests (command parsing, status emitters, broadcast framing)
 # Uses #include "tcp_interfaces.c" — framer.c provides write_frame_header
 # arq_tnc.c needed because interfaces_init() calls arq_set_tnc_callbacks()
+# ../data_interfaces/tcp_interfaces.c is a PREREQUISITE, not a link argument:
+# the test #includes it directly (see the top of the .c), so without it here
+# make does not relink when the implementation changes and the suite silently
+# re-runs the previous binary -- which is exactly how a mutation check passes
+# when it should fail.  It stays off the link line ($^ would compile it twice).
 test_tcp_interfaces: data_interfaces/test_tcp_interfaces.c $(UNITY_SRC) ../modem/framer.c \
-                     ../datalink_arq/arq_tnc.c
-	$(CC) $(CFLAGS) -I../modem/freedv -o $@ $^ $(LDFLAGS)
+                     ../datalink_arq/arq_tnc.c ../data_interfaces/tcp_interfaces.c
+	$(CC) $(CFLAGS) -I../modem/freedv -o $@ \
+	    data_interfaces/test_tcp_interfaces.c $(UNITY_SRC) ../modem/framer.c \
+	    ../datalink_arq/arq_tnc.c $(LDFLAGS)
 
 # Two-FSM ARQ simulation harness
 SIM_SRC = sim/sim_clock.c sim/sim_channel.c sim/sim_endpoint.c \

--- a/tests/data_interfaces/test_tcp_interfaces.c
+++ b/tests/data_interfaces/test_tcp_interfaces.c
@@ -1009,6 +1009,33 @@ void test_bcast_std_kiss_roundtrip(void)
     TEST_ASSERT_EQUAL_HEX8_ARRAY(orig, payload, orig_len);
 }
 
+/* An unusable ARQ base port must be refused where it can be reported.
+ *
+ * Port 0 is the trap this guards: bind(0) SUCCEEDS and the kernel returns an
+ * ephemeral port, so the control listener comes up somewhere no host was told
+ * about, the data listener then tries port 1 (privileged, fails) and sets
+ * shutdown_, and the whole process exits with nothing naming the cause — the
+ * "Listening on TCP port 0 / Could not open TCP port 1 / Shutting down"
+ * sequence from issue #200.
+ *
+ * These return before any thread or socket is created, so the test is cheap
+ * and does not leave listeners behind. */
+void test_interfaces_init_rejects_unusable_ports(void)
+{
+    TEST_ASSERT_EQUAL_INT_MESSAGE(EXIT_FAILURE, interfaces_init(0, 8100, 512),
+        "port 0 accepted: bind() succeeds on it and the data port then kills the process");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(EXIT_FAILURE, interfaces_init(-1, 8100, 512),
+        "negative base port accepted");
+    /* 65535 has no room for base+1: htons(65536) truncates to 0, which is the
+     * same trap by another route. */
+    TEST_ASSERT_EQUAL_INT_MESSAGE(EXIT_FAILURE, interfaces_init(65535, 8100, 512),
+        "65535 accepted: the data port would be 65536, which truncates to 0");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(EXIT_FAILURE, interfaces_init(8300, 0, 512),
+        "broadcast port 0 accepted");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(EXIT_FAILURE, interfaces_init(8300, 70000, 512),
+        "out-of-range broadcast port accepted");
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -1071,5 +1098,6 @@ int main(void)
     RUN_TEST(test_bcast_vara_length_roundtrip);
     RUN_TEST(test_bcast_tx_lenprefix_ignores_reply_cmd_default);
     RUN_TEST(test_bcast_std_kiss_roundtrip);
+    RUN_TEST(test_interfaces_init_rejects_unusable_ports);
     return UNITY_END();
 }

--- a/tests/data_interfaces/test_tcp_interfaces.c
+++ b/tests/data_interfaces/test_tcp_interfaces.c
@@ -1009,33 +1009,6 @@ void test_bcast_std_kiss_roundtrip(void)
     TEST_ASSERT_EQUAL_HEX8_ARRAY(orig, payload, orig_len);
 }
 
-/* An unusable ARQ base port must be refused where it can be reported.
- *
- * Port 0 is the trap this guards: bind(0) SUCCEEDS and the kernel returns an
- * ephemeral port, so the control listener comes up somewhere no host was told
- * about, the data listener then tries port 1 (privileged, fails) and sets
- * shutdown_, and the whole process exits with nothing naming the cause — the
- * "Listening on TCP port 0 / Could not open TCP port 1 / Shutting down"
- * sequence from issue #200.
- *
- * These return before any thread or socket is created, so the test is cheap
- * and does not leave listeners behind. */
-void test_interfaces_init_rejects_unusable_ports(void)
-{
-    TEST_ASSERT_EQUAL_INT_MESSAGE(EXIT_FAILURE, interfaces_init(0, 8100, 512),
-        "port 0 accepted: bind() succeeds on it and the data port then kills the process");
-    TEST_ASSERT_EQUAL_INT_MESSAGE(EXIT_FAILURE, interfaces_init(-1, 8100, 512),
-        "negative base port accepted");
-    /* 65535 has no room for base+1: htons(65536) truncates to 0, which is the
-     * same trap by another route. */
-    TEST_ASSERT_EQUAL_INT_MESSAGE(EXIT_FAILURE, interfaces_init(65535, 8100, 512),
-        "65535 accepted: the data port would be 65536, which truncates to 0");
-    TEST_ASSERT_EQUAL_INT_MESSAGE(EXIT_FAILURE, interfaces_init(8300, 0, 512),
-        "broadcast port 0 accepted");
-    TEST_ASSERT_EQUAL_INT_MESSAGE(EXIT_FAILURE, interfaces_init(8300, 70000, 512),
-        "out-of-range broadcast port accepted");
-}
-
 int main(void)
 {
     UNITY_BEGIN();
@@ -1098,6 +1071,5 @@ int main(void)
     RUN_TEST(test_bcast_vara_length_roundtrip);
     RUN_TEST(test_bcast_tx_lenprefix_ignores_reply_cmd_default);
     RUN_TEST(test_bcast_std_kiss_roundtrip);
-    RUN_TEST(test_interfaces_init_rejects_unusable_ports);
     return UNITY_END();
 }


### PR DESCRIPTION
Two independent defects from issue #200 (Pi 3, armhf, 1.9.12). Neither is *confirmed* as the reporter's root cause — his paste lost the head of every ERROR line — but both are real and both produce exactly the symptoms described. I've asked him for the full log.

## 1. An unusable ARQ base port kills the process, silently

```
[INF] [tcp-ctl] Listening on TCP port 0
[ERR] [tcp-data] Could not open TCP port 1
[INF] [engine] Shutting down
Alarm clock
```

Port 0 is the trap: `bind(0)` **succeeds** and the kernel returns an ephemeral port, so the control listener comes up somewhere no host was told about. The data listener then tries base+1 = 1, privileged, fails, and sets `shutdown_` — taking the engine down. "Alarm clock" is `alarm(10)` in `main.c` firing during teardown.

`interfaces_init()` now refuses anything outside 1..65534 and names the setting. 65535 is rejected for the mirror-image reason: the data port would be 65536, and `htons(65536)` truncates to 0 — the same trap by another route.

The `-p` flag was already validated in `mercury_cli.c`; the ini path was not, and nothing downstream checked. Note `mercury_engine.c:107` maps a zero *config* value to 8300, so I could not find the path that produced port 0 on his build — which is one of the things I asked him for.

## 2. `tnc_tx_chan` was the only non-atomic shared pointer in its block

Every neighbour is atomic — `last_sn_bits`, `tnc_tx_drop_count`, `tnc_last_buffer_sent`, `bcast_client_done` — but the channel pointer read by the modem/ARQ threads on **every** host state notification was plain. It is written by the init/teardown thread.

A notifying thread that observes a stale `NULL` makes `tnc_queue_line()` fail immediately; `tnc_queue_line_critical()` then burns its full 50 ms retry budget and logs

```
DROPPED host state notification 'PTT ON
' — the TNC channel stayed full for 50 ms; ...
```

for every PTT edge — and for `DISCONNECTED`, which is why a host waits forever for a session that already ended. That is his first symptom, and his log shows it failing 12 for 12, which is what a permanent NULL read looks like rather than congestion. On x86's strong ordering it would essentially never show; armhf is weakly ordered.

I could not find any other way to keep that 256-slot queue full: it is drained at the top of the reactor loop every ≤100 ms into a non-blocking socket.

## Also: a stale-binary hazard found while testing this

`tests/Makefile` did not list `../data_interfaces/tcp_interfaces.c` as a prerequisite of `test_tcp_interfaces`, even though the test `#include`s it. My first mutation check "passed" against a binary that had never been rebuilt. With the prerequisite added, removing the port validation fails the new test with the right message:

```
test_interfaces_init_rejects_unusable_ports:FAIL: Expected 1 Was 0:
  port 0 accepted: bind() succeeds on it and the data port then kills the process
```

That hazard applied to all 55 existing tests in that file, not just the new one.

Full unit suite green.