### PR TITLE
freedv: honor configured archiver

### DIFF
--- a/modem/freedv/Makefile
+++ b/modem/freedv/Makefile
@@ -17,7 +17,7 @@ OBJS_COMMON = freedv_api.o ofdm.o freedv_fsk.o cohpsk.o fsk.o kiss_fft.o freedv_
 all: freedv_data_tx freedv_data_rx freedv_data_raw_tx freedv_data_raw_rx
 
 $(LIBNAME): $(OBJS_COMMON)
-	ar rcs $(LIBNAME) $(OBJS_COMMON)
+	$(AR) rcs $(LIBNAME) $(OBJS_COMMON)
 
 
 freedv_data_tx: freedv_data_tx.o $(LIBNAME)


### PR DESCRIPTION
Use the configured `$(AR)` instead of hard-coding the host `ar` when building `libfreedvdata.a`.

This keeps native builds unchanged and lets MinGW and other cross-builds select the target archiver.

Validated locally on Apple Silicon macOS with:

```sh
make -C modem/freedv clean
make -C modem/freedv -j8 OS=Windows_NT CC=x86_64-w64-mingw32-gcc AR=x86_64-w64-mingw32-ar
```

The build invoked `x86_64-w64-mingw32-ar rcs` successfully.
