### PR TITLE
ci: let the Windows job check out on pull requests from forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,6 +227,7 @@ jobs:
           apt-get install -y --no-install-recommends \
             build-essential \
             git \
+            ca-certificates \
             openssh-client \
             gcc-mingw-w64-x86-64
 


### PR DESCRIPTION
**Every pull request from a fork fails `Build Windows x64`**, always, before anything is compiled:

```
fatal: unable to access 'https://github.com/Rhizomatica/mercury/':
Problem with the SSL CA cert (path? access rights?)
```

Found while reviewing #209 (from `ptsmonteiro/mercury`), where it failed identically on two attempts while the same job passes on `mercuryv2`.

## Cause

All four build jobs check out with `ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}`. GitHub does not expose secrets to workflows triggered by a fork's pull request, so there the key is empty, and `actions/checkout` falls back to HTTPS — which needs a CA bundle the `debian:trixie` container does not ship.

The three Linux jobs install `ca-certificates` and therefore survive the fallback. The Windows job was the only one that did not:

| job | `ssh-key` | `ca-certificates` |
|---|---|---|
| Build Linux amd64 | ✅ | ✅ |
| Build Linux arm64 | ✅ | ✅ |
| Build Linux armhf | ✅ | ✅ |
| **Build Windows x64** | ✅ | **❌** |

That asymmetry is why it reads as a flake: pushes to `mercuryv2` and PRs from branches in this repo have the secret, use SSH, and pass. Only outside contributors ever hit it — and they hit it every single time.

## Fix

Add `ca-certificates` to the Windows job, matching the other three. One line, and no effect on runs that do have the secret.

Verified all four jobs are now consistent, and the workflow still parses.

## Worth considering separately

The `ssh-key` + `repository: Rhizomatica/mercury` overrides look like they predate something; plain `actions/checkout@v4` would clone the PR head over HTTPS with the automatic token and need neither. Not changed here — this PR is deliberately the one-line unblock.
