### PR TITLE
fix(arq): add bounded random jitter to retry deadlines

### DIFF
--- a/common/cfg_utils.c
+++ b/common/cfg_utils.c
@@ -65,6 +65,7 @@ void cfg_set_defaults(mercury_config *cfg)
     cfg->keepalive_miss_limit        = ARQ_KEEPALIVE_MISS_LIMIT_DEFAULT;
     cfg->peer_payload_hold_s         = ARQ_PEER_PAYLOAD_HOLD_S_DEFAULT;
     cfg->startup_max_s               = ARQ_STARTUP_MAX_S_DEFAULT;
+    cfg->retry_jitter_ms             = ARQ_RETRY_JITTER_MS_DEFAULT;
     cfg->busy_detect                 = false;
     cfg->busy_threshold_db           = 10;
     cfg->busy_hysteresis_db          = 3;
@@ -223,6 +224,9 @@ bool cfg_read(mercury_config *cfg, const char *ini_path)
     i = iniparser_getint(ini, CFG_KEY_ARQ_STARTUP_MAX_S, cfg->startup_max_s);
     if (i >= 2 && i <= 60)   cfg->startup_max_s = i;
 
+    i = iniparser_getint(ini, CFG_KEY_ARQ_RETRY_JITTER_MS, cfg->retry_jitter_ms);
+    if (i >= 0 && i <= ARQ_RETRY_JITTER_MS_MAX) cfg->retry_jitter_ms = i;
+
     cfg->busy_detect = (bool) iniparser_getboolean(ini, CFG_KEY_BUSY_DETECT,
                                                    cfg->busy_detect ? 1 : 0);
 
@@ -342,6 +346,7 @@ bool cfg_write(const mercury_config *cfg, const char *ini_path)
     fprintf(f, "keepalive_miss_limit = %d\n", cfg->keepalive_miss_limit);
     fprintf(f, "peer_payload_hold_s = %d\n", cfg->peer_payload_hold_s);
     fprintf(f, "startup_max_s = %d\n", cfg->startup_max_s);
+    fprintf(f, "retry_jitter_ms = %d\n", cfg->retry_jitter_ms);
 
     fprintf(f, "\n[channel]\n");
     fprintf(f, "busy_detect = %s\n", cfg->busy_detect ? "true" : "false");

--- a/common/cfg_utils.c
+++ b/common/cfg_utils.c
@@ -65,7 +65,7 @@ void cfg_set_defaults(mercury_config *cfg)
     cfg->keepalive_miss_limit        = ARQ_KEEPALIVE_MISS_LIMIT_DEFAULT;
     cfg->peer_payload_hold_s         = ARQ_PEER_PAYLOAD_HOLD_S_DEFAULT;
     cfg->startup_max_s               = ARQ_STARTUP_MAX_S_DEFAULT;
-    cfg->retry_jitter_ms             = ARQ_RETRY_JITTER_MS_DEFAULT;
+    cfg->retry_stagger_ms            = ARQ_RETRY_STAGGER_MS_DEFAULT;
     cfg->busy_detect                 = false;
     cfg->busy_threshold_db           = 10;
     cfg->busy_hysteresis_db          = 3;
@@ -224,8 +224,8 @@ bool cfg_read(mercury_config *cfg, const char *ini_path)
     i = iniparser_getint(ini, CFG_KEY_ARQ_STARTUP_MAX_S, cfg->startup_max_s);
     if (i >= 2 && i <= 60)   cfg->startup_max_s = i;
 
-    i = iniparser_getint(ini, CFG_KEY_ARQ_RETRY_JITTER_MS, cfg->retry_jitter_ms);
-    if (i >= 0 && i <= ARQ_RETRY_JITTER_MS_MAX) cfg->retry_jitter_ms = i;
+    i = iniparser_getint(ini, CFG_KEY_ARQ_RETRY_STAGGER_MS, cfg->retry_stagger_ms);
+    if (i >= 0 && i <= ARQ_RETRY_STAGGER_MS_MAX) cfg->retry_stagger_ms = i;
 
     cfg->busy_detect = (bool) iniparser_getboolean(ini, CFG_KEY_BUSY_DETECT,
                                                    cfg->busy_detect ? 1 : 0);
@@ -346,7 +346,7 @@ bool cfg_write(const mercury_config *cfg, const char *ini_path)
     fprintf(f, "keepalive_miss_limit = %d\n", cfg->keepalive_miss_limit);
     fprintf(f, "peer_payload_hold_s = %d\n", cfg->peer_payload_hold_s);
     fprintf(f, "startup_max_s = %d\n", cfg->startup_max_s);
-    fprintf(f, "retry_jitter_ms = %d\n", cfg->retry_jitter_ms);
+    fprintf(f, "retry_stagger_ms = %d\n", cfg->retry_stagger_ms);
 
     fprintf(f, "\n[channel]\n");
     fprintf(f, "busy_detect = %s\n", cfg->busy_detect ? "true" : "false");

--- a/common/cfg_utils.h
+++ b/common/cfg_utils.h
@@ -57,6 +57,7 @@
 #define CFG_KEY_ARQ_KEEPALIVE_MISS_LIMIT      "arq:keepalive_miss_limit"
 #define CFG_KEY_ARQ_PEER_PAYLOAD_HOLD_S       "arq:peer_payload_hold_s"
 #define CFG_KEY_ARQ_STARTUP_MAX_S             "arq:startup_max_s"
+#define CFG_KEY_ARQ_RETRY_JITTER_MS           "arq:retry_jitter_ms"
 #define CFG_KEY_BUSY_DETECT                   "channel:busy_detect"
 #define CFG_KEY_BUSY_THRESHOLD_DB             "channel:busy_threshold_db"
 #define CFG_KEY_BUSY_HYSTERESIS_DB            "channel:busy_hysteresis_db"
@@ -107,6 +108,9 @@ typedef struct {
                                          * activity. Default 15, clamped 1..120.*/
     int      startup_max_s;             /* ARQ: control-mode-only startup
                                          * window. Default 10, clamped 2..60.   */
+    int      retry_jitter_ms;           /* ARQ: bounded random delay added to
+                                         * retry deadlines. 0 disables. Default
+                                         * 2000, clamped 0..5000.              */
     float    tx_gain_db;            /* Linear-equivalent gain on the modulator
                                     * TX samples, in dB. 0.0 = no change.
                                     * Range -20.0 .. +20.0 (clamped). */

--- a/common/cfg_utils.h
+++ b/common/cfg_utils.h
@@ -57,7 +57,7 @@
 #define CFG_KEY_ARQ_KEEPALIVE_MISS_LIMIT      "arq:keepalive_miss_limit"
 #define CFG_KEY_ARQ_PEER_PAYLOAD_HOLD_S       "arq:peer_payload_hold_s"
 #define CFG_KEY_ARQ_STARTUP_MAX_S             "arq:startup_max_s"
-#define CFG_KEY_ARQ_RETRY_JITTER_MS           "arq:retry_jitter_ms"
+#define CFG_KEY_ARQ_RETRY_STAGGER_MS          "arq:retry_stagger_ms"
 #define CFG_KEY_BUSY_DETECT                   "channel:busy_detect"
 #define CFG_KEY_BUSY_THRESHOLD_DB             "channel:busy_threshold_db"
 #define CFG_KEY_BUSY_HYSTERESIS_DB            "channel:busy_hysteresis_db"
@@ -108,9 +108,9 @@ typedef struct {
                                          * activity. Default 15, clamped 1..120.*/
     int      startup_max_s;             /* ARQ: control-mode-only startup
                                          * window. Default 10, clamped 2..60.   */
-    int      retry_jitter_ms;           /* ARQ: bounded random delay added to
-                                         * retry deadlines. 0 disables. Default
-                                         * 2000, clamped 0..5000.              */
+    int      retry_stagger_ms;          /* ARQ: deterministic per-node retry
+                                         * offset. 0 disables. Default 2000,
+                                         * clamped 0..5000.                  */
     float    tx_gain_db;            /* Linear-equivalent gain on the modulator
                                     * TX samples, in dB. 0.0 = no change.
                                     * Range -20.0 .. +20.0 (clamped). */

--- a/common/mercury_engine.c
+++ b/common/mercury_engine.c
@@ -145,7 +145,7 @@ int mercury_engine_init(const mercury_config *cfg,
     arq_set_keepalive_miss_limit(cfg->keepalive_miss_limit);
     arq_set_peer_payload_hold_s(cfg->peer_payload_hold_s);
     arq_set_startup_max_s(cfg->startup_max_s);
-    arq_set_retry_jitter_ms(cfg->retry_jitter_ms);
+    arq_set_retry_stagger_ms(cfg->retry_stagger_ms);
     modem_set_tx_gain(powf(10.0f, cfg->tx_gain_db / 20.0f));
     modem_set_tx_delay_ms(cfg->tx_delay_ms);
     modem_set_busy_cfg((float)cfg->busy_threshold_db,

--- a/common/mercury_engine.c
+++ b/common/mercury_engine.c
@@ -145,6 +145,7 @@ int mercury_engine_init(const mercury_config *cfg,
     arq_set_keepalive_miss_limit(cfg->keepalive_miss_limit);
     arq_set_peer_payload_hold_s(cfg->peer_payload_hold_s);
     arq_set_startup_max_s(cfg->startup_max_s);
+    arq_set_retry_jitter_ms(cfg->retry_jitter_ms);
     modem_set_tx_gain(powf(10.0f, cfg->tx_gain_db / 20.0f));
     modem_set_tx_delay_ms(cfg->tx_delay_ms);
     modem_set_busy_cfg((float)cfg->busy_threshold_db,

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -1253,6 +1253,15 @@ void arq_set_startup_max_s(int s)
     HLOGI(LOG_COMP, "startup_max_s = %d", atomic_load(&arq_startup_max_s));
 }
 
+void arq_set_retry_jitter_ms(int ms)
+{
+    /* 0 is a valid (and useful) value: it disables retry jitter entirely. */
+    if (ms < 0) ms = 0;
+    if (ms > ARQ_RETRY_JITTER_MS_MAX) ms = ARQ_RETRY_JITTER_MS_MAX;
+    atomic_store(&arq_retry_jitter_ms, ms);
+    HLOGI(LOG_COMP, "retry_jitter_ms = %d", atomic_load(&arq_retry_jitter_ms));
+}
+
 void reset_arq_info(arq_info *conn)
 {
     if (!conn) return;

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -1253,13 +1253,13 @@ void arq_set_startup_max_s(int s)
     HLOGI(LOG_COMP, "startup_max_s = %d", atomic_load(&arq_startup_max_s));
 }
 
-void arq_set_retry_jitter_ms(int ms)
+void arq_set_retry_stagger_ms(int ms)
 {
-    /* 0 is a valid (and useful) value: it disables retry jitter entirely. */
+    /* 0 is a valid (and useful) value: it disables the retry stagger entirely. */
     if (ms < 0) ms = 0;
-    if (ms > ARQ_RETRY_JITTER_MS_MAX) ms = ARQ_RETRY_JITTER_MS_MAX;
-    atomic_store(&arq_retry_jitter_ms, ms);
-    HLOGI(LOG_COMP, "retry_jitter_ms = %d", atomic_load(&arq_retry_jitter_ms));
+    if (ms > ARQ_RETRY_STAGGER_MS_MAX) ms = ARQ_RETRY_STAGGER_MS_MAX;
+    atomic_store(&arq_retry_stagger_ms, ms);
+    HLOGI(LOG_COMP, "retry_stagger_ms = %d", atomic_load(&arq_retry_stagger_ms));
 }
 
 void reset_arq_info(arq_info *conn)

--- a/datalink_arq/arq.h
+++ b/datalink_arq/arq.h
@@ -349,6 +349,7 @@ void arq_set_retry_downgrade_threshold(int n);
 void arq_set_mode_hold_after_downgrade_s(int s);
 void arq_set_peer_payload_hold_s(int s);
 void arq_set_startup_max_s(int s);
+void arq_set_retry_jitter_ms(int ms);
 
 /**
  * @brief Trigger outgoing call attempt using current ARQ addresses.

--- a/datalink_arq/arq.h
+++ b/datalink_arq/arq.h
@@ -349,7 +349,7 @@ void arq_set_retry_downgrade_threshold(int n);
 void arq_set_mode_hold_after_downgrade_s(int s);
 void arq_set_peer_payload_hold_s(int s);
 void arq_set_startup_max_s(int s);
-void arq_set_retry_jitter_ms(int ms);
+void arq_set_retry_stagger_ms(int ms);
 
 /**
  * @brief Trigger outgoing call attempt using current ARQ addresses.

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -233,6 +233,14 @@ static uint64_t deadline_from_s(float seconds)
     return time_now_ms() + (uint64_t)(seconds * 1000.0f + 0.5f);
 }
 
+static uint64_t retry_deadline_from_s(const arq_session_t *sess, float seconds)
+{
+    char my_call[CALLSIGN_MAX_SIZE];
+    arq_conn_get_calls(my_call, NULL, NULL, sizeof(my_call));
+    uint32_t salt = arq_protocol_node_salt(sess->session_id, my_call);
+    return arq_protocol_retry_deadline_ms(seconds, salt);
+}
+
 /** Update local_snr_x10 EMA from the SNR carried in a received frame event.
  *  Called in all RX_DATA handlers to avoid cross-thread race with the modem
  *  thread's arq_update_link_metrics() call. */
@@ -1204,7 +1212,7 @@ static void fsm_calling(arq_session_t *sess, const arq_event_t *ev)
          * moment the ACCEPT is arriving -- so the retry keys the transmitter on
          * top of the reply it was waiting for, on essentially every connect.
          * Measuring the interval from here gives the peer a full turnaround. */
-        sess->deadline_ms = deadline_from_s(arq_protocol_call_interval_s());
+        sess->deadline_ms = retry_deadline_from_s(sess, arq_protocol_call_interval_s());
         break;
 
     case ARQ_EV_TIMER_RETRY:
@@ -1214,7 +1222,7 @@ static void fsm_calling(arq_session_t *sess, const arq_event_t *ev)
             send_call_accept(sess, false);
             /* Deadline is re-anchored on TX_COMPLETE above; this is the
              * fallback if that event is ever missed. */
-            sess->deadline_ms = deadline_from_s(arq_protocol_call_interval_s());
+            sess->deadline_ms = retry_deadline_from_s(sess, arq_protocol_call_interval_s());
         }
         else
         {
@@ -1327,7 +1335,7 @@ static void fsm_accepting(arq_session_t *sess, const arq_event_t *ev)
             send_call_accept(sess, true);
             /* deadline is now managed via TX_COMPLETE above; set a generous
              * fallback here in case TX_COMPLETE is missed for any reason */
-            sess->deadline_ms = deadline_from_s(arq_protocol_call_interval_s());
+            sess->deadline_ms = retry_deadline_from_s(sess, arq_protocol_call_interval_s());
         }
         else
         {
@@ -1388,7 +1396,7 @@ static void fsm_disconnecting(arq_session_t *sess, const arq_event_t *ev)
         /* Initial DISCONNECT send after channel guard. */
         send_ctrl_frame(sess, ARQ_SUBTYPE_DISCONNECT);
         tm = arq_protocol_mode_timing(sess->control_mode);
-        sess->deadline_ms    = deadline_from_s(tm ? tm->retry_interval_s : 7.0f);
+        sess->deadline_ms    = retry_deadline_from_s(sess, tm ? tm->retry_interval_s : 7.0f);
         sess->deadline_event = ARQ_EV_TIMER_RETRY;
         HLOGD(LOG_COMP, "Disconnect tx (initial, after guard)");
         break;
@@ -1406,7 +1414,7 @@ static void fsm_disconnecting(arq_session_t *sess, const arq_event_t *ev)
             sess->tx_retries_left--;
             send_ctrl_frame(sess, ARQ_SUBTYPE_DISCONNECT);
             tm = arq_protocol_mode_timing(sess->control_mode);
-            sess->deadline_ms = deadline_from_s(tm ? tm->retry_interval_s : 7.0f);
+            sess->deadline_ms = retry_deadline_from_s(sess, tm ? tm->retry_interval_s : 7.0f);
             HLOGD(LOG_COMP, "Disconnect tx retry=%d", sess->tx_retries_left);
         }
         else
@@ -1531,7 +1539,7 @@ static void fsm_connected(arq_session_t *sess, const arq_event_t *ev)
         send_ctrl_frame(sess, ARQ_SUBTYPE_KEEPALIVE);
         tm = arq_protocol_mode_timing(sess->control_mode);
         dflow_enter(sess, ARQ_DFLOW_KEEPALIVE_TX,
-                    deadline_from_s(tm ? tm->retry_interval_s : 7.0f),
+                    retry_deadline_from_s(sess, tm ? tm->retry_interval_s : 7.0f),
                     ARQ_EV_TIMER_RETRY);
         return;
 
@@ -1885,7 +1893,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                     sess->tx_retries_left = ARQ_DISCONNECT_RETRY_SLOTS;
                     tm = arq_protocol_mode_timing(sess->control_mode);
                     sess_enter(sess, ARQ_CONN_DISCONNECTING,
-                               deadline_from_s(tm ? tm->retry_interval_s : 7.0f),
+                               retry_deadline_from_s(sess, tm ? tm->retry_interval_s : 7.0f),
                                ARQ_EV_TIMER_RETRY);
                 }
                 else
@@ -2066,7 +2074,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                 send_ctrl_frame(sess, ARQ_SUBTYPE_KEEPALIVE);
                 tm = arq_protocol_mode_timing(sess->control_mode);
                 dflow_enter(sess, ARQ_DFLOW_KEEPALIVE_TX,
-                            deadline_from_s(tm ? tm->retry_interval_s : 7.0f),
+                            retry_deadline_from_s(sess, tm ? tm->retry_interval_s : 7.0f),
                             ARQ_EV_TIMER_RETRY);
             }
             else if (session_tx_backlog(sess) > 0)
@@ -2075,7 +2083,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                 sess->tx_retries_left = ARQ_TURN_REQ_RETRIES;
                 tm = arq_protocol_mode_timing(sess->control_mode);
                 dflow_enter(sess, ARQ_DFLOW_TURN_REQ_TX,
-                            deadline_from_s(tm ? tm->retry_interval_s : 7.0f),
+                            retry_deadline_from_s(sess, tm ? tm->retry_interval_s : 7.0f),
                             ARQ_EV_TIMER_RETRY);
             }
             else
@@ -2089,7 +2097,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
             sess->tx_retries_left = ARQ_TURN_REQ_RETRIES;
             tm = arq_protocol_mode_timing(sess->control_mode);
             dflow_enter(sess, ARQ_DFLOW_TURN_REQ_TX,
-                        deadline_from_s(tm ? tm->retry_interval_s : 7.0f),
+                        retry_deadline_from_s(sess, tm ? tm->retry_interval_s : 7.0f),
                         ARQ_EV_TIMER_RETRY);
         }
         else if (ev->id == ARQ_EV_RX_TURN_REQ)
@@ -2212,7 +2220,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
         {
             tm = arq_protocol_mode_timing(sess->control_mode);
             dflow_enter(sess, ARQ_DFLOW_TURN_REQ_WAIT,
-                        deadline_from_s(tm ? tm->retry_interval_s : 7.0f),
+                        retry_deadline_from_s(sess, tm ? tm->retry_interval_s : 7.0f),
                         ARQ_EV_TIMER_RETRY);
         }
         break;
@@ -2259,7 +2267,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                 send_ctrl_frame(sess, ARQ_SUBTYPE_TURN_REQ);
                 tm = arq_protocol_mode_timing(sess->control_mode);
                 dflow_enter(sess, ARQ_DFLOW_TURN_REQ_TX,
-                            deadline_from_s(tm ? tm->retry_interval_s : 7.0f),
+                            retry_deadline_from_s(sess, tm ? tm->retry_interval_s : 7.0f),
                             ARQ_EV_TIMER_RETRY);
             }
             else
@@ -2281,7 +2289,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
         {
             tm = arq_protocol_mode_timing(sess->control_mode);
             dflow_enter(sess, ARQ_DFLOW_KEEPALIVE_WAIT,
-                        deadline_from_s(tm ? tm->retry_interval_s : 7.0f),
+                        retry_deadline_from_s(sess, tm ? tm->retry_interval_s : 7.0f),
                         ARQ_EV_TIMER_RETRY);
         }
         break;
@@ -2316,7 +2324,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                 sess->tx_retries_left = ARQ_DISCONNECT_RETRY_SLOTS;
                 tm = arq_protocol_mode_timing(sess->control_mode);
                 sess_enter(sess, ARQ_CONN_DISCONNECTING,
-                           deadline_from_s(tm ? tm->retry_interval_s : 7.0f),
+                           retry_deadline_from_s(sess, tm ? tm->retry_interval_s : 7.0f),
                            ARQ_EV_TIMER_RETRY);
             }
             else
@@ -2324,7 +2332,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                 send_ctrl_frame(sess, ARQ_SUBTYPE_KEEPALIVE);
                 tm = arq_protocol_mode_timing(sess->control_mode);
                 dflow_enter(sess, ARQ_DFLOW_KEEPALIVE_TX,
-                            deadline_from_s(tm ? tm->retry_interval_s : 7.0f),
+                            retry_deadline_from_s(sess, tm ? tm->retry_interval_s : 7.0f),
                             ARQ_EV_TIMER_RETRY);
             }
         }
@@ -2374,7 +2382,7 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
             else
             {
                 dflow_enter(sess, ARQ_DFLOW_MODE_REQ_WAIT,
-                            deadline_from_s(tm ? tm->retry_interval_s : 7.0f),
+                            retry_deadline_from_s(sess, tm ? tm->retry_interval_s : 7.0f),
                             ARQ_EV_TIMER_RETRY);
             }
         }

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -1670,8 +1670,13 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
             if (g_timing)
                 arq_timing_record_tx_end(g_timing, (int)sess->tx_seq);
             tm = arq_protocol_mode_timing(sess->payload_mode);
+            /* ack_timeout_s is a lower bound (must cover the peer's ACK), so a
+             * bounded positive jitter only ever waits longer and never violates
+             * the margin.  Jitter here is load-bearing: when two connected
+             * stations submit data simultaneously, both send and both land in
+             * WAIT_ACK, and only a jittered retransmit can break the lock. */
             dflow_enter(sess, ARQ_DFLOW_WAIT_ACK,
-                        deadline_from_s(tm ? tm->ack_timeout_s : 9.0f),
+                        retry_deadline_from_s(sess, tm ? tm->ack_timeout_s : 9.0f),
                         ARQ_EV_TIMER_ACK);
         }
         else if (ev->id == ARQ_EV_RX_TURN_REQ)

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -237,8 +237,9 @@ static uint64_t retry_deadline_from_s(const arq_session_t *sess, float seconds)
 {
     char my_call[CALLSIGN_MAX_SIZE];
     arq_conn_get_calls(my_call, NULL, NULL, sizeof(my_call));
-    uint32_t salt = arq_protocol_node_salt(sess->session_id, my_call);
-    return arq_protocol_retry_deadline_ms(seconds, salt);
+    const char *local = sess->local_call[0] ? sess->local_call : my_call;
+    int rank = arq_protocol_retry_rank(local, sess->remote_call);
+    return arq_protocol_retry_deadline_ms(seconds, rank);
 }
 
 /** Update local_snr_x10 EMA from the SNR carried in a received frame event.

--- a/datalink_arq/arq_protocol.c
+++ b/datalink_arq/arq_protocol.c
@@ -20,7 +20,7 @@ _Atomic int arq_call_retry_slots       = ARQ_CALL_RETRY_SLOTS_DEFAULT;
 _Atomic int arq_accept_retry_slots     = ARQ_ACCEPT_RETRY_SLOTS_DEFAULT;
 _Atomic int arq_data_retry_slots       = ARQ_DATA_RETRY_SLOTS_DEFAULT;
 _Atomic int arq_disconnect_retry_slots = ARQ_DISCONNECT_RETRY_SLOTS_DEFAULT;
-_Atomic int arq_retry_jitter_ms        = ARQ_RETRY_JITTER_MS_DEFAULT;
+_Atomic int arq_retry_stagger_ms       = ARQ_RETRY_STAGGER_MS_DEFAULT;
 _Atomic int arq_no_progress_timeout_s  = ARQ_NO_PROGRESS_TIMEOUT_S_DEFAULT;
 _Atomic int arq_disconnect_drain_timeout_s = ARQ_DISCONNECT_DRAIN_TIMEOUT_S_DEFAULT;
 
@@ -144,41 +144,36 @@ float arq_protocol_call_interval_s(void)
     return tm ? tm->retry_interval_s : 8.0f;
 }
 
-uint32_t arq_protocol_node_salt(uint8_t session_id, const char *local_callsign)
+int arq_protocol_retry_rank(const char *local_call, const char *remote_call)
 {
-    uint64_t x = 0x9E3779B97F4A7C15ULL;
-    for (const unsigned char *p = (const unsigned char *)local_callsign;
-         p && *p; p++)
-    {
-        x ^= *p;
-        x *= 0x100000001B3ULL; /* FNV-1a 64-bit prime */
-    }
-    x ^= (uint64_t)session_id;
-    /* Final avalanche so distinct callsign/session pairs land far apart. */
-    x ^= x >> 33;
-    x *= 0xFF51AFD7ED558CCDULL;
-    x ^= x >> 33;
-    x *= 0xC4CEB9FE1A85EC53ULL;
-    x ^= x >> 33;
-    return (uint32_t)x;
+    if (!local_call || !remote_call || !local_call[0] || !remote_call[0])
+        return -1;  /* missing identity — cannot decide, random fallback */
+    int c = strcmp(local_call, remote_call);
+    if (c == 0)
+        return -1;  /* identical callsigns — misconfigured pair, random fallback */
+    return (c > 0) ? 1 : 0;
 }
 
-uint64_t arq_protocol_retry_deadline_ms(float seconds, uint32_t salt)
+uint64_t arq_protocol_retry_deadline_ms(float seconds, int rank)
 {
     uint64_t now_ms = time_now_ms();
     uint64_t base_ms = (uint64_t)(seconds * 1000.0f + 0.5f);
-    int jitter_ms = atomic_load(&arq_retry_jitter_ms);
-    if (jitter_ms <= 0)
+    int stagger_ms = atomic_load(&arq_retry_stagger_ms);
+    if (stagger_ms <= 0 || rank == 0)
         return now_ms + base_ms;
 
-    uint64_t x = ((uint64_t)salt << 32) ^ now_ms ^ 0x9E3779B97F4A7C15ULL;
+    if (rank == 1)
+        return now_ms + base_ms + (uint64_t)stagger_ms;
+
+    /* rank < 0: degenerate pair — random fallback over [0, stagger_ms). */
+    uint64_t x = now_ms ^ 0x9E3779B97F4A7C15ULL;
     x ^= x >> 30;
     x *= 0xBF58476D1CE4E5B9ULL;
     x ^= x >> 27;
     x *= 0x94D049BB133111EBULL;
     x ^= x >> 31;
 
-    return now_ms + base_ms + (x % (uint64_t)jitter_ms);
+    return now_ms + base_ms + (x % (uint64_t)stagger_ms);
 }
 
 /* ======================================================================

--- a/datalink_arq/arq_protocol.c
+++ b/datalink_arq/arq_protocol.c
@@ -13,11 +13,14 @@
 #include <stdatomic.h>
 #include <math.h>
 
+#include "../common/virtual_clock.h"
+
 /* Runtime-configurable retry counts, initialised from compile-time defaults */
 _Atomic int arq_call_retry_slots       = ARQ_CALL_RETRY_SLOTS_DEFAULT;
 _Atomic int arq_accept_retry_slots     = ARQ_ACCEPT_RETRY_SLOTS_DEFAULT;
 _Atomic int arq_data_retry_slots       = ARQ_DATA_RETRY_SLOTS_DEFAULT;
 _Atomic int arq_disconnect_retry_slots = ARQ_DISCONNECT_RETRY_SLOTS_DEFAULT;
+_Atomic int arq_retry_jitter_ms        = ARQ_RETRY_JITTER_MS_DEFAULT;
 _Atomic int arq_no_progress_timeout_s  = ARQ_NO_PROGRESS_TIMEOUT_S_DEFAULT;
 _Atomic int arq_disconnect_drain_timeout_s = ARQ_DISCONNECT_DRAIN_TIMEOUT_S_DEFAULT;
 
@@ -139,6 +142,43 @@ float arq_protocol_call_interval_s(void)
 
     const arq_mode_timing_t *tm = arq_protocol_mode_timing(ARQ_CONTROL_MODE);
     return tm ? tm->retry_interval_s : 8.0f;
+}
+
+uint32_t arq_protocol_node_salt(uint8_t session_id, const char *local_callsign)
+{
+    uint64_t x = 0x9E3779B97F4A7C15ULL;
+    for (const unsigned char *p = (const unsigned char *)local_callsign;
+         p && *p; p++)
+    {
+        x ^= *p;
+        x *= 0x100000001B3ULL; /* FNV-1a 64-bit prime */
+    }
+    x ^= (uint64_t)session_id;
+    /* Final avalanche so distinct callsign/session pairs land far apart. */
+    x ^= x >> 33;
+    x *= 0xFF51AFD7ED558CCDULL;
+    x ^= x >> 33;
+    x *= 0xC4CEB9FE1A85EC53ULL;
+    x ^= x >> 33;
+    return (uint32_t)x;
+}
+
+uint64_t arq_protocol_retry_deadline_ms(float seconds, uint32_t salt)
+{
+    uint64_t now_ms = time_now_ms();
+    uint64_t base_ms = (uint64_t)(seconds * 1000.0f + 0.5f);
+    int jitter_ms = atomic_load(&arq_retry_jitter_ms);
+    if (jitter_ms <= 0)
+        return now_ms + base_ms;
+
+    uint64_t x = ((uint64_t)salt << 32) ^ now_ms ^ 0x9E3779B97F4A7C15ULL;
+    x ^= x >> 30;
+    x *= 0xBF58476D1CE4E5B9ULL;
+    x ^= x >> 27;
+    x *= 0x94D049BB133111EBULL;
+    x ^= x >> 31;
+
+    return now_ms + base_ms + (x % (uint64_t)jitter_ms);
 }
 
 /* ======================================================================

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -256,6 +256,19 @@ extern _Atomic int arq_disconnect_retry_slots;
 #define ARQ_CALLINT_DEFAULT_S  0.0f   /* 0 = use table default */
 extern _Atomic float arq_callint_override_s;
 
+/* Bounded random delay (ms) added to retry deadlines.  Compile-time default;
+ * tunable only by direct atomic store (no TCP command). */
+#define ARQ_RETRY_JITTER_MS_DEFAULT 2000
+extern _Atomic int arq_retry_jitter_ms;
+
+/* Per-node retry-jitter salt: mixes the shared session_id with the local
+ * callsign so the two peers of a session derive different jitter even when
+ * their clocks read the same instant (session_id alone is identical on both
+ * sides — the callee adopts the caller's byte). */
+uint32_t arq_protocol_node_salt(uint8_t session_id, const char *local_callsign);
+
+uint64_t arq_protocol_retry_deadline_ms(float seconds, uint32_t salt);
+
 #define ARQ_CALL_RETRY_SLOTS       atomic_load(&arq_call_retry_slots)
 #define ARQ_ACCEPT_RETRY_SLOTS     atomic_load(&arq_accept_retry_slots)
 #define ARQ_DATA_RETRY_SLOTS       atomic_load(&arq_data_retry_slots)

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -256,19 +256,22 @@ extern _Atomic int arq_disconnect_retry_slots;
 #define ARQ_CALLINT_DEFAULT_S  0.0f   /* 0 = use table default */
 extern _Atomic float arq_callint_override_s;
 
-/* Bounded random delay (ms) added to retry deadlines.  0 disables jitter
- * (an explicit off-switch); tunable via the arq:retry_jitter_ms INI key. */
-#define ARQ_RETRY_JITTER_MS_DEFAULT 2000
-#define ARQ_RETRY_JITTER_MS_MAX     5000
-extern _Atomic int arq_retry_jitter_ms;
+/* Deterministic retry stagger (ms).  The two peers of a session compare the
+ * same pair of exchanged callsigns, so exactly one of them defers by this
+ * fixed offset on every retry — no random draw, no tail.  0 disables the
+ * stagger (an explicit off-switch); tunable via arq:retry_stagger_ms. */
+#define ARQ_RETRY_STAGGER_MS_DEFAULT 2000
+#define ARQ_RETRY_STAGGER_MS_MAX     5000
+extern _Atomic int arq_retry_stagger_ms;
 
-/* Per-node retry-jitter salt: mixes the shared session_id with the local
- * callsign so the two peers of a session derive different jitter even when
- * their clocks read the same instant (session_id alone is identical on both
- * sides — the callee adopts the caller's byte). */
-uint32_t arq_protocol_node_salt(uint8_t session_id, const char *local_callsign);
+/* Deterministic per-node retry rank from the exchanged callsign pair.
+ * strcmp() is antisymmetric, so the two peers always disagree: one returns 0
+ * (send first) and the other 1 (defer).  Returns -1 when the pair is
+ * degenerate (identical or missing callsigns) — a misconfiguration that falls
+ * back to a random draw. */
+int arq_protocol_retry_rank(const char *local_call, const char *remote_call);
 
-uint64_t arq_protocol_retry_deadline_ms(float seconds, uint32_t salt);
+uint64_t arq_protocol_retry_deadline_ms(float seconds, int rank);
 
 #define ARQ_CALL_RETRY_SLOTS       atomic_load(&arq_call_retry_slots)
 #define ARQ_ACCEPT_RETRY_SLOTS     atomic_load(&arq_accept_retry_slots)

--- a/datalink_arq/arq_protocol.h
+++ b/datalink_arq/arq_protocol.h
@@ -256,9 +256,10 @@ extern _Atomic int arq_disconnect_retry_slots;
 #define ARQ_CALLINT_DEFAULT_S  0.0f   /* 0 = use table default */
 extern _Atomic float arq_callint_override_s;
 
-/* Bounded random delay (ms) added to retry deadlines.  Compile-time default;
- * tunable only by direct atomic store (no TCP command). */
+/* Bounded random delay (ms) added to retry deadlines.  0 disables jitter
+ * (an explicit off-switch); tunable via the arq:retry_jitter_ms INI key. */
 #define ARQ_RETRY_JITTER_MS_DEFAULT 2000
+#define ARQ_RETRY_JITTER_MS_MAX     5000
 extern _Atomic int arq_retry_jitter_ms;
 
 /* Per-node retry-jitter salt: mixes the shared session_id with the local

--- a/docs/ARQ.md
+++ b/docs/ARQ.md
@@ -589,7 +589,7 @@ globals seeded from the `_DEFAULT` value above and set once at startup:
 `channel_guard_ms`, `iss_post_ack_guard_ms`, `data_retry_slots`,
 `mode_hold_after_downgrade_s`, `ladder_up_successes`, `retry_downgrade_threshold`,
 `keepalive_interval_s`, `keepalive_miss_limit`, `peer_payload_hold_s`,
-`startup_max_s`, `retry_jitter_ms` (each clamped to a safe range). See
+`startup_max_s`, `retry_stagger_ms` (each clamped to a safe range). See
 `mercury.ini.example` for keys, defaults, and ranges.
 
 ---

--- a/docs/ARQ.md
+++ b/docs/ARQ.md
@@ -589,8 +589,8 @@ globals seeded from the `_DEFAULT` value above and set once at startup:
 `channel_guard_ms`, `iss_post_ack_guard_ms`, `data_retry_slots`,
 `mode_hold_after_downgrade_s`, `ladder_up_successes`, `retry_downgrade_threshold`,
 `keepalive_interval_s`, `keepalive_miss_limit`, `peer_payload_hold_s`,
-`startup_max_s` (each clamped to a safe range). See `mercury.ini.example`
-for keys, defaults, and ranges.
+`startup_max_s`, `retry_jitter_ms` (each clamped to a safe range). See
+`mercury.ini.example` for keys, defaults, and ranges.
 
 ---
 

--- a/mercury.ini.example
+++ b/mercury.ini.example
@@ -151,6 +151,12 @@ peer_payload_hold_s = 15
 ; handshake (e.g. UUCP) times out before the first data frames get through.
 startup_max_s = 10
 
+; Bounded random delay added to retry deadlines, in ms (default 2000, range 0..5000).
+; Breaks the phase-lock where two stations on a fixed retry schedule transmit
+; simultaneously and neither can hear the other (issue #217).  Set to 0 to
+; disable jitter entirely and revert to the old fixed retry cadence.
+retry_jitter_ms = 2000
+
 [channel]
 ; Channel-busy (occupancy) detector.  Mercury classifies the HF channel as
 ; busy/clear from the RX spectrum and reports transitions to the host with

--- a/mercury.ini.example
+++ b/mercury.ini.example
@@ -151,11 +151,13 @@ peer_payload_hold_s = 15
 ; handshake (e.g. UUCP) times out before the first data frames get through.
 startup_max_s = 10
 
-; Bounded random delay added to retry deadlines, in ms (default 2000, range 0..5000).
-; Breaks the phase-lock where two stations on a fixed retry schedule transmit
-; simultaneously and neither can hear the other (issue #217).  Set to 0 to
-; disable jitter entirely and revert to the old fixed retry cadence.
-retry_jitter_ms = 2000
+; Deterministic per-node retry stagger, in ms (default 2000, range 0..5000).
+; The two peers compare the same pair of exchanged callsigns, so exactly one of
+; them defers by this fixed offset on every retry — breaking the phase-lock
+; where two stations on a fixed schedule transmit simultaneously and neither
+; can hear the other (issue #217), without any random draw or latency tail.
+; Set to 0 to disable and revert to the old fixed retry cadence.
+retry_stagger_ms = 2000
 
 [channel]
 ; Channel-busy (occupancy) detector.  Mercury classifies the HF channel as

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -76,12 +76,12 @@ test_pcm24: audioio/test_pcm24.c $(UNITY_SRC)
 
 # ARQ protocol tests (frame encode/decode, utilities)
 test_arq_protocol: datalink_arq/test_arq_protocol.c $(UNITY_SRC) $(ARQ_STUBS) \
-                   ../datalink_arq/arq_protocol.c ../datalink_arq/arith.c
+                   ../common/virtual_clock.c ../datalink_arq/arq_protocol.c ../datalink_arq/arith.c
 	$(CC) $(CFLAGS) -I../modem/freedv -o $@ $^ $(LDFLAGS)
 
 # OLLA control-loop test (closed-loop gear-shift convergence)
 test_arq_olla: datalink_arq/test_arq_olla.c $(UNITY_SRC) $(ARQ_STUBS) \
-               ../datalink_arq/arq_protocol.c ../datalink_arq/arith.c
+               ../common/virtual_clock.c ../datalink_arq/arq_protocol.c ../datalink_arq/arith.c
 	$(CC) $(CFLAGS) -I../modem/freedv -o $@ $^ $(LDFLAGS) -lm
 
 # ARQ timing tests (instrumentation recording)

--- a/tests/common/test_cfg_utils.c
+++ b/tests/common/test_cfg_utils.c
@@ -45,7 +45,7 @@ void test_defaults_match_constants(void)
     TEST_ASSERT_EQUAL_INT(5,   c.keepalive_miss_limit);
     TEST_ASSERT_EQUAL_INT(15,  c.peer_payload_hold_s);
     TEST_ASSERT_EQUAL_INT(10,  c.startup_max_s);
-    TEST_ASSERT_EQUAL_INT(2000, c.retry_jitter_ms);
+    TEST_ASSERT_EQUAL_INT(2000, c.retry_stagger_ms);
     /* Opt-in: hosts hold transmissions while BUSY is asserted, so this must
      * never switch on under a station that did not ask for it. */
     TEST_ASSERT_FALSE(c.busy_detect);
@@ -70,7 +70,7 @@ void test_arq_tunables_roundtrip(void)
     w.keepalive_miss_limit        = 8;
     w.peer_payload_hold_s         = 25;
     w.startup_max_s               = 20;
-    w.retry_jitter_ms             = 0;      /* off-switch must round-trip */
+    w.retry_stagger_ms             = 0;      /* off-switch must round-trip */
     w.busy_detect                 = true;   /* non-default: proves it round-trips */
     w.busy_threshold_db           = 14;
     w.busy_hysteresis_db          = 5;
@@ -91,7 +91,7 @@ void test_arq_tunables_roundtrip(void)
     TEST_ASSERT_EQUAL_INT(8,    r.keepalive_miss_limit);
     TEST_ASSERT_EQUAL_INT(25,   r.peer_payload_hold_s);
     TEST_ASSERT_EQUAL_INT(20,   r.startup_max_s);
-    TEST_ASSERT_EQUAL_INT(0,    r.retry_jitter_ms);   /* 0 (off) preserved */
+    TEST_ASSERT_EQUAL_INT(0,    r.retry_stagger_ms);   /* 0 (off) preserved */
     TEST_ASSERT_TRUE(r.busy_detect);
     TEST_ASSERT_EQUAL_INT(14,   r.busy_threshold_db);
     TEST_ASSERT_EQUAL_INT(5,    r.busy_hysteresis_db);
@@ -106,7 +106,7 @@ void test_arq_tunables_clamp_rejects_garbage(void)
     TEST_ASSERT_NOT_NULL(f);
     fputs("[arq]\nchannel_guard_ms = 999999\nkeepalive_miss_limit = 0\n"
           "peer_payload_hold_s = 0\nstartup_max_s = 999\n"
-          "retry_jitter_ms = 999999\n", f);
+          "retry_stagger_ms = 999999\n", f);
     fclose(f);
 
     mercury_config r;
@@ -116,7 +116,7 @@ void test_arq_tunables_clamp_rejects_garbage(void)
     TEST_ASSERT_EQUAL_INT(5,   r.keepalive_miss_limit);/* out of 2..20   -> default kept  */
     TEST_ASSERT_EQUAL_INT(15,  r.peer_payload_hold_s); /* out of 1..120  -> default kept  */
     TEST_ASSERT_EQUAL_INT(10,  r.startup_max_s);       /* out of 2..60   -> default kept  */
-    TEST_ASSERT_EQUAL_INT(2000, r.retry_jitter_ms);    /* out of 0..5000 -> default kept  */
+    TEST_ASSERT_EQUAL_INT(2000, r.retry_stagger_ms);    /* out of 0..5000 -> default kept  */
 }
 
 int main(void)

--- a/tests/common/test_cfg_utils.c
+++ b/tests/common/test_cfg_utils.c
@@ -45,6 +45,7 @@ void test_defaults_match_constants(void)
     TEST_ASSERT_EQUAL_INT(5,   c.keepalive_miss_limit);
     TEST_ASSERT_EQUAL_INT(15,  c.peer_payload_hold_s);
     TEST_ASSERT_EQUAL_INT(10,  c.startup_max_s);
+    TEST_ASSERT_EQUAL_INT(2000, c.retry_jitter_ms);
     /* Opt-in: hosts hold transmissions while BUSY is asserted, so this must
      * never switch on under a station that did not ask for it. */
     TEST_ASSERT_FALSE(c.busy_detect);
@@ -69,6 +70,7 @@ void test_arq_tunables_roundtrip(void)
     w.keepalive_miss_limit        = 8;
     w.peer_payload_hold_s         = 25;
     w.startup_max_s               = 20;
+    w.retry_jitter_ms             = 0;      /* off-switch must round-trip */
     w.busy_detect                 = true;   /* non-default: proves it round-trips */
     w.busy_threshold_db           = 14;
     w.busy_hysteresis_db          = 5;
@@ -89,6 +91,7 @@ void test_arq_tunables_roundtrip(void)
     TEST_ASSERT_EQUAL_INT(8,    r.keepalive_miss_limit);
     TEST_ASSERT_EQUAL_INT(25,   r.peer_payload_hold_s);
     TEST_ASSERT_EQUAL_INT(20,   r.startup_max_s);
+    TEST_ASSERT_EQUAL_INT(0,    r.retry_jitter_ms);   /* 0 (off) preserved */
     TEST_ASSERT_TRUE(r.busy_detect);
     TEST_ASSERT_EQUAL_INT(14,   r.busy_threshold_db);
     TEST_ASSERT_EQUAL_INT(5,    r.busy_hysteresis_db);
@@ -102,7 +105,8 @@ void test_arq_tunables_clamp_rejects_garbage(void)
     FILE *f = fopen(TMP, "w");
     TEST_ASSERT_NOT_NULL(f);
     fputs("[arq]\nchannel_guard_ms = 999999\nkeepalive_miss_limit = 0\n"
-          "peer_payload_hold_s = 0\nstartup_max_s = 999\n", f);
+          "peer_payload_hold_s = 0\nstartup_max_s = 999\n"
+          "retry_jitter_ms = 999999\n", f);
     fclose(f);
 
     mercury_config r;
@@ -112,6 +116,7 @@ void test_arq_tunables_clamp_rejects_garbage(void)
     TEST_ASSERT_EQUAL_INT(5,   r.keepalive_miss_limit);/* out of 2..20   -> default kept  */
     TEST_ASSERT_EQUAL_INT(15,  r.peer_payload_hold_s); /* out of 1..120  -> default kept  */
     TEST_ASSERT_EQUAL_INT(10,  r.startup_max_s);       /* out of 2..60   -> default kept  */
+    TEST_ASSERT_EQUAL_INT(2000, r.retry_jitter_ms);    /* out of 0..5000 -> default kept  */
 }
 
 int main(void)

--- a/tests/datalink_arq/test_arq_fsm.c
+++ b/tests/datalink_arq/test_arq_fsm.c
@@ -950,6 +950,23 @@ void test_call_retry_deadline_anchored_to_ptt_off(void)
                     base_deadline_ms + ARQ_RETRY_JITTER_MS_DEFAULT);
 }
 
+/* The DATA retransmit (ack_timeout_s) is the load-bearing timer for the
+ * #217 deadlock: two connected stations that submit data simultaneously both
+ * transmit, both land in WAIT_ACK, and both would retransmit on the same fixed
+ * schedule without jitter.  ack_timeout_s is a lower bound (must cover the
+ * peer's ACK), so a bounded positive jitter only ever delays the retransmit. */
+void test_wait_ack_deadline_includes_bounded_jitter(void)
+{
+    goto_connected();
+    goto_wait_ack();
+    TEST_ASSERT_EQUAL_INT(ARQ_DFLOW_WAIT_ACK, sess.dflow_state);
+
+    const arq_mode_timing_t *tm = arq_protocol_mode_timing(sess.payload_mode);
+    uint64_t base = 1000 + (uint64_t)(tm->ack_timeout_s * 1000.0f + 0.5f);
+    TEST_ASSERT_TRUE(sess.deadline_ms >= base);
+    TEST_ASSERT_TRUE(sess.deadline_ms <= base + ARQ_RETRY_JITTER_MS_DEFAULT);
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -959,6 +976,7 @@ int main(void)
     RUN_TEST(test_listen_transitions_to_listening);
     RUN_TEST(test_connect_transitions_to_calling);
     RUN_TEST(test_call_retry_deadline_anchored_to_ptt_off);
+    RUN_TEST(test_wait_ack_deadline_includes_bounded_jitter);
     RUN_TEST(test_incoming_call_transitions_to_accepting);
     RUN_TEST(test_incoming_call_records_dialed_secondary);
     RUN_TEST(test_accept_transitions_to_connected);

--- a/tests/datalink_arq/test_arq_fsm.c
+++ b/tests/datalink_arq/test_arq_fsm.c
@@ -80,6 +80,7 @@ void setUp(void)
 
     /* Init session and register callbacks */
     mock_set_uptime_ms(1000);
+    arq_conn.my_call_sign[0] = '\0';
     arq_timing_init(&timing);
     arq_fsm_set_timing(&timing);
     arq_fsm_set_callbacks(&test_callbacks);
@@ -922,6 +923,10 @@ void test_listen_off_drops_live_link_without_draining(void)
  * property, and it fails if the handler is absent. */
 void test_call_retry_deadline_anchored_to_ptt_off(void)
 {
+    /* Deterministic stagger ranks us against "TEST1" (we rank first), so the
+     * deadline is exact — no random draw. */
+    snprintf(arq_conn.my_call_sign, CALLSIGN_MAX_SIZE, "%s", "AAA");
+
     arq_event_t ev = make_event(ARQ_EV_APP_LISTEN);
     arq_fsm_dispatch(&sess, &ev);
     ev = make_event(ARQ_EV_APP_CONNECT);
@@ -939,32 +944,29 @@ void test_call_retry_deadline_anchored_to_ptt_off(void)
     TEST_ASSERT_EQUAL_INT(ARQ_CONN_CALLING, sess.conn_state);
     TEST_ASSERT_TRUE_MESSAGE(sess.deadline_ms > at_enqueue,
         "CALL retry deadline must be re-anchored to PTT-OFF");
-    /* And it must be a full interval from PTT-OFF, with bounded jitter added
-     * on top of the retry cadence so the next retry does not phase-lock with
-     * the peer. */
+    /* And it must be a full interval from PTT-OFF, not a partial remainder. */
     uint64_t ptt_off_ms = (uint64_t)(1000 + 3700);
     uint64_t base_deadline_ms = ptt_off_ms +
                                (uint64_t)arq_protocol_call_interval_s() * 1000ULL;
-    TEST_ASSERT_TRUE(sess.deadline_ms >= base_deadline_ms);
-    TEST_ASSERT_TRUE(sess.deadline_ms <=
-                    base_deadline_ms + ARQ_RETRY_JITTER_MS_DEFAULT);
+    TEST_ASSERT_EQUAL_UINT64(base_deadline_ms, sess.deadline_ms);
 }
 
-/* The DATA retransmit (ack_timeout_s) is the load-bearing timer for the
- * #217 deadlock: two connected stations that submit data simultaneously both
- * transmit, both land in WAIT_ACK, and both would retransmit on the same fixed
- * schedule without jitter.  ack_timeout_s is a lower bound (must cover the
- * peer's ACK), so a bounded positive jitter only ever delays the retransmit. */
-void test_wait_ack_deadline_includes_bounded_jitter(void)
+/* The DATA retransmit (ack_timeout_s) is the load-bearing timer for the #217
+ * deadlock: two connected stations that submit data simultaneously both
+ * transmit, both land in WAIT_ACK, and would retransmit on the same fixed
+ * schedule without a stagger.  ack_timeout_s is a lower bound (must cover the
+ * peer's ACK), so a deterministic positive stagger only ever delays it. */
+void test_wait_ack_deadline_stagger_is_exact(void)
 {
+    snprintf(arq_conn.my_call_sign, CALLSIGN_MAX_SIZE, "%s", "AAA");
+
     goto_connected();
     goto_wait_ack();
     TEST_ASSERT_EQUAL_INT(ARQ_DFLOW_WAIT_ACK, sess.dflow_state);
 
     const arq_mode_timing_t *tm = arq_protocol_mode_timing(sess.payload_mode);
     uint64_t base = 1000 + (uint64_t)(tm->ack_timeout_s * 1000.0f + 0.5f);
-    TEST_ASSERT_TRUE(sess.deadline_ms >= base);
-    TEST_ASSERT_TRUE(sess.deadline_ms <= base + ARQ_RETRY_JITTER_MS_DEFAULT);
+    TEST_ASSERT_EQUAL_UINT64(base, sess.deadline_ms);
 }
 
 int main(void)
@@ -976,7 +978,7 @@ int main(void)
     RUN_TEST(test_listen_transitions_to_listening);
     RUN_TEST(test_connect_transitions_to_calling);
     RUN_TEST(test_call_retry_deadline_anchored_to_ptt_off);
-    RUN_TEST(test_wait_ack_deadline_includes_bounded_jitter);
+    RUN_TEST(test_wait_ack_deadline_stagger_is_exact);
     RUN_TEST(test_incoming_call_transitions_to_accepting);
     RUN_TEST(test_incoming_call_records_dialed_secondary);
     RUN_TEST(test_accept_transitions_to_connected);

--- a/tests/datalink_arq/test_arq_fsm.c
+++ b/tests/datalink_arq/test_arq_fsm.c
@@ -939,10 +939,15 @@ void test_call_retry_deadline_anchored_to_ptt_off(void)
     TEST_ASSERT_EQUAL_INT(ARQ_CONN_CALLING, sess.conn_state);
     TEST_ASSERT_TRUE_MESSAGE(sess.deadline_ms > at_enqueue,
         "CALL retry deadline must be re-anchored to PTT-OFF");
-    /* And it must be a full interval from PTT-OFF, not a partial remainder. */
-    TEST_ASSERT_EQUAL_UINT64((uint64_t)(1000 + 3700) +
-                             (uint64_t)arq_protocol_call_interval_s() * 1000ULL,
-                             sess.deadline_ms);
+    /* And it must be a full interval from PTT-OFF, with bounded jitter added
+     * on top of the retry cadence so the next retry does not phase-lock with
+     * the peer. */
+    uint64_t ptt_off_ms = (uint64_t)(1000 + 3700);
+    uint64_t base_deadline_ms = ptt_off_ms +
+                               (uint64_t)arq_protocol_call_interval_s() * 1000ULL;
+    TEST_ASSERT_TRUE(sess.deadline_ms >= base_deadline_ms);
+    TEST_ASSERT_TRUE(sess.deadline_ms <=
+                    base_deadline_ms + ARQ_RETRY_JITTER_MS_DEFAULT);
 }
 
 int main(void)

--- a/tests/datalink_arq/test_arq_protocol.c
+++ b/tests/datalink_arq/test_arq_protocol.c
@@ -18,10 +18,13 @@
 #include "framer.h"
 #include "freedv/freedv_api.h"
 
+extern void mock_set_uptime_ms(uint64_t ms);
+
 void setUp(void)
 {
     /* Reset CALLINT override before each test so tests are isolated */
     atomic_store(&arq_callint_override_s, 0.0f);
+    mock_set_uptime_ms(1000);
 }
 
 void tearDown(void) { }
@@ -96,6 +99,53 @@ void test_decode_snr_zero_is_unknown(void)
 {
     float out = arq_protocol_decode_snr(0);
     TEST_ASSERT_FLOAT_WITHIN(0.01f, 0.0f, out);
+}
+
+void test_retry_deadline_includes_bounded_jitter(void)
+{
+    mock_set_uptime_ms(1000);
+    uint64_t first = arq_protocol_retry_deadline_ms(7.0f, 0x42);
+    mock_set_uptime_ms(1001);
+    uint64_t second = arq_protocol_retry_deadline_ms(7.0f, 0x42);
+
+    TEST_ASSERT_TRUE(first >= 1000 + 7000ULL);
+    TEST_ASSERT_TRUE(second >= 1001 + 7000ULL);
+    TEST_ASSERT_TRUE(first <= 1000 + 7000ULL + ARQ_RETRY_JITTER_MS_DEFAULT);
+    TEST_ASSERT_TRUE(second <= 1001 + 7000ULL + ARQ_RETRY_JITTER_MS_DEFAULT);
+    TEST_ASSERT_NOT_EQUAL_UINT64(first, second);
+}
+
+void test_retry_deadline_jitter_differs_by_node_salt(void)
+{
+    /* Two stations sharing a clock and a session_id must still desynchronise:
+     * the callsign-derived salt is the only input that differs. */
+    uint32_t salt_a = arq_protocol_node_salt(0x42, "NODE_A");
+    uint32_t salt_b = arq_protocol_node_salt(0x42, "NODE_B");
+    TEST_ASSERT_NOT_EQUAL_UINT32(salt_a, salt_b);
+
+    mock_set_uptime_ms(1000);
+    uint64_t a = arq_protocol_retry_deadline_ms(7.0f, salt_a);
+    mock_set_uptime_ms(1000); /* same instant */
+    uint64_t b = arq_protocol_retry_deadline_ms(7.0f, salt_b);
+    TEST_ASSERT_NOT_EQUAL_UINT64(a, b);
+}
+
+void test_retry_deadline_salt_is_deterministic(void)
+{
+    /* Same callsign + session_id must hash to the same salt every time, so a
+     * node's retry cadence is stable across the session. */
+    uint32_t a = arq_protocol_node_salt(0x42, "NODE_A");
+    uint32_t b = arq_protocol_node_salt(0x42, "NODE_A");
+    TEST_ASSERT_EQUAL_UINT32(a, b);
+}
+
+void test_retry_deadline_jitter_disabled_is_exact(void)
+{
+    mock_set_uptime_ms(1000);
+    atomic_store(&arq_retry_jitter_ms, 0);
+    uint64_t d = arq_protocol_retry_deadline_ms(7.0f, 0x42);
+    TEST_ASSERT_EQUAL_UINT64(1000 + 7000ULL, d);
+    atomic_store(&arq_retry_jitter_ms, ARQ_RETRY_JITTER_MS_DEFAULT);
 }
 
 /* ---- Bandwidth token roundtrip ---- */
@@ -422,6 +472,11 @@ int main(void)
     RUN_TEST(test_encode_decode_snr_positive);
     RUN_TEST(test_encode_decode_snr_negative);
     RUN_TEST(test_decode_snr_zero_is_unknown);
+    /* Retry jitter */
+    RUN_TEST(test_retry_deadline_includes_bounded_jitter);
+    RUN_TEST(test_retry_deadline_jitter_differs_by_node_salt);
+    RUN_TEST(test_retry_deadline_salt_is_deterministic);
+    RUN_TEST(test_retry_deadline_jitter_disabled_is_exact);
     /* Bandwidth */
     RUN_TEST(test_bw_token_500hz);
     RUN_TEST(test_bw_token_2300hz);

--- a/tests/datalink_arq/test_arq_protocol.c
+++ b/tests/datalink_arq/test_arq_protocol.c
@@ -101,67 +101,52 @@ void test_decode_snr_zero_is_unknown(void)
     TEST_ASSERT_FLOAT_WITHIN(0.01f, 0.0f, out);
 }
 
-void test_retry_deadline_includes_bounded_jitter(void)
+void test_retry_rank_is_antisymmetric_and_deterministic(void)
 {
-    /* Jitter is uniform in [0, jitter_ms): every deadline must stay within
-     * [base, base + jitter_ms) and, over many instants, must actually vary.
-     * Sampling 100 instants rather than one pair keeps this robust to a change
-     * in the hash constants, the default jitter, or the seed timestamps. */
-    uint64_t first = 0;
-    int differing = 0;
-    for (uint64_t i = 0; i < 100; i++)
-    {
-        mock_set_uptime_ms(1000 + i);
-        uint64_t d = arq_protocol_retry_deadline_ms(7.0f, 0x42);
-        uint64_t base = 1000 + i + 7000ULL;
-        TEST_ASSERT_TRUE(d >= base);
-        TEST_ASSERT_TRUE(d <= base + ARQ_RETRY_JITTER_MS_DEFAULT);
-        if (i == 0)
-            first = d;
-        else if (d != first)
-            differing++;
-    }
-    TEST_ASSERT_TRUE(differing >= 5);
+    /* The two peers compare the SAME pair of callsigns, so exactly one defers
+     * (rank 1) and the other sends first (rank 0). */
+    int a = arq_protocol_retry_rank("NODE_A", "NODE_B");
+    int b = arq_protocol_retry_rank("NODE_B", "NODE_A");
+    TEST_ASSERT_TRUE(a == 0 || a == 1);
+    TEST_ASSERT_TRUE(b == 0 || b == 1);
+    TEST_ASSERT_EQUAL_INT(1, a + b);   /* they always disagree */
+    /* Stable across the session. */
+    TEST_ASSERT_EQUAL_INT(a, arq_protocol_retry_rank("NODE_A", "NODE_B"));
+    TEST_ASSERT_EQUAL_INT(b, arq_protocol_retry_rank("NODE_B", "NODE_A"));
 }
 
-void test_retry_deadline_jitter_differs_by_node_salt(void)
+void test_retry_rank_degenerate_pair_falls_back(void)
 {
-    /* Two stations sharing a clock and a session_id must still desynchronise:
-     * the callsign-derived salt is the only input that differs.  Check over
-     * many shared instants so a single hash collision cannot mask a broken
-     * salt. */
-    uint32_t salt_a = arq_protocol_node_salt(0x42, "NODE_A");
-    uint32_t salt_b = arq_protocol_node_salt(0x42, "NODE_B");
-    TEST_ASSERT_NOT_EQUAL_UINT32(salt_a, salt_b);
-
-    int differing = 0;
-    for (uint64_t i = 0; i < 100; i++)
-    {
-        mock_set_uptime_ms(1000 + i);
-        uint64_t a = arq_protocol_retry_deadline_ms(7.0f, salt_a);
-        uint64_t b = arq_protocol_retry_deadline_ms(7.0f, salt_b);
-        if (a != b)
-            differing++;
-    }
-    TEST_ASSERT_TRUE(differing >= 5);
+    TEST_ASSERT_EQUAL_INT(-1, arq_protocol_retry_rank("NODE_A", "NODE_A"));
+    TEST_ASSERT_EQUAL_INT(-1, arq_protocol_retry_rank("", "NODE_A"));
+    TEST_ASSERT_EQUAL_INT(-1, arq_protocol_retry_rank("NODE_A", ""));
+    TEST_ASSERT_EQUAL_INT(-1, arq_protocol_retry_rank(NULL, "NODE_A"));
+    TEST_ASSERT_EQUAL_INT(-1, arq_protocol_retry_rank("NODE_A", NULL));
 }
 
-void test_retry_deadline_salt_is_deterministic(void)
-{
-    /* Same callsign + session_id must hash to the same salt every time, so a
-     * node's retry cadence is stable across the session. */
-    uint32_t a = arq_protocol_node_salt(0x42, "NODE_A");
-    uint32_t b = arq_protocol_node_salt(0x42, "NODE_A");
-    TEST_ASSERT_EQUAL_UINT32(a, b);
-}
-
-void test_retry_deadline_jitter_disabled_is_exact(void)
+void test_retry_deadline_stagger_is_exact(void)
 {
     mock_set_uptime_ms(1000);
-    atomic_store(&arq_retry_jitter_ms, 0);
-    uint64_t d = arq_protocol_retry_deadline_ms(7.0f, 0x42);
-    TEST_ASSERT_EQUAL_UINT64(1000 + 7000ULL, d);
-    atomic_store(&arq_retry_jitter_ms, ARQ_RETRY_JITTER_MS_DEFAULT);
+    uint64_t base = 1000 + 7000ULL;
+    TEST_ASSERT_EQUAL_UINT64(base, arq_protocol_retry_deadline_ms(7.0f, 0));
+    TEST_ASSERT_EQUAL_UINT64(base + ARQ_RETRY_STAGGER_MS_DEFAULT,
+                             arq_protocol_retry_deadline_ms(7.0f, 1));
+}
+
+void test_retry_deadline_stagger_disabled_is_exact(void)
+{
+    mock_set_uptime_ms(1000);
+    atomic_store(&arq_retry_stagger_ms, 0);
+    TEST_ASSERT_EQUAL_UINT64(1000 + 7000ULL, arq_protocol_retry_deadline_ms(7.0f, 1));
+    atomic_store(&arq_retry_stagger_ms, ARQ_RETRY_STAGGER_MS_DEFAULT);
+}
+
+void test_retry_deadline_fallback_is_bounded(void)
+{
+    mock_set_uptime_ms(1000);
+    uint64_t d = arq_protocol_retry_deadline_ms(7.0f, -1);
+    TEST_ASSERT_TRUE(d >= 1000 + 7000ULL);
+    TEST_ASSERT_TRUE(d <= 1000 + 7000ULL + ARQ_RETRY_STAGGER_MS_DEFAULT);
 }
 
 /* ---- Bandwidth token roundtrip ---- */
@@ -488,11 +473,12 @@ int main(void)
     RUN_TEST(test_encode_decode_snr_positive);
     RUN_TEST(test_encode_decode_snr_negative);
     RUN_TEST(test_decode_snr_zero_is_unknown);
-    /* Retry jitter */
-    RUN_TEST(test_retry_deadline_includes_bounded_jitter);
-    RUN_TEST(test_retry_deadline_jitter_differs_by_node_salt);
-    RUN_TEST(test_retry_deadline_salt_is_deterministic);
-    RUN_TEST(test_retry_deadline_jitter_disabled_is_exact);
+    /* Retry stagger */
+    RUN_TEST(test_retry_rank_is_antisymmetric_and_deterministic);
+    RUN_TEST(test_retry_rank_degenerate_pair_falls_back);
+    RUN_TEST(test_retry_deadline_stagger_is_exact);
+    RUN_TEST(test_retry_deadline_stagger_disabled_is_exact);
+    RUN_TEST(test_retry_deadline_fallback_is_bounded);
     /* Bandwidth */
     RUN_TEST(test_bw_token_500hz);
     RUN_TEST(test_bw_token_2300hz);

--- a/tests/datalink_arq/test_arq_protocol.c
+++ b/tests/datalink_arq/test_arq_protocol.c
@@ -103,31 +103,47 @@ void test_decode_snr_zero_is_unknown(void)
 
 void test_retry_deadline_includes_bounded_jitter(void)
 {
-    mock_set_uptime_ms(1000);
-    uint64_t first = arq_protocol_retry_deadline_ms(7.0f, 0x42);
-    mock_set_uptime_ms(1001);
-    uint64_t second = arq_protocol_retry_deadline_ms(7.0f, 0x42);
-
-    TEST_ASSERT_TRUE(first >= 1000 + 7000ULL);
-    TEST_ASSERT_TRUE(second >= 1001 + 7000ULL);
-    TEST_ASSERT_TRUE(first <= 1000 + 7000ULL + ARQ_RETRY_JITTER_MS_DEFAULT);
-    TEST_ASSERT_TRUE(second <= 1001 + 7000ULL + ARQ_RETRY_JITTER_MS_DEFAULT);
-    TEST_ASSERT_NOT_EQUAL_UINT64(first, second);
+    /* Jitter is uniform in [0, jitter_ms): every deadline must stay within
+     * [base, base + jitter_ms) and, over many instants, must actually vary.
+     * Sampling 100 instants rather than one pair keeps this robust to a change
+     * in the hash constants, the default jitter, or the seed timestamps. */
+    uint64_t first = 0;
+    int differing = 0;
+    for (uint64_t i = 0; i < 100; i++)
+    {
+        mock_set_uptime_ms(1000 + i);
+        uint64_t d = arq_protocol_retry_deadline_ms(7.0f, 0x42);
+        uint64_t base = 1000 + i + 7000ULL;
+        TEST_ASSERT_TRUE(d >= base);
+        TEST_ASSERT_TRUE(d <= base + ARQ_RETRY_JITTER_MS_DEFAULT);
+        if (i == 0)
+            first = d;
+        else if (d != first)
+            differing++;
+    }
+    TEST_ASSERT_TRUE(differing >= 5);
 }
 
 void test_retry_deadline_jitter_differs_by_node_salt(void)
 {
     /* Two stations sharing a clock and a session_id must still desynchronise:
-     * the callsign-derived salt is the only input that differs. */
+     * the callsign-derived salt is the only input that differs.  Check over
+     * many shared instants so a single hash collision cannot mask a broken
+     * salt. */
     uint32_t salt_a = arq_protocol_node_salt(0x42, "NODE_A");
     uint32_t salt_b = arq_protocol_node_salt(0x42, "NODE_B");
     TEST_ASSERT_NOT_EQUAL_UINT32(salt_a, salt_b);
 
-    mock_set_uptime_ms(1000);
-    uint64_t a = arq_protocol_retry_deadline_ms(7.0f, salt_a);
-    mock_set_uptime_ms(1000); /* same instant */
-    uint64_t b = arq_protocol_retry_deadline_ms(7.0f, salt_b);
-    TEST_ASSERT_NOT_EQUAL_UINT64(a, b);
+    int differing = 0;
+    for (uint64_t i = 0; i < 100; i++)
+    {
+        mock_set_uptime_ms(1000 + i);
+        uint64_t a = arq_protocol_retry_deadline_ms(7.0f, salt_a);
+        uint64_t b = arq_protocol_retry_deadline_ms(7.0f, salt_b);
+        if (a != b)
+            differing++;
+    }
+    TEST_ASSERT_TRUE(differing >= 5);
 }
 
 void test_retry_deadline_salt_is_deterministic(void)


### PR DESCRIPTION
## Summary

Fixes #217 — two stations on a fixed retry schedule can phase-lock: both transmit simultaneously, neither can hear the other, and the session stalls until disconnect.

The fix adds a **deterministic per-node retry stagger**: the two peers compare the same pair of exchanged callsigns, so exactly one defers by a fixed offset on every retry. No random draw, no latency tail, and deadlines become exactly testable.

## How it works

```
rank     = strcmp(local_call, remote_call) > 0 ? 1 : 0
deadline = now + base + rank * retry_stagger_ms   /* default 2000 ms */
```

`strcmp()` is antisymmetric, so both ends compute the *same* comparison from the *same* pair and always disagree about who defers. The stagger accumulates across retransmits (each deadline is re-anchored at PTT-OFF), so the two stations drift apart deterministically and one soon transmits while the other is listening.

- Applied to all retry timers: CALL, ACCEPT, TURN_REQ, KEEPALIVE, DISCONNECT, MODE_REQ, and **the DATA retransmit (`ack_timeout_s`)** — the load-bearing timer for #217's exact scenario, where two connected stations both land in `WAIT_ACK`. `ack_timeout_s` is a lower bound, so a positive offset only ever delays the retransmit.
- `arq_protocol_retry_rank()` returns `-1` for a degenerate pair (identical or missing callsigns — a misconfiguration) and falls back to a random draw over `[0, stagger_ms)`.

## Config

- `arq:retry_stagger_ms` INI key (default 2000, range 0..5000, **0 disables**), plumbed like the neighbouring ARQ tunables.

## Tests

- `test_arq_protocol`: rank antisymmetry + determinism, degenerate-pair fallback, exact stagger deadlines, disabled-stagger exactness, bounded fallback.
- `test_arq_fsm`: PTT-OFF re-anchor and `WAIT_ACK` deadlines assert **exact** equality again.
- `test_cfg_utils`: default, off-switch (`0`) round-trip, out-of-range rejection.
- Full suite passes (23 binaries, 0 failures).

## Trade-offs

Deterministic vs random backoff: point-to-point ARQ has identity, so it doesn't need luck to break symmetry. The stagger is reproducible (a bad run replays exactly), has no tail latency (one side pays a fixed, known offset), and restores exact-equality test assertions. Random backoff remains only as a fallback for the same-callsign misconfiguration.