### PR TITLE
build: fix the macOS universal build (vendored hidapi object never rebuilt per-arch)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,15 @@ ifneq ($(strip $(HAMLIB_W64_LIBS)),)
 MERCURY_CORE_OBJS_W64 += radio_io/rigctl_parse.o
 endif
 
-libmercury_core.a: internal_deps
+# $(HIDAPI_OBJS) is listed in MERCURY_CORE_OBJS but is NOT built by
+# internal_deps -- the vendored hidapi object has its own top-level rule, and
+# radio_io's sub-make does not build it either.  Without it as a prerequisite
+# the archive step just assumed the file was lying around from an earlier
+# build, which it was until `clean` started removing it properly:
+#     ar: radio_io/hidapi-macos/hid.o: No such file or directory
+# $(BINARY) already declares it via MERCURY_LINK_INPUTS, which is why the CLI
+# build was unaffected and only the .app/.dmg packaging path broke.
+libmercury_core.a: internal_deps $(HIDAPI_OBJS)
 	$(CC) $(CFLAGS) -I. -c $(FYNE_UI_DIR)/engine/mercury_bridge.c -o $(FYNE_UI_DIR)/engine/mercury_bridge.o
 	# Remove a stale archive first: macOS ar (cctools) refuses to update an
 	# existing *fat* .a in place, so a leftover universal build would wedge the

--- a/radio_io/Makefile
+++ b/radio_io/Makefile
@@ -121,3 +121,12 @@ rigctl_parse.o: rigctl_parse.c rigctl_parse.h
 
 clean:
 	rm -f *.o
+	@# The vendored hidapi objects live one directory down, so a bare *.o
+	@# misses them.  They MUST go: macos-universal and fyne-ui-macos-universal
+	@# build one arch slice after another with a `clean` in between, and a
+	@# surviving hid.o from the previous slice is silently reused --
+	@# "ld: warning: ignoring file radio_io/hidapi-macos/hid.o: found
+	@# architecture 'x86_64', required architecture 'arm64'" followed by every
+	@# hid_* symbol undefined.  The Windows copy has the same shape, so clean
+	@# both rather than leaving the next cross-build to trip over it.
+	rm -f hidapi-macos/hid.o hidapi-w64/hid.o


### PR DESCRIPTION
`make fyne-ui-macos-universal-dmg` has been failing since #220, so no macOS artifact could be produced — which is why v1.9.13 shipped without one (#172, #225).

Two bugs, both around the vendored macOS hidapi, both invisible to CI because **nothing in the matrix runs the packaging targets** (the macOS job is build-only, single-arch).

### 1. `clean` missed the vendored objects

`macos-universal` and `fyne-ui-macos-universal` build one arch slice after another with a `$(MAKE) clean` in between, but `radio_io`'s clean was a bare `rm -f *.o` — which does not reach `hidapi-macos/hid.o` one directory down. The x86_64 object survived into the arm64 slice and was silently reused:

```
ld: warning: ignoring file 'radio_io/hidapi-macos/hid.o':
    found architecture 'x86_64', required architecture 'arm64'
Undefined symbols for architecture arm64:
  _hid_close, _hid_enumerate, _hid_exit, _hid_free_enumeration,
  _hid_init, _hid_open_path, _hid_write
```

`hidapi-w64/hid.o` is cleaned too — same shape, would trip the next cross-build identically.

### 2. `libmercury_core.a` listed `hid.o` without depending on it

Fixing the clean exposed the second half:

```
ar: radio_io/hidapi-macos/hid.o: No such file or directory
```

`$(HIDAPI_OBJS)` is in `MERCURY_CORE_OBJS`, but `libmercury_core.a: internal_deps` never declared it as a prerequisite, and `internal_deps` does not build it (the vendored object has its own top-level rule; `radio_io`'s sub-make does not build it either). It only ever worked because a stale object happened to be lying around. `$(BINARY)` already declares it via `MERCURY_LINK_INPUTS`, which is exactly why the plain CLI build was fine and only the `.app`/`.dmg` path broke.

### Verified on macOS 15.7.7

`make fyne-ui-macos-universal-dmg` now completes (`rc=0`), and the artifact checks out:

| check | result |
|---|---|
| `Mercury.app/Contents/MacOS/mercury-ui` | `x86_64 arm64` |
| `Command Line/mercury` | `x86_64 arm64` |
| `NSMicrophoneUsageDescription` | present (#222) |
| version | 1.9.13 (git 075631e2) |

The resulting DMG is now attached to the v1.9.13 release, closing the gap noted in #172.

Unsigned, as before — `MACOS_SIGN_P12` was not set for this build, so Gatekeeper still wants right-click → Open on first launch, same as 1.9.11 and 1.9.12.

### Follow-up worth doing separately

CI builds macOS but never packages it, which is precisely how this went unnoticed through a release. A job running `fyne-ui-macos-universal` (build only, no DMG — `hdiutil` needs a real macOS runner anyway) would have caught both bugs at the link step.
