### PR TITLE
watterson: seed the fading channel, from a private generator

### DIFF
--- a/common/mercury_prng.c
+++ b/common/mercury_prng.c
@@ -1,0 +1,132 @@
+/* HERMES Modem — reproducible pseudo-random source
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * See mercury_prng.h for why this is not just rand().
+ */
+
+#include "mercury_prng.h"
+
+#include <math.h>
+#include <stdlib.h>
+#include <time.h>
+#ifdef _WIN32
+#include <process.h>
+#define MERCURY_GETPID() _getpid()
+#else
+#include <unistd.h>
+#define MERCURY_GETPID() getpid()
+#endif
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+/* Separation between the front and rear cursors for TYPE_3 (x**31 + x**3 + 1). */
+#define SEP 3
+
+void mercury_prng_seed(mercury_prng_t *p, unsigned int seed)
+{
+    int32_t word;
+    int     i;
+
+    if (!p)
+        return;
+
+    /* glibc maps 0 to 1: seeding the additive generator with an all-zero
+     * state would make it emit zeros forever. */
+    if (seed == 0)
+        seed = 1;
+
+    p->state[0] = (int32_t)seed;
+    word = (int32_t)seed;
+
+    /* state[i] = (16807 * state[i-1]) % 2147483647, computed by Schrage's
+     * method so the intermediate product never overflows 31 bits. */
+    for (i = 1; i < MERCURY_PRNG_DEG; ++i)
+    {
+        long hi = word / 127773;
+        long lo = word % 127773;
+        word = (int32_t)(16807 * lo - 2836 * hi);
+        if (word < 0)
+            word += 2147483647;
+        p->state[i] = word;
+    }
+
+    p->f = SEP;
+    p->r = 0;
+
+    /* Discard the first 10*DEG outputs so the low-quality LCG warm-up does not
+     * reach the caller.  glibc does exactly this. */
+    for (i = 0; i < MERCURY_PRNG_DEG * 10; ++i)
+        (void)mercury_prng_u31(p);
+}
+
+uint32_t mercury_prng_u31(mercury_prng_t *p)
+{
+    uint32_t val;
+
+    /* Additive feedback: state[f] += state[r], both cursors then advance and
+     * wrap.  Unsigned arithmetic because the addition is meant to wrap. */
+    val = (uint32_t)p->state[p->f] + (uint32_t)p->state[p->r];
+    p->state[p->f] = (int32_t)val;
+
+    if (++p->f >= MERCURY_PRNG_DEG)
+        p->f = 0;
+    if (++p->r >= MERCURY_PRNG_DEG)
+        p->r = 0;
+
+    /* Chuck the least random bit, as random() does. */
+    return val >> 1;
+}
+
+float mercury_prng_uniform(mercury_prng_t *p)
+{
+    /* Deliberately spelled to match the expression this replaced, which was
+     *
+     *     (float)rand() / RAND_MAX
+     *
+     * -- a FLOAT divide by (float)2147483647, which rounds to 2^31.  Using a
+     * cleaner double divide here would be a fractional-ULP change, but the
+     * Doppler-shaping IIR has poles within ~1e-4 of the unit circle, so it is
+     * chaotically sensitive: a last-bit difference in the driving noise gives
+     * a COMPLETELY different fade a few thousand samples later.  Matching the
+     * old arithmetic exactly is what lets this port be verified as a
+     * no-behaviour-change against every result measured before it.
+     *
+     * Range is [0, 1] inclusive, as it was; callers must tolerate both ends. */
+    return (float)mercury_prng_u31(p) / (float)2147483647;
+}
+
+float mercury_prng_gaussian(mercury_prng_t *p)
+{
+    float x = mercury_prng_uniform(p);
+    float y = mercury_prng_uniform(p);
+
+    /* avoid log(0) — extremely unlikely but safe */
+    if (x <= 0.0f)
+        x = 1e-9f;
+
+    /* M_PI stays a DOUBLE here, exactly as in the expression this replaced:
+     * 2.0f * M_PI promotes to double, and only cosf() rounds back to float.
+     * Doing the multiply in float instead changes the last bit, which the
+     * near-unit-circle Doppler IIR turns into a different fade. */
+    return sqrtf(-2.0f * logf(x)) * cosf(2.0f * M_PI * y);
+}
+
+unsigned int mercury_prng_seed_auto(mercury_prng_t *p, const char *env)
+{
+    const char  *e = env ? getenv(env) : NULL;
+    unsigned int seed;
+
+    if (e && *e)
+        seed = (unsigned int)strtoul(e, NULL, 0);
+    else
+        /* Clock XOR pid, so that runs started in the same second -- which a
+         * parallel sweep does constantly -- still get different channels. */
+        seed = (unsigned int)time(NULL) ^ ((unsigned int)MERCURY_GETPID() << 16);
+
+    mercury_prng_seed(p, seed);
+    return seed;
+}

--- a/common/mercury_prng.h
+++ b/common/mercury_prng.h
@@ -1,0 +1,76 @@
+/* HERMES Modem — reproducible pseudo-random source
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * A private, reentrant copy of glibc's TYPE_3 additive-feedback generator --
+ * the one random(3) uses by default -- carried here so that channel models and
+ * test harnesses do NOT depend on libc's rand().
+ *
+ * Three reasons this exists rather than a call to rand():
+ *
+ *   1. REPRODUCIBILITY ACROSS PLATFORMS.  rand() is a different generator on
+ *      glibc, musl, macOS and MinGW, so "the same seed" reproduces a different
+ *      channel on each.  A fading measurement that cannot be replayed on
+ *      another machine cannot be checked by anyone else.
+ *
+ *   2. NO SHARED GLOBAL STATE.  rand() has one hidden global sequence, so any
+ *      other caller -- a test fixture, a library, a second channel instance --
+ *      silently reorders the draws a channel sees.  Each user of this module
+ *      owns its state, so two channels in one process cannot perturb one
+ *      another and neither perturbs libc.
+ *
+ *   3. IT IS EASY TO FORGET TO SEED.  rand() without srand() behaves exactly
+ *      as if seeded with 1: it returns a valid-looking stream, so nothing
+ *      fails, and every "independent" run replays ONE realisation.  That is
+ *      precisely the defect this module was written to retire -- see
+ *      watterson_seed_auto().
+ *
+ * Bit-identical to glibc random() for a given seed (verified in
+ * tests/common/test_mercury_prng.c against a table of known outputs), so
+ * existing pinned-seed results remain reproducible on glibc hosts.
+ *
+ * Ported from mercuryv1's source/common/os_interop.cc, reduced to the single
+ * TYPE_3 degree Mercury actually uses and made reentrant: state lives in the
+ * caller's struct, and the front/rear cursors are indices rather than pointers
+ * so the struct is trivially copyable.
+ *
+ * NOT cryptographically secure, and not meant to be.
+ */
+#ifndef MERCURY_PRNG_H
+#define MERCURY_PRNG_H
+
+#include <stdint.h>
+
+/* Degree of the x**31 + x**3 + 1 polynomial (glibc TYPE_3). */
+#define MERCURY_PRNG_DEG 31
+
+typedef struct
+{
+    int32_t state[MERCURY_PRNG_DEG];
+    int     f;   /* front cursor, index into state[] */
+    int     r;   /* rear cursor                      */
+} mercury_prng_t;
+
+/** Seed the generator.  A seed of 0 is mapped to 1, as glibc does. */
+void mercury_prng_seed(mercury_prng_t *p, unsigned int seed);
+
+/** Next value in [0, 2^31-1], matching random(). */
+uint32_t mercury_prng_u31(mercury_prng_t *p);
+
+/** Uniform in [0, 1], both ends inclusive (see the note in the .c). */
+float mercury_prng_uniform(mercury_prng_t *p);
+
+/** One sample from N(0, 1), via the Box-Muller transform. */
+float mercury_prng_gaussian(mercury_prng_t *p);
+
+/**
+ * Seed from the environment variable @p env if it is set and non-empty,
+ * otherwise from the wall clock XOR the pid so that concurrent runs differ.
+ *
+ * @return the seed actually used, so a caller can PRINT it -- an unreproducible
+ *         measurement is only worth having if the run can be replayed later.
+ */
+unsigned int mercury_prng_seed_auto(mercury_prng_t *p, const char *env);
+
+#endif /* MERCURY_PRNG_H */

--- a/common/watterson.c
+++ b/common/watterson.c
@@ -26,15 +26,9 @@
 
 /* Box-Muller transform: converts uniform [0,1) random numbers to Gaussian.
  * Returns a sample from N(0, 1). */
-static float gaussian()
+static float gaussian(watterson_t *w)
 {
-    float x = (float)rand() / RAND_MAX;
-    float y = (float)rand() / RAND_MAX;
-
-    /* avoid log(0) — extremely unlikely but safe */
-    if (x <= 0.0f) x = 1e-9f;
-
-    return sqrtf(-2.0f * logf(x)) * cosf(2.0f * M_PI * y);
+    return mercury_prng_gaussian(&w->rng);
 }
 
 /* Compute 2nd-order Butterworth LPF IIR coefficients via bilinear transform.
@@ -108,8 +102,29 @@ int watterson_init(watterson_t *w, int sample_rate)
     w->awgn_en = 0;
     w->noise_var = 0.0f;
     w->chan_norm = 1.0f;
+    watterson_seed_auto(w);
 
     return 0;
+}
+
+void watterson_seed(watterson_t *w, unsigned int seed)
+{
+    assert(w != NULL);
+    mercury_prng_seed(&w->rng, seed);
+    w->seed = seed;
+}
+
+unsigned int watterson_seed_auto(watterson_t *w)
+{
+    assert(w != NULL);
+    w->seed = mercury_prng_seed_auto(&w->rng, "MERCURY_WATTERSON_SEED");
+    return w->seed;
+}
+
+unsigned int watterson_get_seed(const watterson_t *w)
+{
+    assert(w != NULL);
+    return w->seed;
 }
 
 void watterson_dispose(watterson_t *w)
@@ -217,8 +232,8 @@ int watterson_add_path(watterson_t *w, float delay_ms, float doppler_hz,
             int k;
             for (k = 0; k < 1000; k++)
             {
-                iir_tick(gaussian(), p->x_i, p->y_i, p->b0, p->b1, p->b2, p->a1, p->a2);
-                iir_tick(gaussian(), p->x_q, p->y_q, p->b0, p->b1, p->b2, p->a1, p->a2);
+                iir_tick(gaussian(w), p->x_i, p->y_i, p->b0, p->b1, p->b2, p->a1, p->a2);
+                iir_tick(gaussian(w), p->x_q, p->y_q, p->b0, p->b1, p->b2, p->a1, p->a2);
             }
         }
     }
@@ -311,8 +326,8 @@ void watterson_process(watterson_t *w, COMP *samples, int n)
                  * the sqrt(1/2)).  Our gaussian() is unit-variance, so apply the
                  * 1/2 here — otherwise the channel is 3 dB hotter than ch and the
                  * SNR<->No calibration (and the mode thresholds) shift by 3 dB. */
-                noise.real = gaussian() * sqrtf(w->noise_var * 0.5f);
-                noise.imag = gaussian() * sqrtf(w->noise_var * 0.5f);
+                noise.real = gaussian(w) * sqrtf(w->noise_var * 0.5f);
+                noise.imag = gaussian(w) * sqrtf(w->noise_var * 0.5f);
                 w->sig_pwr_acc   += (double)samples[i].real * samples[i].real +
                                     (double)samples[i].imag * samples[i].imag;
                 w->noise_pwr_acc += (double)noise.real * noise.real +
@@ -343,8 +358,8 @@ void watterson_process(watterson_t *w, COMP *samples, int n)
              * coefficients are set so the output is 1.0 + j0.0. */
             if (wp->doppler_hz > 0.0f)
             {
-                float xn_i = gaussian();
-                float xn_q = gaussian();
+                float xn_i = gaussian(w);
+                float xn_q = gaussian(w);
                 tap.real = iir_tick(xn_i, wp->x_i, wp->y_i,
                                     wp->b0, wp->b1, wp->b2,
                                     wp->a1, wp->a2);
@@ -419,8 +434,8 @@ void watterson_process(watterson_t *w, COMP *samples, int n)
             COMP noise;
             /* per-component variance noise_var/2 => complex noise power = Fs*No,
              * matching ch.c (see the no-paths branch above). */
-            noise.real = gaussian() * sqrtf(w->noise_var * 0.5f);
-            noise.imag = gaussian() * sqrtf(w->noise_var * 0.5f);
+            noise.real = gaussian(w) * sqrtf(w->noise_var * 0.5f);
+            noise.imag = gaussian(w) * sqrtf(w->noise_var * 0.5f);
             w->sig_pwr_acc   += (double)out.real * out.real +
                                 (double)out.imag * out.imag;
             w->noise_pwr_acc += (double)noise.real * noise.real +

--- a/common/watterson.h
+++ b/common/watterson.h
@@ -26,6 +26,7 @@
 #define watterson_h
 
 #include "modem/freedv/comp.h"
+#include "mercury_prng.h"
 
 /* Maximum number of paths supported */
 #define WATTERSON_MAX_PATHS 4
@@ -95,6 +96,17 @@ typedef struct watterson
     double sig_pwr_acc;    /* Sum |faded signal|^2 (pre-noise)            */
     double noise_pwr_acc;  /* Sum |noise added|^2                         */
     long   meas_nsamp;     /* samples accumulated into the sums           */
+
+    /* The fading and AWGN draws come from HERE, not rand().
+     *
+     * Per-instance so two channels in one process cannot perturb each other's
+     * realisation, and private so nothing else in the program can either.  It
+     * also makes a seed mean the same channel on every platform, which libc's
+     * rand() does not: glibc, musl, macOS and MinGW each implement a different
+     * generator, so a fading result pinned on one host could not be replayed
+     * on another. */
+    mercury_prng_t rng;
+    unsigned int   seed;   /* the seed rng was last seeded with */
 } watterson_t;
 
 /* Initialise the Watterson channel simulator.
@@ -106,6 +118,32 @@ typedef struct watterson
  * Returns 0 on success, -1 on error.
  */
 int watterson_init(watterson_t *w, int sample_rate);
+
+/* Pin the fading realisation to a known seed.
+ *
+ * Use this to replay one specific channel: bisecting a failure, or A/B-ing two
+ * builds over EXACTLY the same fade (which is the only way to compare them at
+ * a sample size a laptop can afford). */
+void watterson_seed(watterson_t *w, unsigned int seed);
+
+/* Seed from MERCURY_WATTERSON_SEED if set, otherwise from the clock and pid.
+ *
+ * Called automatically by watterson_init(), so a channel is never unseeded.
+ * That used to be possible, and it was silent: the model drew from rand(), and
+ * no entry point called srand(), so libc behaved as if seeded with 1 and EVERY
+ * run produced the identical fade.  Repeat runs looked like independent
+ * agreement while being one sample reported N times.
+ *
+ * Returns the seed used.  Print it -- an unpinned result is only worth having
+ * if the run can be replayed later. */
+unsigned int watterson_seed_auto(watterson_t *w);
+
+/* The seed this channel is currently running on.
+ *
+ * Use this to REPORT the seed; calling watterson_seed_auto() again to find out
+ * what init chose would re-seed, discarding the draws watterson_add_path() has
+ * already made and yielding a different channel from the one the seed names. */
+unsigned int watterson_get_seed(const watterson_t *w);
 
 /* Release resources allocated by the Watterson simulator. */
 void watterson_dispose(watterson_t *w);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -46,6 +46,7 @@ TEST_BINS = test_ring_buffer test_arq_protocol test_arq_timing test_arq_fsm \
             test_tcp_interfaces test_resampler test_pcm24 test_arq_olla test_arq_sim \
             test_arq_conn test_cfg_utils test_arq_tnc test_channel_busy \
             test_freedv_harq test_sock_wire test_virtual_clock test_watterson \
+            test_mercury_prng \
             test_ofdm_acq test_ui_status test_ui_devices test_tx_pacing test_radio_port
 
 .PHONY: all test clean
@@ -155,7 +156,12 @@ test_virtual_clock: common/test_virtual_clock.c $(UNITY_SRC) ../common/virtual_c
 
 # Channel model: pins that fading stays finite across sample rates (-I.. because
 # the test includes common/watterson.h by path).
-test_watterson: common/test_watterson.c $(UNITY_SRC) ../common/watterson.c
+test_watterson: common/test_watterson.c $(UNITY_SRC) ../common/watterson.c ../common/mercury_prng.c
+	$(CC) $(CFLAGS) -I.. -o $@ $^ $(LDFLAGS)
+
+# The channel's random source.  Pins actual output values, because the whole
+# point is that a seed means the same fade on every platform.
+test_mercury_prng: common/test_mercury_prng.c $(UNITY_SRC) ../common/mercury_prng.c
 	$(CC) $(CFLAGS) -I.. -o $@ $^ $(LDFLAGS)
 
 # OFDM acquisition: the FFT search must agree with brute force, fringe included.

--- a/tests/common/test_mercury_prng.c
+++ b/tests/common/test_mercury_prng.c
@@ -1,0 +1,164 @@
+/* Tests for common/mercury_prng.c
+ *
+ * Copyright (C) 2026 Rhizomatica
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * The point of this generator is that a seed means the SAME channel on every
+ * platform, so the tests that matter are the ones pinning actual output values
+ * rather than statistical properties.
+ */
+#include "unity.h"
+
+#include <math.h>
+#include <string.h>
+
+#include "common/mercury_prng.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* The first ten outputs of glibc's random() for srandom(1).  Hardcoded, not
+ * computed: comparing against the host's random() would only prove we match
+ * THIS libc, which is exactly the dependency this module exists to remove.
+ * These values must never change -- a pinned-seed measurement recorded in a
+ * commit message has to stay replayable. */
+static const uint32_t glibc_seed1[10] = {
+    1804289383u,  846930886u, 1681692777u, 1714636915u, 1957747793u,
+     424238335u,  719885386u, 1649760492u,  596516649u, 1189641421u
+};
+
+void test_seed1_matches_the_reference_stream(void)
+{
+    mercury_prng_t p;
+    mercury_prng_seed(&p, 1);
+    for (int i = 0; i < 10; i++)
+        TEST_ASSERT_EQUAL_UINT32(glibc_seed1[i], mercury_prng_u31(&p));
+}
+
+/* glibc maps seed 0 to 1; an all-zero additive state emits zeros forever. */
+void test_seed_zero_is_mapped_to_one(void)
+{
+    mercury_prng_t a, b;
+    mercury_prng_seed(&a, 0);
+    mercury_prng_seed(&b, 1);
+    for (int i = 0; i < 100; i++)
+        TEST_ASSERT_EQUAL_UINT32(mercury_prng_u31(&b), mercury_prng_u31(&a));
+}
+
+void test_same_seed_replays_exactly(void)
+{
+    mercury_prng_t a, b;
+    mercury_prng_seed(&a, 20260818);
+    mercury_prng_seed(&b, 20260818);
+    for (int i = 0; i < 1000; i++)
+        TEST_ASSERT_EQUAL_UINT32(mercury_prng_u31(&b), mercury_prng_u31(&a));
+}
+
+void test_different_seeds_diverge(void)
+{
+    mercury_prng_t a, b;
+    int same = 0;
+    mercury_prng_seed(&a, 1001);
+    mercury_prng_seed(&b, 1002);
+    for (int i = 0; i < 1000; i++)
+        if (mercury_prng_u31(&a) == mercury_prng_u31(&b)) same++;
+    /* A handful of coincidental collisions is fine; lockstep is not. */
+    TEST_ASSERT_LESS_THAN_INT(10, same);
+}
+
+/* Two instances must be independent.  This is the property rand() cannot
+ * offer, and its absence is how an unrelated caller silently reorders the
+ * draws a channel model sees. */
+void test_instances_do_not_share_state(void)
+{
+    mercury_prng_t a, b, ref;
+    mercury_prng_seed(&a, 7);
+    mercury_prng_seed(&ref, 7);
+    mercury_prng_seed(&b, 999);
+
+    for (int i = 0; i < 500; i++)
+    {
+        (void)mercury_prng_u31(&b);          /* interleave a foreign consumer */
+        TEST_ASSERT_EQUAL_UINT32(mercury_prng_u31(&ref), mercury_prng_u31(&a));
+    }
+}
+
+void test_uniform_stays_in_range(void)
+{
+    mercury_prng_t p;
+    mercury_prng_seed(&p, 12345);
+    for (int i = 0; i < 20000; i++)
+    {
+        float u = mercury_prng_uniform(&p);
+        TEST_ASSERT_TRUE(u >= 0.0f && u <= 1.0f);
+    }
+}
+
+/* The port must not perturb the channel.  Reproduces the exact expression
+ * common/watterson.c used before this module existed -- (float)rand()/RAND_MAX
+ * on glibc's TYPE_3 stream -- and requires bit-equality, because the Doppler
+ * IIR's near-unit-circle poles turn a last-bit difference into a completely
+ * different fade. */
+void test_uniform_is_bit_exact_with_the_expression_it_replaced(void)
+{
+    mercury_prng_t raw, uni;
+    mercury_prng_seed(&raw, 1);
+    mercury_prng_seed(&uni, 1);
+
+    for (int i = 0; i < 5000; i++)
+    {
+        float expect = (float)mercury_prng_u31(&raw) / (float)2147483647;
+        float got    = mercury_prng_uniform(&uni);
+        /* Bit-equality, not near-equality. */
+        TEST_ASSERT_EQUAL_MEMORY(&expect, &got, sizeof(float));
+    }
+}
+
+/* Enough to catch a broken Box-Muller (wrong scaling, or cos/sin swapped so
+ * the variance halves), which is what feeds the channel's tap gains. */
+void test_gaussian_is_zero_mean_unit_variance(void)
+{
+    mercury_prng_t p;
+    double sum = 0.0, sumsq = 0.0;
+    const int N = 200000;
+
+    mercury_prng_seed(&p, 4242);
+    for (int i = 0; i < N; i++)
+    {
+        double g = mercury_prng_gaussian(&p);
+        sum += g;
+        sumsq += g * g;
+    }
+    double mean = sum / N;
+    double var  = sumsq / N - mean * mean;
+
+    TEST_ASSERT_TRUE(fabs(mean) < 0.02);
+    TEST_ASSERT_TRUE(fabs(var - 1.0) < 0.05);
+}
+
+/* The struct carries no pointers, so it can be copied to fork a stream. */
+void test_state_is_trivially_copyable(void)
+{
+    mercury_prng_t a, copy;
+    mercury_prng_seed(&a, 555);
+    for (int i = 0; i < 37; i++) (void)mercury_prng_u31(&a);
+
+    memcpy(&copy, &a, sizeof(copy));
+    for (int i = 0; i < 200; i++)
+        TEST_ASSERT_EQUAL_UINT32(mercury_prng_u31(&a), mercury_prng_u31(&copy));
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_seed1_matches_the_reference_stream);
+    RUN_TEST(test_seed_zero_is_mapped_to_one);
+    RUN_TEST(test_same_seed_replays_exactly);
+    RUN_TEST(test_different_seeds_diverge);
+    RUN_TEST(test_instances_do_not_share_state);
+    RUN_TEST(test_uniform_stays_in_range);
+    RUN_TEST(test_uniform_is_bit_exact_with_the_expression_it_replaced);
+    RUN_TEST(test_gaussian_is_zero_mean_unit_variance);
+    RUN_TEST(test_state_is_trivially_copyable);
+    return UNITY_END();
+}

--- a/tests/common/test_watterson.c
+++ b/tests/common/test_watterson.c
@@ -13,6 +13,13 @@
 #include "watterson.h"
 #include <math.h>
 #include <stdlib.h>
+#include <stdint.h>
+
+/* FNV-1a of the channel output for seed 1, two 1 Hz paths, No=-20 at 8 kHz.
+ * Captured from the port that replaced rand() with mercury_prng, which was
+ * verified byte-identical to the pre-port channel across three presets and
+ * three noise levels. */
+#define GOLDEN_SEED1_HASH 0xB0B9513Cu
 
 void setUp(void) {}
 void tearDown(void) {}
@@ -82,10 +89,64 @@ void test_single_static_path_is_rate_invariant(void)
     TEST_ASSERT_FLOAT_WITHIN(0.5f, a, b);
 }
 
+/* A fixed seed must name a fixed channel, FOREVER.
+ *
+ * That is the whole value of seeding: a fading result quoted in a commit
+ * message has to be replayable, on this machine and on someone else's.  The
+ * realisation depends not only on the generator but on the ORDER and COUNT of
+ * the draws -- watterson_add_path() consumes some to estimate tap_norm before
+ * a single sample is processed -- so a refactor that merely moves a draw
+ * silently invalidates every recorded measurement without failing anything.
+ *
+ * Hence a golden checksum rather than a statistical assertion.  If this test
+ * fails, the channel changed: either fix the change, or accept it deliberately
+ * and re-measure everything that was pinned to a seed.
+ */
+void test_a_pinned_seed_reproduces_a_fixed_realisation(void)
+{
+    const int   fs = 8000;
+    const int   n  = fs;
+    watterson_t w;
+    uint32_t    sum = 0;
+
+    TEST_ASSERT_EQUAL_INT(0, watterson_init(&w, fs));
+    watterson_seed(&w, 1);
+    watterson_add_path(&w, 0.0f, 1.0f, 0.0f, 0.7f);
+    watterson_add_path(&w, 2.0f, 1.0f, 0.0f, 0.7f);
+    watterson_set_noise(&w, -20.0f);
+    watterson_reset_meas(&w);
+
+    COMP *s = malloc(sizeof(COMP) * (size_t)n);
+    TEST_ASSERT_NOT_NULL(s);
+    for (int i = 0; i < n; i++) {
+        s[i].real = 3000.0f * sinf(2.0f * (float)M_PI * 1500.0f * i / fs);
+        s[i].imag = 0.0f;
+    }
+    watterson_process(&w, s, n);
+
+    /* FNV-1a over the raw sample bytes: sensitive to a single changed bit. */
+    sum = 2166136261u;
+    for (int i = 0; i < n; i++) {
+        const unsigned char *b = (const unsigned char *)&s[i];
+        for (size_t k = 0; k < sizeof(COMP); k++) {
+            sum ^= b[k];
+            sum *= 16777619u;
+        }
+    }
+    free(s);
+
+    TEST_ASSERT_EQUAL_HEX32(GOLDEN_SEED1_HASH, sum);
+
+    /* And the seed must be reported back, so a run can say what it used. */
+    TEST_ASSERT_EQUAL_UINT(1, watterson_get_seed(&w));
+    watterson_dispose(&w);
+}
+
 int main(void)
 {
     UNITY_BEGIN();
     RUN_TEST(test_fading_is_stable_across_sample_rates);
     RUN_TEST(test_single_static_path_is_rate_invariant);
+    RUN_TEST(test_a_pinned_seed_reproduces_a_fixed_realisation);
     return UNITY_END();
 }

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -31,7 +31,7 @@ broadcast_diag_tx: broadcast_diag_tx.c ../datalink_broadcast/kiss.c ../modem/fra
 broadcast_diag_rx: broadcast_diag_rx.c ../datalink_broadcast/kiss.c ../modem/framer.c
 	$(CC) $(CFLAGS) -I../datalink_broadcast -o $@ $^ $(LDFLAGS)
 
-watterson_test: watterson_test.c ../common/watterson.c
+watterson_test: watterson_test.c ../common/watterson.c ../common/mercury_prng.c
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) -lm
 
 # Clean up build artifacts
@@ -45,7 +45,7 @@ run: broadcast_test
 # Drives the real freedv OFDM modems (not a model) to separate acquisition
 # failures from decode failures.  chanutil puts it on the project's own
 # Watterson channel so its numbers are comparable with other instruments'.
-acquire_vs_decode: acquire_vs_decode.c chanutil.c ../common/watterson.c
+acquire_vs_decode: acquire_vs_decode.c chanutil.c ../common/watterson.c ../common/mercury_prng.c
 	$(CC) $(CFLAGS) -o $@ $^ ../modem/freedv/libfreedvdata.a $(LDFLAGS) -lm
 
 # Perf instruments for issue #162 (idle CPU on a 48 kHz Pi 4).

--- a/utils/chanutil.c
+++ b/utils/chanutil.c
@@ -119,9 +119,11 @@ chanutil_t *chanutil_open(int preset, float no_dbhz, unsigned seed)
     watterson_set_noise(&c->w, no_dbhz);
     watterson_reset_meas(&c->w);
 
-    /* The fading realisation is driven by the model's own RNG; seeding here
-     * makes a sweep reproducible. */
-    srand(seed);
+    /* The fading realisation is driven by the model's own RNG, which is
+     * per-instance -- so seed THAT, not libc's global rand().  srand() here
+     * used to work only by accident, and stopped controlling the channel the
+     * moment anything else in the process drew a number. */
+    watterson_seed(&c->w, seed);
     warm_up(&c->w);
     return c;
 }

--- a/utils/watterson_test.c
+++ b/utils/watterson_test.c
@@ -232,6 +232,16 @@ int main(int argc, char *argv[])
     if (!watterson_configured)
         watterson_init(&watterson, Fs);
 
+    /* Report the fading seed on stderr (stdout may be the sample stream).
+     *
+     * watterson_init() has already seeded the model -- from
+     * MERCURY_WATTERSON_SEED if set, otherwise the clock and pid.  Printing it
+     * is what makes an unpinned run reproducible after the fact: re-run with
+     * MERCURY_WATTERSON_SEED set to this value and the fade replays exactly. */
+    fprintf(stderr, "watterson: fading seed %u%s\n",
+            watterson_get_seed(&watterson),
+            getenv("MERCURY_WATTERSON_SEED") ? " (pinned)" : "");
+
     /* Apply the AWGN level ONCE, after all options are parsed — so --No takes
      * effect regardless of its position relative to a preset/--path (getopt
      * may permute argv, and presets must not bake in a stale No). */


### PR DESCRIPTION
## The bug

`common/watterson.c` draws its Rayleigh taps and AWGN from `rand()`, and **nothing on that path ever called `srand()`**. libc then behaves exactly as if seeded with 1, so every run produces the *identical* fading realisation.

This is worse than a missing feature, because it looks like agreement. Four "independent" runs of a connect sweep at SNR3k −10.8 dB all decoded at +27.107 s with `snr=-5.78`, and were reported as 4/4. It was **one sample printed four times**. Every fading A/B measured through this tool has the defect.

Demonstrated directly on the pre-fix code — two runs of `watterson_test --moderate` are byte-identical:

```
6bdf9e85435fa3c92aa53eb8154897f6  trunk_run1.raw
6bdf9e85435fa3c92aa53eb8154897f6  trunk_run2.raw
```

## Why a private generator, not just an `srand()` call

Ported from mercuryv1's `source/common/os_interop.cc`, reduced to the single glibc TYPE_3 degree Mercury needs and made reentrant (cursors are indices, so the struct is trivially copyable).

- **Reproducible across platforms.** `rand()` is a different generator on glibc, musl, macOS and MinGW — the same seed reproduces a *different* channel on each. A fading measurement nobody else can replay cannot be checked.
- **No shared global state.** `rand()` has one hidden sequence, so any other caller silently reorders the draws the channel sees. State now lives in `watterson_t`, per instance.
- **Hard to leave unseeded.** `watterson_init()` seeds from `MERCURY_WATTERSON_SEED`, else clock XOR pid, and *records* the seed; `watterson_test` prints it, so an unpinned run stays replayable after the fact.

## This is a verified no-behaviour-change

Not merely a plausible one. The uniform draw is deliberately spelled to match the expression it replaced — `(float)rand() / RAND_MAX`, a *float* divide by `(float)2147483647` — and `M_PI` stays a `double` in the Box-Muller step. The Doppler IIR's poles sit within ~1e-4 of the unit circle, so a last-bit difference in the driving noise gives a completely different fade a few thousand samples later.

With the seed pinned to 1 (what unseeded `rand()` effectively was), the new channel is **byte-identical to the old**:

```
  --moderate No=-6   IDENTICAL      --poor No=-6   IDENTICAL      --good No=-6   IDENTICAL
  --moderate No=0    IDENTICAL      --poor No=0    IDENTICAL      --good No=0    IDENTICAL
  --moderate No=-20  IDENTICAL      --poor No=-20  IDENTICAL      --good No=-20  IDENTICAL
```

And afterwards: two unpinned runs differ; two runs at `MERCURY_WATTERSON_SEED=777` are identical.

`utils/chanutil.c` seeded libc rather than the model; it now calls `watterson_seed()`, which is what it always meant.

## Tests

- `tests/common/test_mercury_prng.c` — pins the generator against a **hardcoded** glibc reference stream (hardcoded, not read from the host's `random()`, which would only prove we match *this* libc — the very dependency being removed); proves two instances cannot perturb each other; asserts the uniform draw is bit-exact with the old expression.
- `test_watterson.c` — golden FNV-1a of the seed-1 realisation. The fade depends on the **order and count** of draws, not just the generator, so a refactor that merely moves a draw would otherwise invalidate every pinned measurement without failing anything. This guard already earned its keep: it caught a bug in this PR's own first draft, where reporting the seed *re-seeded* the model after `watterson_add_path()` had already drawn.

Full suite green; `make`, `make -C utils`, `make -C tests` all clean.

## Consequence

Any fading result in this repo's history that was measured through this tool is one realisation, not a sample. They need re-measuring before being relied on — I've already retracted one of my own on that basis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)