### PR TITLE
Support VarAC Beacon

### DIFF
--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -997,8 +997,9 @@ void *server_worker_thread_ctl(void *port)
  * header extension (BCAST_EXT_KISS_STD for 0x00, BCAST_EXT_KISS_DATA for 0x02,
  * neither for 0x01) so the receiving side can mirror it.
  *
- * hermes-broadcast (CMD_DATA with an existing Mercury broadcast header): the
- * frame is passed raw — zero-pad if short, discard if oversized.
+ * hermes-broadcast (CMD_DATA): a full modem frame (frame_len == frame_size)
+ * with a Mercury broadcast header already in place — passed raw.  Oversized
+ * CMD_DATA frames are discarded.
  *
  * Also latches bcast_reply_cmd so send_thread mirrors the client's framing.
  *
@@ -1014,18 +1015,33 @@ static bool bcast_process_decoded_frame(uint8_t *decoded_frame, int frame_len,
         memory_order_relaxed);
 
     /* CMD_DATA is used by two very different clients:
-     *   - hermes-broadcast: full modem frame with a Mercury broadcast header
+     *   - hermes-broadcast: a full modem frame with a Mercury broadcast header
      *     already in place (PACKET_TYPE_BROADCAST_CONTROL/_DATA) → pass raw.
-     *   - VarAC beacons/pings: unformatted KISS payload with no Mercury header
-     *     (its first byte is arbitrary and may even decode as an ARQ type) →
-     *     wrap it like an AX.25 frame so the receiver routes it to broadcast.
-     * Distinguish by the header byte already being a broadcast type. */
+     *   - VarAC beacons/pings: a short unformatted KISS payload with no Mercury
+     *     header, whose first byte is arbitrary (it can even land in the
+     *     broadcast-type range — e.g. a lowercase letter) → wrap it like an
+     *     AX.25 frame so the receiver routes it to broadcast.
+     * Distinguishing by the header bits alone misclassifies ~25% of arbitrary
+     * first bytes, so require the frame to also be exactly frame_size: a real
+     * hermes-broadcast frame always fills the modem frame, while a 20-byte
+     * beacon can never satisfy that. */
     bool is_raw_modem_frame = false;
     if (kiss_cmd == CMD_DATA)
     {
         uint8_t pt = frame_header_packet_type(decoded_frame[0]);
-        is_raw_modem_frame = (pt == PACKET_TYPE_BROADCAST_CONTROL ||
-                              pt == PACKET_TYPE_BROADCAST_DATA);
+        is_raw_modem_frame =
+            (pt == PACKET_TYPE_BROADCAST_CONTROL ||
+             pt == PACKET_TYPE_BROADCAST_DATA) &&
+            (size_t)frame_len == frame_size;
+    }
+
+    /* hermes-broadcast / unformatted CMD_DATA frames never fragment: anything
+     * larger than one modem frame is discarded (0x00/0x01 truncate instead). */
+    if (kiss_cmd == CMD_DATA && (size_t)frame_len > frame_size)
+    {
+        HLOGW("tcp-bcast", "Discarding broadcast frame: size %d exceeds modem frame size %zu",
+              frame_len, frame_size);
+        return false;
     }
 
     bool needs_wrap = (kiss_cmd == CMD_AX25 || kiss_cmd == CMD_AX25CALLSIGN) ||

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -1015,16 +1015,33 @@ static bool bcast_process_decoded_frame(uint8_t *decoded_frame, int frame_len,
         memory_order_relaxed);
 
     /* CMD_DATA is used by two very different clients:
-     *   - hermes-broadcast: a full modem frame with a Mercury broadcast header
+     *   - hermes-broadcast: a modem frame with a Mercury broadcast header
      *     already in place (PACKET_TYPE_BROADCAST_CONTROL/_DATA) → pass raw.
-     *   - VarAC beacons/pings: a short unformatted KISS payload with no Mercury
-     *     header, whose first byte is arbitrary (it can even land in the
-     *     broadcast-type range — e.g. a lowercase letter) → wrap it like an
-     *     AX.25 frame so the receiver routes it to broadcast.
-     * Distinguishing by the header bits alone misclassifies ~25% of arbitrary
-     * first bytes, so require the frame to also be exactly frame_size: a real
-     * hermes-broadcast frame always fills the modem frame, while a 20-byte
-     * beacon can never satisfy that. */
+     *   - VarAC beacons/pings: an unformatted KISS payload with no Mercury
+     *     header, whose first byte is arbitrary → wrap it like an AX.25 frame
+     *     so the receiver routes it to broadcast.
+     *
+     * The type bits alone are not enough: they are the top 3 of the first
+     * byte, so 64 of 256 arbitrary first bytes look like a broadcast type --
+     * 25%, including the whole lowercase alphabet.  A beacon starting with a
+     * lowercase letter would be passed raw and lost.
+     *
+     * Frame LENGTH cannot be the second test either, tempting as it is.
+     * hermes-broadcast does not always fill the modem frame: transmitter.c
+     * sends payload frames as packet_size + RQ_HEADER_SIZE (== frame_size) but
+     * CONFIG frames as packet_size alone, i.e. RQ_HEADER_SIZE short, and
+     * relies on the zero-padding below to bring them up.  Requiring
+     * frame_len == frame_size drops every config packet, and since its
+     * receiver discards anything that is not exactly frame_size, the far end
+     * never gets the RaptorQ configuration and can never start decoding.
+     *
+     * So validate the WHOLE header byte instead.  hermes-broadcast writes both
+     * of its frame kinds with extension 0 (hermes_write_frame_header(...,
+     * PACKET_RQ_CONFIG/PACKET_RQ_PAYLOAD, 0)), while a beacon's extension bits
+     * are as arbitrary as the rest of its first byte.  Type plus a zero
+     * extension takes the false-positive space from 64/256 to 2/256 (0.8%),
+     * and to ZERO across a-z: the only printable ASCII that still collides is
+     * a leading backtick. */
     bool is_raw_modem_frame = false;
     if (kiss_cmd == CMD_DATA)
     {
@@ -1032,7 +1049,7 @@ static bool bcast_process_decoded_frame(uint8_t *decoded_frame, int frame_len,
         is_raw_modem_frame =
             (pt == PACKET_TYPE_BROADCAST_CONTROL ||
              pt == PACKET_TYPE_BROADCAST_DATA) &&
-            (size_t)frame_len == frame_size;
+            frame_header_extension(decoded_frame[0]) == 0;
     }
 
     /* hermes-broadcast / unformatted CMD_DATA frames never fragment: anything

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -967,7 +967,7 @@ void *server_worker_thread_ctl(void *port)
  * The broadcast datalink uses fixed-size modem frames, so a short VARA/AX.25
  * frame is zero-padded up to frame_size for TX. Without recording the original
  * length, the receiver can only hand the client the whole padded frame, and a
- * VARA client (e.g. VarAC) then rejects it because the trailing zeros corrupt
+ * VARA client then rejects it because the trailing zeros corrupt
  * its payload. To fix this we store the real payload length in a 2-byte
  * big-endian prefix right after the Mercury header and flag it with a header
  * extension bit, so the receiver delivers the exact original frame. Receivers
@@ -979,10 +979,10 @@ void *server_worker_thread_ctl(void *port)
                                       standard KISS CMD_DATA/CMD_AX25 (0x00), so
                                       deliver with 0x00 (e.g. Reticulum). Clear =
                                       VARA compressed-callsign framing, deliver
-                                      with CMD_AX25CALLSIGN (VarAC). */
+                                      with CMD_AX25CALLSIGN (VARA). */
 #define BCAST_EXT_KISS_DATA  0x04  /* header extension bit: sender framed with
                                       unformatted KISS CMD_DATA (0x02, e.g. a
-                                      VarAC beacon/ping), so deliver with 0x02.
+                                      VARA beacon/ping), so deliver with 0x02.
                                       Mutually exclusive with _KISS_STD. */
 
 /*
@@ -990,7 +990,7 @@ void *server_worker_thread_ctl(void *port)
  * data_tx_buffer_broadcast.
  *
  * VARA clients (CMD_AX25 / CMD_AX25CALLSIGN, and CMD_DATA frames that do not
- * already carry a Mercury header — e.g. a VarAC beacon): inject the 1-byte
+ * already carry a Mercury header — e.g. a VARA beacon): inject the 1-byte
  * Mercury PACKET_TYPE_BROADCAST_DATA header plus a 2-byte length prefix
  * (flagged with BCAST_EXT_LEN_PREFIX), truncate if the payload would overflow,
  * then zero-pad to frame_size.  The sender's KISS framing is recorded in the
@@ -1017,7 +1017,7 @@ static bool bcast_process_decoded_frame(uint8_t *decoded_frame, int frame_len,
     /* CMD_DATA is used by two very different clients:
      *   - hermes-broadcast: a modem frame with a Mercury broadcast header
      *     already in place (PACKET_TYPE_BROADCAST_CONTROL/_DATA) → pass raw.
-     *   - VarAC beacons/pings: an unformatted KISS payload with no Mercury
+     *   - VARA beacons/pings: an unformatted KISS payload with no Mercury
      *     header, whose first byte is arbitrary → wrap it like an AX.25 frame
      *     so the receiver routes it to broadcast.
      *
@@ -1122,14 +1122,14 @@ static bool bcast_process_decoded_frame(uint8_t *decoded_frame, int frame_len,
  * padding dropped) and reply with the sender's own KISS framing, carried in
  * the BCAST_EXT_KISS_STD / BCAST_EXT_KISS_DATA header bits: standard 0x00
  * (CMD_AX25, e.g. Reticulum) when _KISS_STD set, unformatted 0x02 (CMD_DATA,
- * e.g. a VarAC beacon) when _KISS_DATA set, else CMD_AX25CALLSIGN (VarAC) —
+ * e.g. a VARA beacon) when _KISS_DATA set, else CMD_AX25CALLSIGN (VARA) —
  * which is also what frames from pre-extension senders yield. This is detected
  * from the received frame itself, so it works on a receive-only station
  * regardless of the latched bcast_reply_cmd.
  *
  * Otherwise mirror the latched bcast_reply_cmd:
  *   CMD_DATA (hermes-broadcast): forward the full frame including the header.
- *   else (VarAC/VARA legacy): strip the 1-byte Mercury header only.
+ *   else (VARA legacy): strip the 1-byte Mercury header only.
  *
  * Sets *payload_out and *payload_len_out; returns the reply command byte.
  */
@@ -1141,7 +1141,7 @@ static uint8_t bcast_get_tx_payload(uint8_t *frame_buffer, size_t frame_size,
      * transmitted (bcast_reply_cmd defaults to CMD_DATA and is reset on every
      * client connect, so a receive-only station would otherwise forward the raw
      * padded frame). Deliver exactly the original payload and reply with the
-     * sender's KISS command so a VARA client (VarAC) accepts it. */
+     * sender's KISS command so a VARA client accepts it. */
     if (frame_size >= HEADER_SIZE + BCAST_LEN_SIZE &&
         frame_header_packet_type(frame_buffer[0]) == PACKET_TYPE_BROADCAST_DATA &&
         (frame_header_extension(frame_buffer[0]) & BCAST_EXT_LEN_PREFIX))
@@ -1510,7 +1510,7 @@ void tnc_send_sn(float snr)
 
 void tnc_send_busy(bool busy)
 {
-    /* VARA-compatible channel-occupancy notification: hosts (VarAC, BPQ32,
+    /* VARA-compatible channel-occupancy notification: hosts (BPQ32,
      * Winlink) already understand "BUSY ON" / "BUSY OFF".  Edge-triggered by
      * the caller (the channel-busy detector), so this only fires on a real
      * CLEAR<->BUSY transition — which is why it goes out on the critical path

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -980,18 +980,25 @@ void *server_worker_thread_ctl(void *port)
                                       deliver with 0x00 (e.g. Reticulum). Clear =
                                       VARA compressed-callsign framing, deliver
                                       with CMD_AX25CALLSIGN (VarAC). */
+#define BCAST_EXT_KISS_DATA  0x04  /* header extension bit: sender framed with
+                                      unformatted KISS CMD_DATA (0x02, e.g. a
+                                      VarAC beacon/ping), so deliver with 0x02.
+                                      Mutually exclusive with _KISS_STD. */
 
 /*
  * Normalises a decoded KISS broadcast frame and queues it to
  * data_tx_buffer_broadcast.
  *
- * VARA clients (CMD_AX25 / CMD_AX25CALLSIGN): inject the 1-byte Mercury
- * PACKET_TYPE_BROADCAST_DATA header plus a 2-byte length prefix (flagged with
- * BCAST_EXT_LEN_PREFIX), truncate if the payload would overflow, then zero-pad
- * to frame_size.
+ * VARA clients (CMD_AX25 / CMD_AX25CALLSIGN, and CMD_DATA frames that do not
+ * already carry a Mercury header — e.g. a VarAC beacon): inject the 1-byte
+ * Mercury PACKET_TYPE_BROADCAST_DATA header plus a 2-byte length prefix
+ * (flagged with BCAST_EXT_LEN_PREFIX), truncate if the payload would overflow,
+ * then zero-pad to frame_size.  The sender's KISS framing is recorded in the
+ * header extension (BCAST_EXT_KISS_STD for 0x00, BCAST_EXT_KISS_DATA for 0x02,
+ * neither for 0x01) so the receiving side can mirror it.
  *
- * hermes-broadcast (CMD_DATA): the frame already carries the Mercury header;
- * zero-pad if short, discard if oversized.
+ * hermes-broadcast (CMD_DATA with an existing Mercury broadcast header): the
+ * frame is passed raw — zero-pad if short, discard if oversized.
  *
  * Also latches bcast_reply_cmd so send_thread mirrors the client's framing.
  *
@@ -1006,13 +1013,32 @@ static bool bcast_process_decoded_frame(uint8_t *decoded_frame, int frame_len,
             ? CMD_AX25CALLSIGN : CMD_DATA,
         memory_order_relaxed);
 
-    if (kiss_cmd == CMD_AX25 || kiss_cmd == CMD_AX25CALLSIGN)
+    /* CMD_DATA is used by two very different clients:
+     *   - hermes-broadcast: full modem frame with a Mercury broadcast header
+     *     already in place (PACKET_TYPE_BROADCAST_CONTROL/_DATA) → pass raw.
+     *   - VarAC beacons/pings: unformatted KISS payload with no Mercury header
+     *     (its first byte is arbitrary and may even decode as an ARQ type) →
+     *     wrap it like an AX.25 frame so the receiver routes it to broadcast.
+     * Distinguish by the header byte already being a broadcast type. */
+    bool is_raw_modem_frame = false;
+    if (kiss_cmd == CMD_DATA)
     {
-        /* Inject Mercury header + 2-byte payload-length prefix before the AX.25
-         * payload, so the receiver can recover the exact frame length (the modem
-         * zero-pads to frame_size). The length prefix is flagged in the header,
-         * along with the sender's KISS framing (0x00 standard vs 0x01 VARA
-         * callsign-compressed) so the receiving side can mirror it. */
+        uint8_t pt = frame_header_packet_type(decoded_frame[0]);
+        is_raw_modem_frame = (pt == PACKET_TYPE_BROADCAST_CONTROL ||
+                              pt == PACKET_TYPE_BROADCAST_DATA);
+    }
+
+    bool needs_wrap = (kiss_cmd == CMD_AX25 || kiss_cmd == CMD_AX25CALLSIGN) ||
+                      (kiss_cmd == CMD_DATA && !is_raw_modem_frame);
+
+    if (needs_wrap)
+    {
+        /* Inject Mercury header + 2-byte payload-length prefix before the
+         * payload, so the receiver can recover the exact frame length (the
+         * modem zero-pads to frame_size). The length prefix is flagged in the
+         * header, along with the sender's KISS framing (0x00 standard, 0x01
+         * VARA callsign-compressed, 0x02 unformatted) so the receiving side can
+         * mirror it. */
         size_t max_payload = frame_size - HEADER_SIZE - BCAST_LEN_SIZE;
         if ((size_t)frame_len > max_payload)
         {
@@ -1023,6 +1049,8 @@ static bool bcast_process_decoded_frame(uint8_t *decoded_frame, int frame_len,
         uint8_t ext = BCAST_EXT_LEN_PREFIX;
         if (kiss_cmd == CMD_AX25)
             ext |= BCAST_EXT_KISS_STD;
+        else if (kiss_cmd == CMD_DATA)
+            ext |= BCAST_EXT_KISS_DATA;
         memmove(decoded_frame + HEADER_SIZE + BCAST_LEN_SIZE, decoded_frame, (size_t)frame_len);
         write_frame_header(decoded_frame, PACKET_TYPE_BROADCAST_DATA, ext);
         decoded_frame[HEADER_SIZE]     = (uint8_t)(((unsigned)frame_len >> 8) & 0xFF);
@@ -1057,13 +1085,14 @@ static bool bcast_process_decoded_frame(uint8_t *decoded_frame, int frame_len,
  * client.
  *
  * Length-prefixed frame (BCAST_EXT_LEN_PREFIX set in a BROADCAST_DATA header):
- * return exactly the original AX.25 payload (header + 2-byte length stripped,
+ * return exactly the original payload (header + 2-byte length stripped,
  * padding dropped) and reply with the sender's own KISS framing, carried in
- * the BCAST_EXT_KISS_STD header bit: standard 0x00 (CMD_AX25, e.g. Reticulum)
- * when set, CMD_AX25CALLSIGN (VarAC) when clear — which is also what frames
- * from pre-extension senders yield. This is detected from the received frame
- * itself, so it works on a receive-only station regardless of the latched
- * bcast_reply_cmd.
+ * the BCAST_EXT_KISS_STD / BCAST_EXT_KISS_DATA header bits: standard 0x00
+ * (CMD_AX25, e.g. Reticulum) when _KISS_STD set, unformatted 0x02 (CMD_DATA,
+ * e.g. a VarAC beacon) when _KISS_DATA set, else CMD_AX25CALLSIGN (VarAC) —
+ * which is also what frames from pre-extension senders yield. This is detected
+ * from the received frame itself, so it works on a receive-only station
+ * regardless of the latched bcast_reply_cmd.
  *
  * Otherwise mirror the latched bcast_reply_cmd:
  *   CMD_DATA (hermes-broadcast): forward the full frame including the header.
@@ -1078,8 +1107,8 @@ static uint8_t bcast_get_tx_payload(uint8_t *frame_buffer, size_t frame_size,
      * received frame's own header, independent of what the local client last
      * transmitted (bcast_reply_cmd defaults to CMD_DATA and is reset on every
      * client connect, so a receive-only station would otherwise forward the raw
-     * padded frame). Deliver exactly the original AX.25 payload and reply with
-     * the AX.25/CALLSIGN KISS command so a VARA client (VarAC) accepts it. */
+     * padded frame). Deliver exactly the original payload and reply with the
+     * sender's KISS command so a VARA client (VarAC) accepts it. */
     if (frame_size >= HEADER_SIZE + BCAST_LEN_SIZE &&
         frame_header_packet_type(frame_buffer[0]) == PACKET_TYPE_BROADCAST_DATA &&
         (frame_header_extension(frame_buffer[0]) & BCAST_EXT_LEN_PREFIX))
@@ -1090,8 +1119,12 @@ static uint8_t bcast_get_tx_payload(uint8_t *frame_buffer, size_t frame_size,
         if (len > max_len) len = max_len;
         *payload_out     = frame_buffer + HEADER_SIZE + BCAST_LEN_SIZE;
         *payload_len_out = len;
-        return (frame_header_extension(frame_buffer[0]) & BCAST_EXT_KISS_STD)
-                   ? CMD_AX25 : CMD_AX25CALLSIGN;
+        uint8_t ext = frame_header_extension(frame_buffer[0]);
+        if (ext & BCAST_EXT_KISS_STD)
+            return CMD_AX25;
+        if (ext & BCAST_EXT_KISS_DATA)
+            return CMD_DATA;
+        return CMD_AX25CALLSIGN;
     }
 
     /* Legacy / hermes-broadcast frames: mirror the latched client framing. */

--- a/datalink_broadcast/kiss.h
+++ b/datalink_broadcast/kiss.h
@@ -52,7 +52,7 @@ extern "C" {
 #define CMD_RQ_CONFIG 0x03 // Reserved/legacy KISS command value; current TCP framing does not use it for RaptorQ config
 #define CMD_RQ_PAYLOAD 0x04 // Reserved/legacy KISS command value; current TCP framing does not use it for RaptorQ payload
 
-#define MAX_PAYLOAD 756 // ~ 18 frames at VARA Level 4
+#define MAX_PAYLOAD 1213 // largest broadcast frame we can select (QAM16C2)
 
 void kiss_reset_state(void);
 

--- a/docs/ARDOP-IDEAS.md
+++ b/docs/ARDOP-IDEAS.md
@@ -71,12 +71,12 @@ FSM transmits CALLs unconditionally. So Mercury has ARDOP's *sensor* but not its
   VARA and is friendlier on a shared channel than failing instantly.
 - **Config-gated.** New knob (e.g. `busy_gate_tx`), default *on* when the busy
   detector is enabled; document it beside the existing `busy_*` knobs in
-  `docs/TNC.md`. Interaction is benign: a host (uucp/VarAC) may also gate on the
+  `docs/TNC.md`. Interaction is benign: a host (uucp, or a VARA client) may also gate on the
   `BUSY` report — TNC-level LBT is just a politeness backstop, and double-gating
   does no harm.
 
 **Why it matters now.** Mercury increasingly shares channels with Winlink,
-VarAC and BPQ stations (e.g. the 14.110 neighbourhood). Gating our own CALLs on a
+VARA and BPQ stations (e.g. the 14.110 neighbourhood). Gating our own CALLs on a
 busy channel is basic good-neighbour behaviour and costs us almost nothing to
 add given the detector is already built and tuned.
 

--- a/docs/RETICULUM.md
+++ b/docs/RETICULUM.md
@@ -82,11 +82,11 @@ react to the `PTT ON`/`PTT OFF` control-port lines.
 ### KISS command-byte compatibility (older Mercury builds)
 
 Reticulum frames broadcasts with the standard KISS data command byte
-(`0x00`), while VarAC uses VARA's compressed-callsign framing (`0x01`).
+(`0x00`), while VARA clients use VARA's compressed-callsign framing (`0x01`).
 Current Mercury carries the sender's framing over the air in a broadcast
 header extension bit (`BCAST_EXT_KISS_STD`) and delivers each received
 frame to the local client with the **sender's own command byte** — so
-stock Reticulum works against the broadcast port directly, and VarAC
+stock Reticulum works against the broadcast port directly, and VARA
 behavior is unchanged.  Both stations must run a Mercury build with this
 feature (newer than 1.9.10).
 

--- a/docs/TNC.md
+++ b/docs/TNC.md
@@ -514,13 +514,20 @@ Three client framings are accepted, distinguished by the KISS command byte:
   delivers exactly the original payload with the **sender's** command byte
   — so VarAC↔VarAC traffic stays `0x01` and standard-KISS clients
   (e.g. Reticulum, see [RETICULUM.md](RETICULUM.md)) get `0x00`.
-- `0x02` (`CMD_DATA`, used by hermes-broadcast): the frame is passed raw —
-  the client supplies its own broadcast header, and receivers with a
-  `CMD_DATA` client get the full unmodified frame back.
+- `0x02` (`CMD_DATA`) is used by two different clients and is distinguished
+  by the frame content:
+  - **hermes-broadcast**: the frame already carries a Mercury broadcast
+    header (`PACKET_TYPE_BROADCAST_CONTROL`/`PACKET_TYPE_BROADCAST_DATA`),
+    so it is passed raw and receivers get the full unmodified frame back.
+  - **VarAC beacons/pings** (and any other unformatted `CMD_DATA` payload
+    without a Mercury header): Mercury wraps it exactly like `0x00`/`0x01`
+    and records the framing in a `BCAST_EXT_KISS_DATA` extension bit, so the
+    receiver delivers the original payload back as `0x02`.  Without this the
+    beacon's first byte could decode as an ARQ packet type and be dropped.
 
 Payloads larger than the modem frame (minus 3 bytes of header+length)
-are truncated (`0x00`/`0x01`) or discarded (`0x02`) — the broadcast plane
-does not fragment.
+are truncated (`0x00`/`0x01`/unformatted-`0x02`) or discarded (raw
+hermes-broadcast `0x02`) — the broadcast plane does not fragment.
 
 ---
 

--- a/docs/TNC.md
+++ b/docs/TNC.md
@@ -68,7 +68,7 @@ LISTEN CQ\r
 When enabled, Mercury enters the LISTENING state and will accept incoming
 CALL frames addressed to the local callsign (or any callsign if PUBLIC is ON).
 
-`LISTEN CQ` is treated as `LISTEN ON` (VarAC compatibility).
+`LISTEN CQ` is treated as `LISTEN ON` (VARA compatibility).
 
 ---
 
@@ -125,7 +125,7 @@ COMPRESSION OFF\r
 **Response:** `OK\r` (always).
 
 Mercury does not use compression; this command exists so VARA-compatible
-clients (e.g., Pat, VarAC) can connect without errors.
+clients can connect without errors.
 
 ---
 
@@ -141,8 +141,8 @@ CHAT OFF\r
 **Response:** `OK\r` on success, `WRONG\r` on error.
 
 `CHAT ON` implicitly enables `LISTEN ON`, placing Mercury in the LISTENING
-state.  This matches VARA behavior where chat applications (VarAC, VARA Chat)
-expect the modem to be ready for incoming connections after `CHAT ON`.
+state.  This matches VARA behavior, where chat applications expect the modem
+to be ready for incoming connections after `CHAT ON`.
 
 `CHAT OFF` is acknowledged but has no effect — Mercury does not currently
 differentiate chat and file-transfer timing.
@@ -243,8 +243,8 @@ VERSION\r
 
 **Response:** A VARA-compatible version string on the control port.
 
-This command exists for VARA-compatible clients (e.g., VarAC) that check
-the modem version at startup.
+This command exists for VARA-compatible clients that check the modem version
+at startup.
 
 ---
 
@@ -430,7 +430,7 @@ advertised inside that CQ frame (`500`, `2300`, or `2750`).
 
 Emitted by the optional channel-busy (occupancy) detector when it observes the
 HF channel transition between clear and occupied, using VARA's exact wording so
-existing VARA-compatible hosts (VarAC, BPQ32, Winlink) act on them unchanged.
+existing VARA-compatible hosts (BPQ32, Winlink) act on them unchanged.
 Edge-triggered: `BUSY ON\r` on clear→busy, `BUSY OFF\r` on busy→clear.
 
 The detector is **disabled by default** and is enabled via the `[channel]`
@@ -507,12 +507,12 @@ fixed-size KISS-encoded packets matching the modem's payload size.
 Three client framings are accepted, distinguished by the KISS command byte:
 
 - `0x00` (standard KISS data / VARA "AX.25 standard") and `0x01` (VARA
-  "AX.25 7-char callsign", used by VarAC): Mercury injects its 1-byte
+  "AX.25 7-char callsign", used by VARA): Mercury injects its 1-byte
   broadcast header plus a 2-byte payload-length prefix, zero-pads to the
   modem frame size, and records which of the two framings the sender used
   in a header extension bit (`BCAST_EXT_KISS_STD`).  The receiving side
   delivers exactly the original payload with the **sender's** command byte
-  — so VarAC↔VarAC traffic stays `0x01` and standard-KISS clients
+  — so VARA↔VARA traffic stays `0x01` and standard-KISS clients
   (e.g. Reticulum, see [RETICULUM.md](RETICULUM.md)) get `0x00`.
 - `0x02` (`CMD_DATA`) is used by two different clients and is distinguished
   by the whole first byte:
@@ -521,7 +521,7 @@ Three client framings are accepted, distinguished by the KISS command byte:
     `PACKET_TYPE_BROADCAST_DATA`) **and** a zero extension, which is what
     hermes-broadcast writes for both its config and payload frames.  Passed
     raw; zero-padded if short, discarded if oversized.
-  - **VarAC beacons/pings** (and any other unformatted `CMD_DATA` payload):
+  - **VARA beacons/pings** (and any other unformatted `CMD_DATA` payload):
     Mercury wraps it exactly like `0x00`/`0x01` and records the framing in a
     `BCAST_EXT_KISS_DATA` extension bit, so the receiver delivers the original
     payload back as `0x02`.

--- a/docs/TNC.md
+++ b/docs/TNC.md
@@ -515,15 +515,17 @@ Three client framings are accepted, distinguished by the KISS command byte:
   — so VarAC↔VarAC traffic stays `0x01` and standard-KISS clients
   (e.g. Reticulum, see [RETICULUM.md](RETICULUM.md)) get `0x00`.
 - `0x02` (`CMD_DATA`) is used by two different clients and is distinguished
-  by the frame content:
-  - **hermes-broadcast**: the frame already carries a Mercury broadcast
-    header (`PACKET_TYPE_BROADCAST_CONTROL`/`PACKET_TYPE_BROADCAST_DATA`),
-    so it is passed raw and receivers get the full unmodified frame back.
-  - **VarAC beacons/pings** (and any other unformatted `CMD_DATA` payload
-    without a Mercury header): Mercury wraps it exactly like `0x00`/`0x01`
-    and records the framing in a `BCAST_EXT_KISS_DATA` extension bit, so the
-    receiver delivers the original payload back as `0x02`.  Without this the
-    beacon's first byte could decode as an ARQ packet type and be dropped.
+  by the frame length *and* content:
+  - **hermes-broadcast**: a **full** modem frame (`frame_len == frame_size`)
+    that carries a Mercury broadcast header
+    (`PACKET_TYPE_BROADCAST_CONTROL`/`PACKET_TYPE_BROADCAST_DATA`), so it is
+    passed raw and receivers get the full unmodified frame back.
+  - **VarAC beacons/pings** (and any other short unformatted `CMD_DATA`
+    payload): Mercury wraps it exactly like `0x00`/`0x01` and records the
+    framing in a `BCAST_EXT_KISS_DATA` extension bit, so the receiver
+    delivers the original payload back as `0x02`.  Without the length check
+    a short beacon whose first byte happened to be e.g. a lowercase letter
+    would be mistaken for a hermes-broadcast header and dropped.
 
 Payloads larger than the modem frame (minus 3 bytes of header+length)
 are truncated (`0x00`/`0x01`/unformatted-`0x02`) or discarded (raw

--- a/docs/TNC.md
+++ b/docs/TNC.md
@@ -515,17 +515,27 @@ Three client framings are accepted, distinguished by the KISS command byte:
   — so VarAC↔VarAC traffic stays `0x01` and standard-KISS clients
   (e.g. Reticulum, see [RETICULUM.md](RETICULUM.md)) get `0x00`.
 - `0x02` (`CMD_DATA`) is used by two different clients and is distinguished
-  by the frame length *and* content:
-  - **hermes-broadcast**: a **full** modem frame (`frame_len == frame_size`)
-    that carries a Mercury broadcast header
-    (`PACKET_TYPE_BROADCAST_CONTROL`/`PACKET_TYPE_BROADCAST_DATA`), so it is
-    passed raw and receivers get the full unmodified frame back.
-  - **VarAC beacons/pings** (and any other short unformatted `CMD_DATA`
-    payload): Mercury wraps it exactly like `0x00`/`0x01` and records the
-    framing in a `BCAST_EXT_KISS_DATA` extension bit, so the receiver
-    delivers the original payload back as `0x02`.  Without the length check
-    a short beacon whose first byte happened to be e.g. a lowercase letter
-    would be mistaken for a hermes-broadcast header and dropped.
+  by the whole first byte:
+  - **hermes-broadcast**: the frame carries a Mercury broadcast header — a
+    broadcast packet type (`PACKET_TYPE_BROADCAST_CONTROL`/
+    `PACKET_TYPE_BROADCAST_DATA`) **and** a zero extension, which is what
+    hermes-broadcast writes for both its config and payload frames.  Passed
+    raw; zero-padded if short, discarded if oversized.
+  - **VarAC beacons/pings** (and any other unformatted `CMD_DATA` payload):
+    Mercury wraps it exactly like `0x00`/`0x01` and records the framing in a
+    `BCAST_EXT_KISS_DATA` extension bit, so the receiver delivers the original
+    payload back as `0x02`.
+
+  Testing only the packet-type bits is not sufficient — they are the top 3
+  bits, so 25% of arbitrary first bytes look like a broadcast type, including
+  every lowercase letter, and such a beacon would be passed raw and lost.
+  Requiring a zero extension as well cuts that to 0.8%, and to nothing across
+  `a`–`z`.
+
+  Frame length must **not** be used as the discriminator: hermes-broadcast
+  sends its config frames `RQ_HEADER_SIZE` short of a full modem frame and
+  relies on Mercury's zero-padding, so a `frame_len == frame_size` test drops
+  every config packet and the far side never starts decoding.
 
 Payloads larger than the modem frame (minus 3 bytes of header+length)
 are truncated (`0x00`/`0x01`/unformatted-`0x02`) or discarded (raw

--- a/tests/data_interfaces/test_tcp_interfaces.c
+++ b/tests/data_interfaces/test_tcp_interfaces.c
@@ -771,6 +771,12 @@ void test_cmd_callint_negative(void)
 #define BCAST_HDR_BYTE_LEN   (BCAST_HDR_BYTE | BCAST_EXT_LEN_PREFIX)
 #define BCAST_HDR_BYTE_STD   (BCAST_HDR_BYTE | BCAST_EXT_LEN_PREFIX | BCAST_EXT_KISS_STD)
 #define BCAST_HDR_BYTE_DATA  (BCAST_HDR_BYTE | BCAST_EXT_LEN_PREFIX | BCAST_EXT_KISS_DATA)
+/* A RAW hermes-broadcast header: broadcast packet type with a ZERO extension,
+ * which is what hermes_write_frame_header(..., PACKET_RQ_CONFIG, 0) produces.
+ * Distinct from BCAST_HDR_BYTE_DATA above, which is the header Mercury writes
+ * when it WRAPS a client payload. */
+#define BCAST_HDR_RAW_CONTROL \
+    ((uint8_t)(PACKET_TYPE_BROADCAST_CONTROL << PACKET_TYPE_SHIFT))
 
 /* CMD_DATA, exact frame_size: queued unchanged, bcast_reply_cmd = CMD_DATA */
 void test_bcast_rx_cmd_data_exact_size(void)
@@ -795,30 +801,39 @@ void test_bcast_rx_cmd_data_exact_size(void)
 /* CMD_DATA, short frame with a broadcast-header-looking first byte (0x60): NOT
  * hermes-broadcast, which always fills frame_size, so it must be wrapped like
  * an unformatted VarAC frame rather than passed through raw. */
-void test_bcast_rx_cmd_data_short_wrapped(void)
+/* 0x60 is the one genuinely ambiguous first byte: it is
+ * PACKET_TYPE_BROADCAST_CONTROL with a zero extension, i.e. byte-for-byte what
+ * hermes-broadcast puts on a config frame -- and also a printable backtick that
+ * a beacon could in principle start with.  Nothing in the frame distinguishes
+ * them.
+ *
+ * Resolve it in favour of hermes-broadcast: that is a protocol in daily use
+ * whose config frames arrive short by RQ_HEADER_SIZE, and whose receiver
+ * discards anything that is not exactly frame_size, so guessing "beacon" here
+ * silently kills the broadcast stream.  A beacon whose payload begins with a
+ * literal backtick is hypothetical by comparison, and every other printable
+ * first byte -- including all of a-z -- is wrapped correctly because its
+ * extension bits are non-zero. */
+void test_bcast_rx_cmd_data_ambiguous_0x60_treated_as_hermes(void)
 {
     const size_t fsz = 10;
     broadcast_frame_size_cfg = fsz;
 
     uint8_t frame[MAX_PAYLOAD];
     memset(frame, 0, sizeof(frame));
-    frame[0] = 0x60;                 /* PACKET_TYPE_BROADCAST_CONTROL header byte */
-    memset(frame + 1, 0xBB, 4);      /* 5 bytes total */
+    frame[0] = 0x60;                 /* BROADCAST_CONTROL, extension 0 */
+    memset(frame + 1, 0xBB, 4);      /* 5 bytes total, short */
 
     bool ok = bcast_process_decoded_frame(frame, 5, CMD_DATA, fsz);
 
     TEST_ASSERT_TRUE(ok);
     TEST_ASSERT_EQUAL(1, write_buffer_call_count);
     TEST_ASSERT_EQUAL_size_t(fsz, last_write_buffer_len);
-    /* Wrapped: header + 2-byte length prefix, original payload shifted. */
-    TEST_ASSERT_EQUAL_HEX8(BCAST_HDR_BYTE_DATA, last_write_buffer_data[0]);
-    TEST_ASSERT_EQUAL_HEX8(0x00, last_write_buffer_data[1]);
-    TEST_ASSERT_EQUAL_HEX8(0x05, last_write_buffer_data[2]);
-    TEST_ASSERT_EQUAL_HEX8(0x60, last_write_buffer_data[3]);
+    /* Passed raw and zero-padded -- no wrapper, no length prefix. */
+    TEST_ASSERT_EQUAL_HEX8(0x60, last_write_buffer_data[0]);
     for (int i = 1; i < 5; i++)
-        TEST_ASSERT_EQUAL_HEX8(0xBB, last_write_buffer_data[3 + i]);
-    /* Tail zero-filled */
-    for (size_t i = 8; i < fsz; i++)
+        TEST_ASSERT_EQUAL_HEX8(0xBB, last_write_buffer_data[i]);
+    for (size_t i = 5; i < fsz; i++)
         TEST_ASSERT_EQUAL_HEX8(0x00, last_write_buffer_data[i]);
     TEST_ASSERT_EQUAL_HEX8(CMD_DATA,
         atomic_load_explicit(&bcast_reply_cmd, memory_order_relaxed));
@@ -1130,6 +1145,62 @@ void test_bcast_rx_cmd_data_varac_beacon_wrapped(void)
 /* Round-trip: a CMD_DATA unformatted frame (VarAC beacon) run through TX
  * framing then RX extraction must be delivered as CMD_DATA with the exact
  * original length, even on a receive-only station (reply_cmd at its default). */
+/* hermes-broadcast sends CONFIG frames RQ_HEADER_SIZE short of a full modem
+ * frame (transmitter.c: payload is packet_size + RQ_HEADER_SIZE, config is
+ * packet_size alone) and relies on Mercury zero-padding them back up.  Its
+ * receiver then discards anything that is not exactly frame_size, so if
+ * Mercury wraps a short config frame instead of passing it raw, the far side
+ * never receives the RaptorQ configuration and can never start decoding.
+ *
+ * This is why frame length cannot be the hermes-broadcast discriminator. */
+void test_bcast_short_hermes_config_passed_raw(void)
+{
+    const size_t fsz = 10;
+    broadcast_frame_size_cfg = fsz;
+
+    uint8_t frame[MAX_PAYLOAD];
+    memset(frame, 0, sizeof(frame));
+    frame[0] = BCAST_HDR_RAW_CONTROL;   /* PACKET_RQ_CONFIG, extension 0 */
+    frame[1] = 0xAA;
+    frame[2] = 0xBB;
+
+    bool ok = bcast_process_decoded_frame(frame, 3, CMD_DATA, fsz);  /* 3 < fsz */
+
+    TEST_ASSERT_TRUE(ok);
+    TEST_ASSERT_EQUAL_size_t(fsz, last_write_buffer_len);
+    /* Passed raw and zero-padded: the client's own header stays at byte 0 and
+     * no length prefix is injected. */
+    TEST_ASSERT_EQUAL_HEX8(BCAST_HDR_RAW_CONTROL, last_write_buffer_data[0]);
+    TEST_ASSERT_EQUAL_HEX8(0xAA, last_write_buffer_data[1]);
+    TEST_ASSERT_EQUAL_HEX8(0xBB, last_write_buffer_data[2]);
+    for (size_t i = 3; i < fsz; i++)
+        TEST_ASSERT_EQUAL_HEX8(0x00, last_write_buffer_data[i]);
+}
+
+/* A beacon whose first byte lands in the broadcast-type range but carries a
+ * non-zero extension is still an unformatted payload and must be wrapped.
+ * 'a' (0x61) is type 3 with extension 1 -- the case the type-bits-only test
+ * got wrong, and the one a text beacon is most likely to hit. */
+void test_bcast_beacon_broadcast_type_nonzero_ext_wrapped(void)
+{
+    const size_t fsz = 10;
+    broadcast_frame_size_cfg = fsz;
+
+    uint8_t frame[MAX_PAYLOAD];
+    memset(frame, 0, sizeof(frame));
+    frame[0] = 0x61;   /* 'a' : type 3, extension 1 */
+    frame[1] = 'b';
+    frame[2] = 'c';
+
+    bool ok = bcast_process_decoded_frame(frame, 3, CMD_DATA, fsz);
+
+    TEST_ASSERT_TRUE(ok);
+    TEST_ASSERT_EQUAL_HEX8(BCAST_HDR_BYTE_DATA, last_write_buffer_data[0]);
+    TEST_ASSERT_EQUAL_HEX8(0x00, last_write_buffer_data[1]);
+    TEST_ASSERT_EQUAL_HEX8(0x03, last_write_buffer_data[2]);
+    TEST_ASSERT_EQUAL_HEX8(0x61, last_write_buffer_data[HEADER_SIZE + BCAST_LEN_SIZE]);
+}
+
 void test_bcast_data_lenprefix_roundtrip(void)
 {
     const size_t fsz = 32;
@@ -1252,7 +1323,7 @@ int main(void)
     RUN_TEST(test_tnc_send_registered);
     /* Broadcast framing helper tests */
     RUN_TEST(test_bcast_rx_cmd_data_exact_size);
-    RUN_TEST(test_bcast_rx_cmd_data_short_wrapped);
+    RUN_TEST(test_bcast_rx_cmd_data_ambiguous_0x60_treated_as_hermes);
     RUN_TEST(test_bcast_rx_cmd_data_short_lowercase_wrapped);
     RUN_TEST(test_bcast_rx_cmd_data_oversized_discarded);
     RUN_TEST(test_bcast_rx_vara_header_injected);
@@ -1264,6 +1335,8 @@ int main(void)
     RUN_TEST(test_bcast_tx_lenprefix_ignores_reply_cmd_default);
     RUN_TEST(test_bcast_std_kiss_roundtrip);
     RUN_TEST(test_bcast_rx_cmd_data_varac_beacon_wrapped);
+    RUN_TEST(test_bcast_short_hermes_config_passed_raw);
+    RUN_TEST(test_bcast_beacon_broadcast_type_nonzero_ext_wrapped);
     RUN_TEST(test_bcast_data_lenprefix_roundtrip);
     RUN_TEST(test_sn_query_is_always_answered);
     RUN_TEST(test_bitrate_query_is_always_answered);

--- a/tests/data_interfaces/test_tcp_interfaces.c
+++ b/tests/data_interfaces/test_tcp_interfaces.c
@@ -792,27 +792,69 @@ void test_bcast_rx_cmd_data_exact_size(void)
         atomic_load_explicit(&bcast_reply_cmd, memory_order_relaxed));
 }
 
-/* CMD_DATA, short frame: zero-padded to frame_size */
-void test_bcast_rx_cmd_data_short_padded(void)
+/* CMD_DATA, short frame with a broadcast-header-looking first byte (0x60): NOT
+ * hermes-broadcast, which always fills frame_size, so it must be wrapped like
+ * an unformatted VarAC frame rather than passed through raw. */
+void test_bcast_rx_cmd_data_short_wrapped(void)
 {
     const size_t fsz = 10;
     broadcast_frame_size_cfg = fsz;
 
     uint8_t frame[MAX_PAYLOAD];
     memset(frame, 0, sizeof(frame));
-    frame[0] = 0x60;
-    memset(frame + 1, 0xBB, 4); /* 5 bytes total */
+    frame[0] = 0x60;                 /* PACKET_TYPE_BROADCAST_CONTROL header byte */
+    memset(frame + 1, 0xBB, 4);      /* 5 bytes total */
 
     bool ok = bcast_process_decoded_frame(frame, 5, CMD_DATA, fsz);
 
     TEST_ASSERT_TRUE(ok);
     TEST_ASSERT_EQUAL(1, write_buffer_call_count);
     TEST_ASSERT_EQUAL_size_t(fsz, last_write_buffer_len);
-    /* Tail must be zero-filled */
-    for (size_t i = 5; i < fsz; i++)
+    /* Wrapped: header + 2-byte length prefix, original payload shifted. */
+    TEST_ASSERT_EQUAL_HEX8(BCAST_HDR_BYTE_DATA, last_write_buffer_data[0]);
+    TEST_ASSERT_EQUAL_HEX8(0x00, last_write_buffer_data[1]);
+    TEST_ASSERT_EQUAL_HEX8(0x05, last_write_buffer_data[2]);
+    TEST_ASSERT_EQUAL_HEX8(0x60, last_write_buffer_data[3]);
+    for (int i = 1; i < 5; i++)
+        TEST_ASSERT_EQUAL_HEX8(0xBB, last_write_buffer_data[3 + i]);
+    /* Tail zero-filled */
+    for (size_t i = 8; i < fsz; i++)
         TEST_ASSERT_EQUAL_HEX8(0x00, last_write_buffer_data[i]);
     TEST_ASSERT_EQUAL_HEX8(CMD_DATA,
         atomic_load_explicit(&bcast_reply_cmd, memory_order_relaxed));
+}
+
+/* A short beacon whose body begins with a lowercase letter ('a'=0x61, 'z'=0x7A)
+ * decodes as PACKET_TYPE_BROADCAST_CONTROL (0x60-0x7F first-byte range).  It
+ * must still be wrapped — the length check, not just the header bits, is what
+ * keeps it from being mistaken for a full hermes-broadcast frame. */
+void test_bcast_rx_cmd_data_short_lowercase_wrapped(void)
+{
+    const size_t fsz = 126;
+    broadcast_frame_size_cfg = fsz;
+
+    const uint8_t firsts[] = { 'a', 'z' };  /* 0x61, 0x7A → packet type 3 */
+    for (size_t k = 0; k < sizeof(firsts) / sizeof(firsts[0]); k++)
+    {
+        uint8_t frame[MAX_PAYLOAD];
+        memset(frame, 0, sizeof(frame));
+        frame[0] = firsts[k];
+        memset(frame + 1, 0xCC, 19);        /* 20 bytes total, like a beacon */
+
+        write_buffer_call_count = 0;
+        memset(last_write_buffer_data, 0, sizeof(last_write_buffer_data));
+
+        bool ok = bcast_process_decoded_frame(frame, 20, CMD_DATA, fsz);
+
+        TEST_ASSERT_TRUE(ok);
+        TEST_ASSERT_EQUAL(1, write_buffer_call_count);
+        TEST_ASSERT_EQUAL_size_t(fsz, last_write_buffer_len);
+        TEST_ASSERT_EQUAL_HEX8(BCAST_HDR_BYTE_DATA, last_write_buffer_data[0]);
+        TEST_ASSERT_EQUAL_HEX8(0x00, last_write_buffer_data[1]);
+        TEST_ASSERT_EQUAL_HEX8(0x14, last_write_buffer_data[2]); /* len = 20 */
+        TEST_ASSERT_EQUAL_HEX8(firsts[k], last_write_buffer_data[3]);
+        TEST_ASSERT_EQUAL_HEX8(0xCC, last_write_buffer_data[4]);
+    }
 }
 
 /* CMD_DATA, oversized, with a real Mercury broadcast header (hermes-broadcast):
@@ -1066,7 +1108,7 @@ void test_bcast_rx_cmd_data_varac_beacon_wrapped(void)
 
     uint8_t frame[MAX_PAYLOAD];
     memset(frame, 0, sizeof(frame));
-    /* VarAC beacon body: first byte 0x2E decodes as an ARQ type, i.e. NOT a
+    /* VarAC beacon body: first byte 0x20 decodes as an ARQ type, i.e. NOT a
      * broadcast header, so it must be treated as an unformatted client frame. */
     for (int i = 0; i < 5; i++) frame[i] = (uint8_t)(0x20 + i);
 
@@ -1210,7 +1252,8 @@ int main(void)
     RUN_TEST(test_tnc_send_registered);
     /* Broadcast framing helper tests */
     RUN_TEST(test_bcast_rx_cmd_data_exact_size);
-    RUN_TEST(test_bcast_rx_cmd_data_short_padded);
+    RUN_TEST(test_bcast_rx_cmd_data_short_wrapped);
+    RUN_TEST(test_bcast_rx_cmd_data_short_lowercase_wrapped);
     RUN_TEST(test_bcast_rx_cmd_data_oversized_discarded);
     RUN_TEST(test_bcast_rx_vara_header_injected);
     RUN_TEST(test_bcast_rx_cmd_ax25_reply_cmd);

--- a/tests/data_interfaces/test_tcp_interfaces.c
+++ b/tests/data_interfaces/test_tcp_interfaces.c
@@ -767,8 +767,10 @@ void test_cmd_callint_negative(void)
 #define BCAST_LEN_SIZE       2
 #define BCAST_EXT_LEN_PREFIX 0x01
 #define BCAST_EXT_KISS_STD   0x02
+#define BCAST_EXT_KISS_DATA  0x04
 #define BCAST_HDR_BYTE_LEN   (BCAST_HDR_BYTE | BCAST_EXT_LEN_PREFIX)
 #define BCAST_HDR_BYTE_STD   (BCAST_HDR_BYTE | BCAST_EXT_LEN_PREFIX | BCAST_EXT_KISS_STD)
+#define BCAST_HDR_BYTE_DATA  (BCAST_HDR_BYTE | BCAST_EXT_LEN_PREFIX | BCAST_EXT_KISS_DATA)
 
 /* CMD_DATA, exact frame_size: queued unchanged, bcast_reply_cmd = CMD_DATA */
 void test_bcast_rx_cmd_data_exact_size(void)
@@ -813,7 +815,8 @@ void test_bcast_rx_cmd_data_short_padded(void)
         atomic_load_explicit(&bcast_reply_cmd, memory_order_relaxed));
 }
 
-/* CMD_DATA, oversized: discarded, write_buffer never called */
+/* CMD_DATA, oversized, with a real Mercury broadcast header (hermes-broadcast):
+ * discarded, write_buffer never called */
 void test_bcast_rx_cmd_data_oversized_discarded(void)
 {
     const size_t fsz = 10;
@@ -821,6 +824,7 @@ void test_bcast_rx_cmd_data_oversized_discarded(void)
 
     uint8_t frame[MAX_PAYLOAD];
     memset(frame, 0x11, sizeof(frame));
+    frame[0] = BCAST_HDR_BYTE; /* PACKET_TYPE_BROADCAST_DATA header already in place */
 
     bool ok = bcast_process_decoded_frame(frame, (int)fsz + 5, CMD_DATA, fsz);
 
@@ -1050,6 +1054,71 @@ void test_bcast_std_kiss_roundtrip(void)
     TEST_ASSERT_EQUAL_HEX8_ARRAY(orig, payload, orig_len);
 }
 
+/* CMD_DATA with no Mercury header (VarAC beacon/ping): the frame must be
+ * wrapped with the broadcast header + length prefix, flagged with the
+ * BCAST_EXT_KISS_DATA bit so the far side mirrors the 0x02 framing.  This is
+ * the regression for the bug where a VarAC beacon was queued raw (its first
+ * byte collided with an ARQ packet type) and dropped on the receiver. */
+void test_bcast_rx_cmd_data_varac_beacon_wrapped(void)
+{
+    const size_t fsz = 10;
+    broadcast_frame_size_cfg = fsz;
+
+    uint8_t frame[MAX_PAYLOAD];
+    memset(frame, 0, sizeof(frame));
+    /* VarAC beacon body: first byte 0x2E decodes as an ARQ type, i.e. NOT a
+     * broadcast header, so it must be treated as an unformatted client frame. */
+    for (int i = 0; i < 5; i++) frame[i] = (uint8_t)(0x20 + i);
+
+    bool ok = bcast_process_decoded_frame(frame, 5, CMD_DATA, fsz);
+
+    TEST_ASSERT_TRUE(ok);
+    TEST_ASSERT_EQUAL(1, write_buffer_call_count);
+    TEST_ASSERT_EQUAL_size_t(fsz, last_write_buffer_len);
+    TEST_ASSERT_EQUAL_HEX8(BCAST_HDR_BYTE_DATA, last_write_buffer_data[0]);
+    TEST_ASSERT_EQUAL_HEX8(0x00, last_write_buffer_data[1]);
+    TEST_ASSERT_EQUAL_HEX8(0x05, last_write_buffer_data[2]);
+    for (int i = 0; i < 5; i++)
+        TEST_ASSERT_EQUAL_HEX8((uint8_t)(0x20 + i),
+            last_write_buffer_data[HEADER_SIZE + BCAST_LEN_SIZE + i]);
+    TEST_ASSERT_EQUAL_HEX8(CMD_DATA,
+        atomic_load_explicit(&bcast_reply_cmd, memory_order_relaxed));
+}
+
+/* Round-trip: a CMD_DATA unformatted frame (VarAC beacon) run through TX
+ * framing then RX extraction must be delivered as CMD_DATA with the exact
+ * original length, even on a receive-only station (reply_cmd at its default). */
+void test_bcast_data_lenprefix_roundtrip(void)
+{
+    const size_t fsz = 32;
+    broadcast_frame_size_cfg = fsz;
+
+    const int orig_len = 11;
+    uint8_t orig[32];
+    for (int i = 0; i < orig_len; i++) orig[i] = (uint8_t)(0x20 + i);
+
+    uint8_t txframe[MAX_PAYLOAD];
+    memset(txframe, 0, sizeof(txframe));
+    memcpy(txframe, orig, orig_len);
+    bool ok = bcast_process_decoded_frame(txframe, orig_len, CMD_DATA, fsz);
+    TEST_ASSERT_TRUE(ok);
+    TEST_ASSERT_EQUAL_size_t(fsz, last_write_buffer_len);
+    TEST_ASSERT_EQUAL_HEX8(BCAST_HDR_BYTE_DATA, last_write_buffer_data[0]);
+
+    uint8_t rxframe[MAX_PAYLOAD];
+    memcpy(rxframe, last_write_buffer_data, fsz);
+    atomic_store_explicit(&bcast_reply_cmd, CMD_DATA, memory_order_relaxed);
+
+    uint8_t *payload = NULL;
+    int plen = 0;
+    uint8_t cmd = bcast_get_tx_payload(rxframe, fsz, &payload, &plen);
+
+    TEST_ASSERT_EQUAL_HEX8(CMD_DATA, cmd);               /* 0x02, mirrored */
+    TEST_ASSERT_EQUAL_INT(orig_len, plen);
+    TEST_ASSERT_EQUAL_PTR(rxframe + HEADER_SIZE + BCAST_LEN_SIZE, payload);
+    TEST_ASSERT_EQUAL_HEX8_ARRAY(orig, payload, orig_len);
+}
+
 /* A host that ASKS for telemetry must be answered, every time.
  *
  * This guards a rate-limit that was briefly added to tnc_send_sn()/
@@ -1151,6 +1220,8 @@ int main(void)
     RUN_TEST(test_bcast_vara_length_roundtrip);
     RUN_TEST(test_bcast_tx_lenprefix_ignores_reply_cmd_default);
     RUN_TEST(test_bcast_std_kiss_roundtrip);
+    RUN_TEST(test_bcast_rx_cmd_data_varac_beacon_wrapped);
+    RUN_TEST(test_bcast_data_lenprefix_roundtrip);
     RUN_TEST(test_sn_query_is_always_answered);
     RUN_TEST(test_bitrate_query_is_always_answered);
     return UNITY_END();

--- a/tests/data_interfaces/test_tcp_interfaces.c
+++ b/tests/data_interfaces/test_tcp_interfaces.c
@@ -800,7 +800,7 @@ void test_bcast_rx_cmd_data_exact_size(void)
 
 /* CMD_DATA, short frame with a broadcast-header-looking first byte (0x60): NOT
  * hermes-broadcast, which always fills frame_size, so it must be wrapped like
- * an unformatted VarAC frame rather than passed through raw. */
+ * an unformatted VARA frame rather than passed through raw. */
 /* 0x60 is the one genuinely ambiguous first byte: it is
  * PACKET_TYPE_BROADCAST_CONTROL with a zero extension, i.e. byte-for-byte what
  * hermes-broadcast puts on a config frame -- and also a printable backtick that
@@ -1074,7 +1074,7 @@ void test_bcast_tx_lenprefix_ignores_reply_cmd_default(void)
 /* Standard-KISS roundtrip: a frame the client transmitted with KISS cmd 0x00
  * (CMD_AX25, e.g. Reticulum) must carry the BCAST_EXT_KISS_STD header bit on
  * the air and be delivered on the far side with cmd 0x00 — even on a
- * receive-only station (reply_cmd still at its default). VarAC-framed frames
+ * receive-only station (reply_cmd still at its default). VARA-framed frames
  * (cmd 0x01) must NOT carry the bit and keep being delivered as 0x01, which
  * test_bcast_vara_length_roundtrip guards. */
 void test_bcast_std_kiss_roundtrip(void)
@@ -1111,19 +1111,19 @@ void test_bcast_std_kiss_roundtrip(void)
     TEST_ASSERT_EQUAL_HEX8_ARRAY(orig, payload, orig_len);
 }
 
-/* CMD_DATA with no Mercury header (VarAC beacon/ping): the frame must be
+/* CMD_DATA with no Mercury header (VARA beacon/ping): the frame must be
  * wrapped with the broadcast header + length prefix, flagged with the
  * BCAST_EXT_KISS_DATA bit so the far side mirrors the 0x02 framing.  This is
- * the regression for the bug where a VarAC beacon was queued raw (its first
+ * the regression for the bug where a VARA beacon was queued raw (its first
  * byte collided with an ARQ packet type) and dropped on the receiver. */
-void test_bcast_rx_cmd_data_varac_beacon_wrapped(void)
+void test_bcast_rx_cmd_data_vara_beacon_wrapped(void)
 {
     const size_t fsz = 10;
     broadcast_frame_size_cfg = fsz;
 
     uint8_t frame[MAX_PAYLOAD];
     memset(frame, 0, sizeof(frame));
-    /* VarAC beacon body: first byte 0x20 decodes as an ARQ type, i.e. NOT a
+    /* VARA beacon body: first byte 0x20 decodes as an ARQ type, i.e. NOT a
      * broadcast header, so it must be treated as an unformatted client frame. */
     for (int i = 0; i < 5; i++) frame[i] = (uint8_t)(0x20 + i);
 
@@ -1142,7 +1142,7 @@ void test_bcast_rx_cmd_data_varac_beacon_wrapped(void)
         atomic_load_explicit(&bcast_reply_cmd, memory_order_relaxed));
 }
 
-/* Round-trip: a CMD_DATA unformatted frame (VarAC beacon) run through TX
+/* Round-trip: a CMD_DATA unformatted frame (VARA beacon) run through TX
  * framing then RX extraction must be delivered as CMD_DATA with the exact
  * original length, even on a receive-only station (reply_cmd at its default). */
 /* hermes-broadcast sends CONFIG frames RQ_HEADER_SIZE short of a full modem
@@ -1334,7 +1334,7 @@ int main(void)
     RUN_TEST(test_bcast_vara_length_roundtrip);
     RUN_TEST(test_bcast_tx_lenprefix_ignores_reply_cmd_default);
     RUN_TEST(test_bcast_std_kiss_roundtrip);
-    RUN_TEST(test_bcast_rx_cmd_data_varac_beacon_wrapped);
+    RUN_TEST(test_bcast_rx_cmd_data_vara_beacon_wrapped);
     RUN_TEST(test_bcast_short_hermes_config_passed_raw);
     RUN_TEST(test_bcast_beacon_broadcast_type_nonzero_ext_wrapped);
     RUN_TEST(test_bcast_data_lenprefix_roundtrip);


### PR DESCRIPTION
VarAC sends its beacon on the broadcast port (8100) as a KISS `CMD_DATA` (0x02) "unformatted" frame. Mercury's `bcast_process_decoded_frame()` treated every `CMD_DATA` frame as a hermes-broadcast frame that already carries a Mercury header, so it did not wrap the beacon with the Mercury broadcast header. It just zero-padded 20→126 and put it on air.

**Fix:**

In `data_interfaces/tcp_interfaces.c`, distinguish the two `CMD_DATA` clients by content:
- **hermes-broadcast:** first byte already a broadcast header (`PACKET_TYPE_BROADCAST_CONTROL/_DATA`) → passed raw (unchanged).
- **VarAC beacon/ping:** no broadcast header → wrapped like `0x00`/`0x01` with the Mercury header + 2-byte length prefix, plus a new `BCAST_EXT_KISS_DATA` (0x04) extension bit so the far side mirrors the `0x02` framing and strips the padding.

`bcast_get_tx_payload()` now returns `CMD_DATA` for those length-prefixed frames, delivering the exact 20-byte payload instead of the padded frame.

This is symmetric, so beacons now work both directions, and existing `0x00`/`0x01` broadcast/Reticulum and hermes-broadcast paths are untouched.