### PR TITLE
Add Logs menu, Submit issue item, and logs directory handling

### DIFF
--- a/gui_interface/fyne-ui/main.go
+++ b/gui_interface/fyne-ui/main.go
@@ -550,7 +550,9 @@ func main() {
 
 	// open UI log file for appending; if it fails, uiLog will be nil and logs go only to the UI
 	var uiLog *os.File
-	uiLogPath := filepath.Join(getLogDir(), "ui.log")
+	logDir := getLogDir()
+	_ = os.MkdirAll(logDir, 0755)
+	uiLogPath := filepath.Join(logDir, "ui.log")
 	uiLog, _ = os.OpenFile(uiLogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 
 	appendLog := func(msg string) {
@@ -1265,6 +1267,17 @@ func main() {
 		}
 	}
 
+	openLogsDir := func() {
+		dir := getLogDir()
+		p := filepath.ToSlash(dir)
+		if runtime.GOOS == "windows" && !strings.HasPrefix(p, "/") {
+			p = "/" + p
+		}
+		if err := myApp.OpenURL(&url.URL{Scheme: "file", Path: p}); err != nil {
+			appendLog(fmt.Sprintf("Failed to open logs directory %s: %v\n", dir, err))
+		}
+	}
+
 	showVersionDialog := func() {
 		version, gitHash := "unknown", "unknown000"
 		state.mu.RLock()
@@ -1289,7 +1302,10 @@ func main() {
 	})
 	helpMenu := fyne.NewMenu("Help", versionItem, supportItem, mailingItem, submitIssueItem)
 
-	myWindow.SetMainMenu(fyne.NewMainMenu(remoteMenu, configMenu, helpMenu))
+	logsItem := fyne.NewMenuItem("Open logs directory", openLogsDir)
+	logsMenu := fyne.NewMenu("Logs", logsItem)
+
+	myWindow.SetMainMenu(fyne.NewMainMenu(remoteMenu, configMenu, logsMenu, helpMenu))
 
 	// Single idempotent teardown, used by both the window-close handler and the
 	// signal handler.  It runs entirely OFF the GL/main thread: SetOnClosed is
@@ -1698,18 +1714,23 @@ func netJoinHostPort(host, port string) string {
 	return net.JoinHostPort(host, port)
 }
 
+func getExeDir() string {
+	if exePath, err := os.Executable(); err == nil {
+		return filepath.Dir(exePath)
+	}
+	return "."
+}
+
 func getBaseDir() string {
 	if runtime.GOOS == "windows" {
-		if exePath, err := os.Executable(); err == nil {
-			return filepath.Dir(exePath)
-		}
+		return getExeDir()
 	}
 	return "."
 }
 
 func getLogDir() string {
-	if runtime.GOOS == "windows" {
-		return getBaseDir()
+	if runtime.GOOS == "linux" || runtime.GOOS == "windows" {
+		return filepath.Join(getExeDir(), "logs")
 	}
 	return "."
 }

--- a/gui_interface/fyne-ui/main.go
+++ b/gui_interface/fyne-ui/main.go
@@ -1284,7 +1284,10 @@ func main() {
 	mailingItem := fyne.NewMenuItem("Join our mailing list", func() {
 		openExternalURL("https://lists.riseup.net/www/info/hermes-general")
 	})
-	helpMenu := fyne.NewMenu("Help", versionItem, supportItem, mailingItem)
+	submitIssueItem := fyne.NewMenuItem("Submit issue", func() {
+		openExternalURL("https://github.com/Rhizomatica/mercury/issues/new")
+	})
+	helpMenu := fyne.NewMenu("Help", versionItem, supportItem, mailingItem, submitIssueItem)
 
 	myWindow.SetMainMenu(fyne.NewMainMenu(remoteMenu, configMenu, helpMenu))
 

--- a/gui_interface/fyne-ui/main.go
+++ b/gui_interface/fyne-ui/main.go
@@ -1729,7 +1729,16 @@ func getBaseDir() string {
 }
 
 func getLogDir() string {
-	if runtime.GOOS == "linux" || runtime.GOOS == "windows" {
+	if runtime.GOOS == "linux" {
+		if dir := os.Getenv("XDG_STATE_HOME"); dir != "" {
+			return filepath.Join(dir, "mercury", "logs")
+		}
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, ".local", "state", "mercury", "logs")
+		}
+		return "."
+	}
+	if runtime.GOOS == "windows" {
 		return filepath.Join(getExeDir(), "logs")
 	}
 	return "."

--- a/gui_interface/fyne-ui/main.go
+++ b/gui_interface/fyne-ui/main.go
@@ -550,10 +550,6 @@ func main() {
 
 	// open UI log file for appending; if it fails, uiLog will be nil and logs go only to the UI
 	var uiLog *os.File
-	logDir := getLogDir()
-	_ = os.MkdirAll(logDir, 0755)
-	uiLogPath := filepath.Join(logDir, "ui.log")
-	uiLog, _ = os.OpenFile(uiLogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 
 	appendLog := func(msg string) {
 		// write only to file by default; UI log widget removed from layout
@@ -565,6 +561,17 @@ func main() {
 		if uiLog != nil {
 			_, _ = uiLog.WriteString(msg)
 		}
+	}
+
+	logDir := getLogDir()
+	if err := os.MkdirAll(logDir, 0755); err != nil {
+		appendLog(fmt.Sprintf("Failed to create logs directory %s: %v\n", logDir, err))
+	}
+	uiLogPath := filepath.Join(logDir, "ui.log")
+	if f, err := os.OpenFile(uiLogPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644); err != nil {
+		appendLog(fmt.Sprintf("Failed to open log file %s: %v\n", uiLogPath, err))
+	} else {
+		uiLog = f
 	}
 
 	setWSStatus := func(text string) {}

--- a/windows-installer/installer.iss
+++ b/windows-installer/installer.iss
@@ -62,6 +62,8 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 
 [Dirs]
 Name: "{app}"; Permissions: users-modify
+; Writable logs sub-directory: the GUI writes ui.log and mercury_engine.log here.
+Name: "{app}\logs"; Permissions: users-modify
 
 [Files]
 Source: "mercury.ini"; DestDir: "{app}"; Flags: ignoreversion; Permissions: users-modify


### PR DESCRIPTION
## Summary

Adds a few Fyne UI menu improvements and makes the log output directory explicit.

## Changes

- **Help menu**: new "Submit issue" item that opens `https://github.com/Rhizomatica/mercury/issues/new`.
- **Logs menu** (next to Settings): "Open logs directory" opens the current log folder in the file manager.
- The UI now creates the log directory at startup before opening `ui.log`.
- **Windows installer**: creates a writable `logs\` sub-directory (`{app}\logs`) where `ui.log` and `mercury_engine.log` are written.
- **Log directory resolution**:
  - Linux: `$XDG_STATE_HOME/mercury/logs`, falling back to `~/.local/state/mercury/logs`.
  - Windows: `<exe dir>\logs`.

## Notes

No changes to runtime behavior for the engine itself; this is UI/install packaging only.