### PR TITLE
fix(arq): strictly validate session IDs

### DIFF
--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -2496,6 +2496,25 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
  * Top-level dispatch
  * ====================================================================== */
 
+static bool is_session_bound_rx_event(arq_event_id_t id)
+{
+    switch (id)
+    {
+    case ARQ_EV_RX_DATA:
+    case ARQ_EV_RX_ACK:
+    case ARQ_EV_RX_DISCONNECT:
+    case ARQ_EV_RX_TURN_REQ:
+    case ARQ_EV_RX_TURN_ACK:
+    case ARQ_EV_RX_MODE_REQ:
+    case ARQ_EV_RX_MODE_ACK:
+    case ARQ_EV_RX_KEEPALIVE:
+    case ARQ_EV_RX_KEEPALIVE_ACK:
+        return true;
+    default:
+        return false;
+    }
+}
+
 void arq_fsm_dispatch(arq_session_t *sess, const arq_event_t *ev)
 {
     if (!sess || !ev)
@@ -2505,6 +2524,21 @@ void arq_fsm_dispatch(arq_session_t *sess, const arq_event_t *ev)
           arq_conn_state_name(sess->conn_state),
           arq_dflow_state_name(sess->dflow_state),
           arq_event_name(ev->id));
+
+    /* Once a session is established, every session-bound frame must carry
+     * exactly its ID.  In particular, zero is not a wildcard: transmitters
+     * never create a zero session ID, and accepting one would let a malformed
+     * or stale frame affect the active link.  Validate before updating
+     * last_rx_ms so foreign traffic cannot keep the session alive. */
+    if ((sess->conn_state == ARQ_CONN_CONNECTED ||
+         sess->conn_state == ARQ_CONN_DISCONNECTING) &&
+        is_session_bound_rx_event(ev->id) &&
+        ev->session_id != sess->session_id)
+    {
+        HLOGD(LOG_COMP, "Session ID mismatch: got %d expected %d — dropped",
+              (int)ev->session_id, (int)sess->session_id);
+        return;
+    }
 
     /* Track last RX time from any received frame */
     switch (ev->id)
@@ -2516,21 +2550,11 @@ void arq_fsm_dispatch(arq_session_t *sess, const arq_event_t *ev)
     case ARQ_EV_RX_DISCONNECT:
     case ARQ_EV_RX_TURN_REQ:
     case ARQ_EV_RX_TURN_ACK:
+    case ARQ_EV_RX_MODE_REQ:
+    case ARQ_EV_RX_MODE_ACK:
     case ARQ_EV_RX_KEEPALIVE:
     case ARQ_EV_RX_KEEPALIVE_ACK:
         sess->last_rx_ms = time_now_ms();
-        /* Session ID validation: drop frames from a different session when
-         * we are in CONNECTED or DISCONNECTING state (CALL/ACCEPT frames
-         * are handled separately and carry session_id in their own format). */
-        if ((sess->conn_state == ARQ_CONN_CONNECTED ||
-             sess->conn_state == ARQ_CONN_DISCONNECTING) &&
-            ev->id != ARQ_EV_RX_CALL && ev->id != ARQ_EV_RX_ACCEPT &&
-            ev->session_id != 0 && ev->session_id != sess->session_id)
-        {
-            HLOGD(LOG_COMP, "Session ID mismatch: got %d expected %d — dropped",
-                  (int)ev->session_id, (int)sess->session_id);
-            return;
-        }
         break;
     default:
         break;

--- a/tests/datalink_arq/test_arq_fsm.c
+++ b/tests/datalink_arq/test_arq_fsm.c
@@ -339,6 +339,42 @@ static void goto_connected(void)
     TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
 }
 
+/* Session ID zero is invalid, not a wildcard.  A zero-ID DISCONNECT used to
+ * bypass the mismatch check and tear down an unrelated active session. */
+void test_connected_rejects_zero_session_id(void)
+{
+    goto_connected();
+    uint64_t last_rx = sess.last_rx_ms;
+
+    mock_set_uptime_ms(5000);
+    arq_event_t ev = make_event(ARQ_EV_RX_DISCONNECT);
+    ev.session_id = 0;
+    arq_fsm_dispatch(&sess, &ev);
+
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
+    TEST_ASSERT_EQUAL_UINT64(last_rx, sess.last_rx_ms);
+}
+
+/* Mode negotiation frames are session-bound too.  They were previously
+ * absent from the top-level validation list, allowing another session's
+ * MODE_REQ to change the active receiver mode. */
+void test_connected_rejects_foreign_mode_request(void)
+{
+    goto_connected();
+    uint64_t last_rx = sess.last_rx_ms;
+    int peer_tx_mode = sess.peer_tx_mode;
+
+    mock_set_uptime_ms(5000);
+    arq_event_t ev = make_event(ARQ_EV_RX_MODE_REQ);
+    ev.session_id = (uint8_t)(sess.session_id + 1);
+    ev.mode = FREEDV_MODE_DATAC4;
+    arq_fsm_dispatch(&sess, &ev);
+
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
+    TEST_ASSERT_EQUAL_INT(peer_tx_mode, sess.peer_tx_mode);
+    TEST_ASSERT_EQUAL_UINT64(last_rx, sess.last_rx_ms);
+}
+
 /* ---- Disconnect teardown tests (K7EK field regressions) ---- */
 
 /* Entering CONNECTED seeds the no-progress clock so the wall-clock budget
@@ -502,6 +538,7 @@ void test_wait_ack_cumulative_ack_advances_window(void)
     TEST_ASSERT_EQUAL_INT(1, sess.tx_window_count);
 
     arq_event_t ev = make_event(ARQ_EV_RX_ACK);
+    ev.session_id = sess.session_id;
     ev.ack_seq = (uint8_t)(sess.tx_window[0].seq + 1);
     arq_fsm_dispatch(&sess, &ev);
 
@@ -520,6 +557,7 @@ void test_wait_ack_stale_ack_keeps_window(void)
     TEST_ASSERT_EQUAL_INT(1, sess.tx_window_count);
 
     arq_event_t ev = make_event(ARQ_EV_RX_ACK);
+    ev.session_id = sess.session_id;
     ev.ack_seq = sess.tx_window[0].seq;   /* nothing new received */
     arq_fsm_dispatch(&sess, &ev);
 
@@ -543,6 +581,7 @@ void test_wait_ack_yields_on_turn_req(void)
     TEST_ASSERT_EQUAL_INT(1, sess.tx_window_count);
 
     arq_event_t ev = make_event(ARQ_EV_RX_TURN_REQ);
+    ev.session_id = sess.session_id;
     arq_fsm_dispatch(&sess, &ev);
 
     /* Yielded the floor instead of deadlocking in WAIT_ACK. */
@@ -899,6 +938,8 @@ int main(void)
     RUN_TEST(test_deferred_listen_off_survives_connect);
     RUN_TEST(test_listen_off_drops_live_link_without_draining);
     RUN_TEST(test_rx_disconnect_from_connected);
+    RUN_TEST(test_connected_rejects_zero_session_id);
+    RUN_TEST(test_connected_rejects_foreign_mode_request);
     RUN_TEST(test_connected_seeds_no_progress_clock);
     RUN_TEST(test_app_disconnect_defers_with_backlog);
     RUN_TEST(test_pending_disconnect_retries_last_frame_before_teardown);


### PR DESCRIPTION
Prevents frames from another or invalid ARQ session from affecting an active connection.