### PR TITLE
Avoid libatomic on macOS arm64 build

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -60,11 +60,13 @@ endif
 # $(CC) -dumpmachine (arm-linux-gnueabihf), but anyone who overrides it by hand
 # reaches for the name of the port -- "armhf" -- which matched NEITHER this rule
 # nor the aarch64 one above, silently dropping -latomic on the one target that
-# needs it (issue #200).  aarch64 does not begin with "arm", so it is still
-# excluded.
+# needs it (issue #200).  Exclude arm64 explicitly: Apple Clang reports targets
+# such as arm64-apple-darwin, and macOS does not provide a separate libatomic.
 ATOMIC_LDFLAGS =
 ifneq ($(filter arm%,$(TARGET_MACHINE)),)
+ifeq ($(filter arm64%,$(TARGET_MACHINE)),)
   ATOMIC_LDFLAGS = -latomic
+endif
 endif
 
 GIT_HASH ?= $(shell git rev-parse --short=8 HEAD 2>/dev/null || echo unknown000)


### PR DESCRIPTION
## Summary

Prevent Apple Silicon builds from linking against the unavailable `libatomic` library.

Apple Clang reports its target as `arm64-apple-darwin`, which was incorrectly matched by the generic 32-bit `arm%` rule. The updated detection excludes `arm64` while preserving `-latomic` for ARM32 targets.

## Testing

- Confirmed build succeeds on Apple Silicon
- Verified `-latomic` remains enabled for ARM32 and disabled for ARM64, x86, and MinGW targets