### PR TITLE
modem/rx + arq/fsm: fix two causes of missed first-burst decodes (fixes #223)

### DIFF
--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -701,15 +701,29 @@ static bool maybe_upgrade_mode(arq_session_t *sess)
 
     sess->mode_upgrade_count = 0;
     sess->pending_tx_mode = desired_mode;
-    sess->tx_retries_left = ARQ_MODE_REQ_RETRIES;
 
     HLOGI(LOG_COMP, "Mode negotiation: %d -> %d (peer_snr=%.1f olla=%+.1f eff=%.1f dB, backlog=%d)",
           sess->payload_mode, desired_mode,
           (float)sess->peer_snr_x10 / 10.0f, sess->olla_offset_db,
           (float)sess->peer_snr_x10 / 10.0f + sess->olla_offset_db, backlog);
 
-    send_mode_negotiation(sess, ARQ_SUBTYPE_MODE_REQ, desired_mode);
-    dflow_enter(sess, ARQ_DFLOW_MODE_REQ_TX, UINT64_MAX, ARQ_EV_TIMER_RETRY);
+    /* Do NOT transmit here.  Negotiation starts on RX_ACK, and ack_rx fires
+     * ~168 ms before the peer's ACK PTT actually drops (see
+     * enter_idle_iss_guarded) -- so an immediate MODE_REQ lands on the tail of
+     * the peer's own transmission and is lost, exactly like an unguarded
+     * DATA_TX.  Observed as: ACK decoded at +21.805, MODE_REQ keyed at +21.839
+     * (34 ms later), peer still transmitting until +22.020, MODE_REQ never
+     * decoded -- costing a full MODE_REQ retry interval on every mode change
+     * that happens to be triggered by an ACK (issue #223).
+     *
+     * Wait out the same guard every other post-ACK transmission uses, then let
+     * the MODE_REQ_WAIT retry path do the actual send.  tx_retries_left gets
+     * one extra slot because that path decrements before sending, so the
+     * number of MODE_REQs on the air is unchanged. */
+    sess->tx_retries_left = ARQ_MODE_REQ_RETRIES + 1;
+    dflow_enter(sess, ARQ_DFLOW_MODE_REQ_WAIT,
+                time_now_ms() + ARQ_ISS_POST_ACK_GUARD_MS,
+                ARQ_EV_TIMER_RETRY);
     return true;
 }
 

--- a/modem/modem.c
+++ b/modem/modem.c
@@ -1479,6 +1479,10 @@ static void rx_metrics_update(rx_metrics_accum_t *metrics, int sync, float snr, 
  * transfer reaches Login/Handshake/Sending like HARQ-off / v1.9.9.  The fading
  * Es/No gain (the point of HARQ) is realised when retransmissions of the same
  * frame accumulate; confirm the magnitude on a fading link (Watterson / OTA). */
+/* Set by the control plane when it decodes a DATAC16 frame; consumed by the
+ * payload plane.  See rx_worker_thread for why. */
+static _Atomic bool g_payload_resync_req = false;
+
 static int harq_enabled(void)
 {
     const char *e = getenv("MERCURY_HARQ");
@@ -1738,6 +1742,36 @@ static void *rx_worker_thread(void *arg)
             continue;
         }
 
+        /* Drop a sync the payload decoder picked up off a control burst.
+         *
+         * Both planes are fed the same audio, so while the peer transmits
+         * DATAC16 the payload (DATAC15) correlator can trial-sync on it and
+         * stay latched.  When the peer's first real DATA burst then arrives,
+         * the decoder demodulates it against that stale estimate: measured as
+         * rx_status=SYNC|BIT_ERRORS with an SNR estimate of ~5 dB on a burst
+         * that reads ~18 dB once the decoder acquires it cleanly (issue #223).
+         * The answerer therefore missed the caller's first DATA burst on most
+         * transfers, and enough in a row to fail outright ~8% of the time.
+         *
+         * Only the control plane raises this, and only on a frame it actually
+         * decoded, so a burst the payload decoder is legitimately mid-way
+         * through is never interrupted: a real DATA burst does not decode as
+         * DATAC16.  UNSYNC also zeroes freedv's rxbuf, which the comments in
+         * rx_decoder_bind_mode warn starves the preamble normalizer -- but
+         * that costs ~770 ms of audio to refill and the peer's data burst
+         * follows its control burst by longer than that (it has to key up,
+         * and the ARQ guard interval sits in between). */
+        if (w->state.mode != FREEDV_MODE_DATAC16 &&
+            atomic_exchange(&g_payload_resync_req, false))
+        {
+            pthread_mutex_t *rl = modem_inst_lock_for(w->state.freedv);
+            pthread_mutex_lock(rl);
+            if (w->state.freedv)
+                freedv_set_sync(w->state.freedv, FREEDV_SYNC_UNSYNC);
+            pthread_mutex_unlock(rl);
+            w->state.demod_count = 0;
+        }
+
         int want = rx_decoder_target_chunk_samples(&w->state);
         size_t have = size_buffer(w->ring) / sizeof(int16_t);
         if (have < (size_t)want)
@@ -1875,6 +1909,15 @@ static void rx_decoder_consume_chunk(rx_decoder_state_t *state,
 
         if (nbytes_out > 0)
         {
+            /* A decoded control frame proves the audio just consumed was a
+             * DATAC16 burst, not payload.  The payload decoder was fed the
+             * same audio and may have trial-synced on it (its correlator can
+             * latch a control preamble), and a stale sync makes it decode the
+             * NEXT real payload burst with the wrong timing/frequency
+             * estimate.  Ask it to drop that sync -- see rx_worker_thread. */
+            if (state->mode == FREEDV_MODE_DATAC16)
+                atomic_store(&g_payload_resync_req, true);
+
             HLOGD("modem-rx", "Decoded frame mode=%d (%s) bytes=%zu snr=%.2f",
                   state->mode,
                   mode_name_from_enum(state->mode),


### PR DESCRIPTION
Fixes #223. **Two independent bugs**, both traced, both in the RX/turnaround path.

## 1. The payload decoder false-synced on control bursts (`48ae074`)

Both RX planes are fed the same audio from one tee. While the peer transmits **DATAC16 control**, the **DATAC15 payload** correlator trial-syncs on it and stays latched; the first real DATA burst is then demodulated against that stale timing estimate.

```
+9.314   sync=1 rx_status=0x3 snr=-5.0    false sync during A's CONTROL burst
+12.275  Decoded frame mode=23 (DATAC16)   that audio was control
+14.010  sync=1 rx_status=0xa snr=5.3      real DATA burst: SYNC|BIT_ERRORS
+33.058  sync=1 rx_status=0x6 snr=18.1     finally acquired cleanly
```

`0xa` = `FREEDV_RX_SYNC | FREEDV_RX_BIT_ERRORS`. **5.3 dB latched vs 18.1 dB clean on the same transmission** — a 13 dB self-inflicted penalty. Transfers only completed because the false sync eventually times out on its own.

Fix: a decoded DATAC16 frame proves that audio was control, so the payload plane drops any sync it took off it. Only a *successfully decoded* control frame triggers it, so a payload burst legitimately in progress is never interrupted.

## 2. The initial MODE_REQ ignored the post-ACK guard (`8d96cd0`)

Mode negotiation starts on RX_ACK, and `ack_rx` fires ~168 ms **before** the peer's ACK PTT drops. The MODE_REQ went out immediately, landing on the tail of the peer's own transmission:

```
+21.805  A decodes B's ACK           (B keyed until +22.020)
+21.805  Mode negotiation: 22 -> 12
+21.839  A keys MODE_REQ             34 ms after the decode
+22.020  B's PTT finally drops       B missed the preamble entirely
```

This is the hazard `enter_idle_iss_guarded()` already documents ("at 500ms that was only 432ms, too tight for DATAC1 re-sync, causing ~39% first-frame misses"). DATA_TX and ACK_TX both defer by `ARQ_ISS_POST_ACK_GUARD_MS`, and the IRS guards its MODE_ACK — the ISS's initial MODE_REQ was the one post-ACK transmit that did not, despite being triggered by exactly that RX_ACK.

Fix: route it through the existing `MODE_REQ_WAIT` retry path after the same guard, rather than adding a state. That path decrements before sending, so it gets one extra slot and the number of MODE_REQs on the air is unchanged.

## Measured

24 runs of `TestMercuryARQTransfer` at each stage:

| | trunk | +fix 1 | +fix 2 |
|---|---|---|---|
| wedged transfers | 2 / 24 | 0 / 24 | **0 / 24** |
| typical run | 69.70 s | 54.16 s | **55.1 s** |
| 66 s outliers | — | 4 / 24 | **0** |
| 108 s outliers | — | 4 / 24 | **0** |

Full 24-run range is now **54.963–55.175 s** — a 0.21 s spread, where trunk produced a four-humped distribution (54 / 66 / 108 / wedge). The humps were the lost MODE_REQ costing exactly one retry interval each.

The ~1 s against fix 1 alone is the 900 ms guard itself, paid once per mode negotiation — a good trade for removing a 12 s and a 54 s tail.

- Unit suite: all passing
- Integration suite: `ok mercuryintegration 211.063s` (was 320 s on trunk)

## Scope

Both bugs **predate the current release branch** — reproduced on `4eac25e` at 1 wedge in 24 — so neither is a regression from any recent merge.

**HARQ is not implicated and stays enabled.** A/B'd with `MERCURY_HARQ=0`: 1 wedge in *each* arm of 9. Both mechanisms found here are unrelated to it, and disabling it would have cost fading margin for nothing.

**Not yet validated on air.** Neither mechanism is harness-specific — two decoder planes sharing one audio stream, and a PTT tail overlapping the peer's reply, both exist on a real radio — but the numbers are from the `ch`-bridged FIFO harness, which is not real-time paced. The throughput figures should be confirmed on a live link before being treated as a claim.
