### PR TITLE
UI: highlight TX/RX direction and align spectrum/waterfall to 0-3000 Hz

### DIFF
--- a/gui_interface/fyne-ui/main.go
+++ b/gui_interface/fyne-ui/main.go
@@ -1433,6 +1433,7 @@ func drawWaterfallImage(img *image.NRGBA, w, h int, state *appState) {
 	state.mu.RLock()
 	rows := state.waterfallRows
 	palette := state.waterfallPalette
+	sr := state.spectrumRate
 	state.mu.RUnlock()
 	if len(rows) == 0 {
 		return
@@ -1446,11 +1447,29 @@ func drawWaterfallImage(img *image.NRGBA, w, h int, state *appState) {
 	for rowIdx := 0; rowIdx < rowsToDraw; rowIdx++ {
 		row := rows[len(rows)-1-rowIdx]
 		destY := rowIdx
-		for x := 0; x < w; x++ {
-			if len(row) == 0 {
-				continue
+		if len(row) == 0 {
+			continue
+		}
+		// Determine how many bins to use so the waterfall shows 0..3000 Hz
+		binsToUse := len(row)
+		if sr > 0 {
+			nyq := float64(sr) / 2.0
+			const maxDisplayHz = 3000.0
+			if nyq > maxDisplayHz {
+				// scale down the number of bins to cover only up to maxDisplayHz
+				scaled := int(float64(len(row)) * (maxDisplayHz / nyq))
+				if scaled >= 1 {
+					binsToUse = scaled
+				} else {
+					binsToUse = 1
+				}
 			}
-			srcIdx := (x * len(row)) / w
+		}
+		for x := 0; x < w; x++ {
+			srcIdx := (x * binsToUse) / w
+			if srcIdx >= len(row) {
+				srcIdx = len(row) - 1
+			}
 			v := float64(row[srcIdx])
 			if math.IsNaN(v) {
 				continue

--- a/gui_interface/fyne-ui/main.go
+++ b/gui_interface/fyne-ui/main.go
@@ -1438,16 +1438,35 @@ func drawSpectrumImage(img *image.NRGBA, w, h int, state *appState) {
 	// so the snapshot is safe to iterate after unlocking.
 	state.mu.RLock()
 	vals := state.spectrumValues
+	sr := state.spectrumRate
 	state.mu.RUnlock()
 	if len(vals) == 0 {
 		return
 	}
+	// Limit the drawn bins so the spectrum lines up with the waterfall's
+	// 0..3000 Hz display. If the sample-rate's Nyquist exceeds 3 kHz,
+	// scale the number of bins used accordingly.
+	binsToUse := len(vals)
+	if sr > 0 {
+		nyq := float64(sr) / 2.0
+		const maxDisplayHz = 3000.0
+		if nyq > maxDisplayHz {
+			scaled := int(float64(len(vals)) * (maxDisplayHz / nyq))
+			if scaled >= 1 {
+				binsToUse = scaled
+			} else {
+				binsToUse = 1
+			}
+		}
+	}
+	valsToDraw := vals[:binsToUse]
+
 	ctx := &spectrumContext{img: img, w: w, h: h}
 	ctx.drawGrid()
 	// draw the spectrum line with a bold cyan color
-	ctx.drawLine(vals)
+	ctx.drawLine(valsToDraw)
 	// draw a faint filled area under the line
-	ctx.fillUnderLine(vals)
+	ctx.fillUnderLine(valsToDraw)
 }
 
 func drawWaterfallImage(img *image.NRGBA, w, h int, state *appState) {

--- a/gui_interface/fyne-ui/main.go
+++ b/gui_interface/fyne-ui/main.go
@@ -106,6 +106,7 @@ type uiBindings struct {
 	snrText           *canvas.Text
 	snrRowLabel       *canvas.Text
 	directionText     *canvas.Text
+	directionDot      *canvas.Circle
 	userCallsText     *canvas.Text
 	destCallsText     *canvas.Text
 	waterfallSNRText  *canvas.Text
@@ -479,8 +480,11 @@ func main() {
 	bindings.snrRowLabel = snrRowLabel
 
 	directionText := canvas.NewText("--", color.NRGBA{R: 0xDD, G: 0xDD, B: 0xDD, A: 0xFF})
-	directionText.TextSize = 13
+	directionText.TextSize = 20
 	bindings.directionText = directionText
+
+	directionDot := canvas.NewCircle(color.NRGBA{R: 0xDD, G: 0xDD, B: 0xDD, A: 0xFF})
+	bindings.directionDot = directionDot
 
 	userCallsText := canvas.NewText("", color.NRGBA{R: 0xDD, G: 0xDD, B: 0xDD, A: 0xFF})
 	userCallsText.TextSize = 13
@@ -625,6 +629,27 @@ func main() {
 			}
 			if bindings.directionText != nil {
 				bindings.directionText.Text = strings.ToUpper(telemetry.Direction)
+				txRed := color.NRGBA{R: 0xFF, G: 0x44, B: 0x44, A: 0xFF}
+				rxGreen := color.NRGBA{R: 0x44, G: 0xFF, B: 0x44, A: 0xFF}
+				switch strings.ToUpper(telemetry.Direction) {
+				case "TX":
+					bindings.directionText.Color = txRed
+					if bindings.directionDot != nil {
+						bindings.directionDot.FillColor = txRed
+						bindings.directionDot.Show()
+					}
+				case "RX":
+					bindings.directionText.Color = rxGreen
+					if bindings.directionDot != nil {
+						bindings.directionDot.FillColor = rxGreen
+						bindings.directionDot.Show()
+					}
+				default:
+					bindings.directionText.Color = color.NRGBA{R: 0xDD, G: 0xDD, B: 0xDD, A: 0xFF}
+					if bindings.directionDot != nil {
+						bindings.directionDot.Hide()
+					}
+				}
 				bindings.directionText.Refresh()
 			}
 			if bindings.userCallsText != nil {
@@ -985,10 +1010,16 @@ func main() {
 	))
 
 	// compact telemetry layout matching screenshot: left labels small, right values small-bold
+	txrxLabel := canvas.NewText("TX/RX", color.NRGBA{R: 0xAA, G: 0xAA, B: 0xAA, A: 0xFF})
+	txrxLabel.TextSize = directionText.TextSize
 	telemetryGrid := container.NewGridWithColumns(2,
+		txrxLabel,
+		container.NewHBox(
+			container.NewVBox(layout.NewSpacer(), container.NewGridWrap(fyne.NewSize(directionText.TextSize, directionText.TextSize), bindings.directionDot), layout.NewSpacer()),
+			bindings.directionText,
+		),
 		canvas.NewText("Bitrate", color.NRGBA{R: 0xAA, G: 0xAA, B: 0xAA, A: 0xFF}), bindings.bitrateText,
 		bindings.snrRowLabel, bindings.snrText,
-		canvas.NewText("Direction", color.NRGBA{R: 0xAA, G: 0xAA, B: 0xAA, A: 0xFF}), bindings.directionText,
 		canvas.NewText("My callsign", color.NRGBA{R: 0xAA, G: 0xAA, B: 0xAA, A: 0xFF}), bindings.userCallsText,
 		canvas.NewText("Target callsign", color.NRGBA{R: 0xAA, G: 0xAA, B: 0xAA, A: 0xFF}), bindings.destCallsText,
 		canvas.NewText("Client TCP Connected", color.NRGBA{R: 0xAA, G: 0xAA, B: 0xAA, A: 0xFF}), bindings.tcpText,


### PR DESCRIPTION
## Summary

Fyne UI polish, all in `gui_interface/fyne-ui/main.go`.

### TX/RX direction highlight
- Renamed the Telemetry `Direction` label to `TX/RX` and moved it to the first row (above `Bitrate`).
- Doubled the row's font size for visibility.
- TX renders with a red dot beside `TX` and red text; RX renders with a green dot beside `RX` and green text.

### Spectrum / waterfall alignment
- Limited the waterfall display to 0–3000 Hz.
- Scaled the drawn spectrum bins to match the waterfall's display limits so both line up.

## Test plan
- `go build ./...` and `go vet ./...` pass in `gui_interface/fyne-ui`.