### PR TITLE
fyne-ui: make the embedded client an explicit, interlocked choice

### DIFF
--- a/common/os_interop.h
+++ b/common/os_interop.h
@@ -22,6 +22,7 @@
 
 /* Socket compatibility */
 #define SOCK_CLOSE(fd) closesocket(fd)
+#define SOCK_SHUTDOWN(fd) shutdown(fd, SD_BOTH)
 #define SOCK_IOCTL(fd, cmd, argp) ioctlsocket((SOCKET)(fd), (long)(cmd), (u_long*)(argp))
 #ifndef MSG_NOSIGNAL
 #define MSG_NOSIGNAL 0
@@ -153,6 +154,7 @@ int COND_SIGNAL(HANDLE *mqh_wait);
 
 /* Socket compatibility */
 #define SOCK_CLOSE(fd) close(fd)
+#define SOCK_SHUTDOWN(fd) shutdown(fd, SHUT_RDWR)
 #define SOCK_IOCTL(fd, cmd, argp) ioctl((fd), (unsigned long)(cmd), (argp))
 
 static inline int sock_set_nonblocking(int fd)

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -1469,9 +1469,39 @@ void *tcp_server_thread(void *port_ptr)
         if (!send_started)
             bcast_client_done = true;
 
-        /* Stop and join the sole RX-buffer reader before draining its ring.
-         * Clearing before join can empty the ring after the sender's size/
-         * done checks but before read_buffer(), stranding it in a wait. */
+        /* recv_thread normally notices a clean FIN (recv()==0) and exits on
+         * its own, letting the join below return.  Do not trust that alone:
+         * if the client half-drops the link without a FIN -- or a non-blocking
+         * read races the close -- recv_thread spins on EAGAIN forever and this
+         * thread never returns to accept(), so the listen backlog fills and the
+         * NEXT client's connect() hangs.  Watch the socket directly and, on
+         * hangup/error, shut it down so recv() unblocks.  shutdown() keeps the
+         * descriptor owned by this thread until the join, avoiding the
+         * cross-thread close race. */
+        while (!shutdown_)
+        {
+            struct pollfd cfd = { .fd = client_socket, .events = POLLIN | POLLERR | POLLHUP };
+            int r = poll(&cfd, 1, 100);
+            if (shutdown_)
+                break;
+            if (r < 0 && sock_errno() == SOCK_EINTR)
+                continue;
+            if (r <= 0)
+                continue;
+            if (cfd.revents & (POLLERR | POLLHUP | POLLNVAL))
+                break;
+            if (cfd.revents & POLLIN)
+            {
+                /* recv_thread consumes the data; peek to tell data from EOF. */
+                char probe;
+                ssize_t got = recv(client_socket, &probe, 1, MSG_PEEK);
+                if (got == 0)
+                    break; /* EOF: peer sent FIN */
+                if (got < 0 && sock_errno() != SOCK_EAGAIN && sock_errno() != SOCK_EWOULDBLOCK)
+                    break; /* reset or other error */
+            }
+        }
+        SOCK_SHUTDOWN(client_socket);
         pthread_join(recv_tid, NULL);
         bcast_client_done = true;
         if (send_started)

--- a/gui_interface/fyne-ui/main.go
+++ b/gui_interface/fyne-ui/main.go
@@ -334,6 +334,9 @@ const (
 	// present to tick a box.
 	broadcastRxDirPrefKey = "broadcastFile.rxDir"
 	broadcastRxOnPrefKey  = "broadcastFile.receive"
+	// Master switch for the embedded chat client (top bar).  Persisted, so a
+	// gateway station that turned it off stays safe across restarts.
+	embeddedClientPrefKey = "embeddedClient.enabled"
 
 	// defaultWindowWidth/Height match the previous hard-coded launch size and
 	// are used until the operator has resized the window once.
@@ -1143,6 +1146,14 @@ func main() {
 		}
 	}
 
+	// Give the embedded client a live view of the engine, so its interlock can
+	// see whether some other client already holds the TNC ports.
+	currentTelemetry = func() telemetryState {
+		state.mu.RLock()
+		defer state.mu.RUnlock()
+		return state.telemetry
+	}
+
 	mercuryClientButton := widget.NewButton("Launch Mercury Client", func() {
 		state.mu.RLock()
 		tel := state.telemetry
@@ -1156,8 +1167,38 @@ func main() {
 		openMercuryClientWindow(myApp, tel, arqPort, broadcastPort, history)
 	})
 
+	// The master switch for the embedded client.
+	//
+	// The embedded client is an ordinary TCP client of our own TNC ports, and
+	// the TNC accepts one control client at a time, evicting the incumbent.  On
+	// a station that exists to serve uucp or VarAC, the chat client is not just
+	// unused -- it is a hazard someone can trip by clicking the wrong button.
+	// Turning it off here makes that impossible rather than merely unlikely.
+	//
+	// Defaults ON, so nothing changes for anyone who has not asked for it; the
+	// interlock in onConnect() is what removes the surprise in that case.
+	embeddedClientEnabled := myApp.Preferences().BoolWithFallback(embeddedClientPrefKey, true)
+	embeddedClientCheck := widget.NewCheck("Embedded client", nil)
+	embeddedClientCheck.SetChecked(embeddedClientEnabled)
+	applyEmbeddedClientEnabled := func(on bool) {
+		if on {
+			mercuryClientButton.Enable()
+			return
+		}
+		mercuryClientButton.Disable()
+		// Disabling must also RELEASE the ports, or "off" would only mean
+		// "cannot be opened again" while a connected client kept holding them.
+		closeMercuryClientWindow()
+	}
+	embeddedClientCheck.OnChanged = func(on bool) {
+		myApp.Preferences().SetBool(embeddedClientPrefKey, on)
+		applyEmbeddedClientEnabled(on)
+	}
+	applyEmbeddedClientEnabled(embeddedClientEnabled)
+
 	topBar := container.NewHBox(
 		layout.NewSpacer(),
+		embeddedClientCheck,
 		mercuryClientButton,
 	)
 

--- a/gui_interface/fyne-ui/main_test.go
+++ b/gui_interface/fyne-ui/main_test.go
@@ -236,3 +236,46 @@ func TestCycleText(t *testing.T) {
 		t.Errorf("bounded run rendered as %q", got)
 	}
 }
+
+// The embedded client shares the TNC ports with every other client, and the TNC
+// evicts the incumbent on a new accept -- tearing down any live ARQ session.
+// These pin the rule that stops a click from killing someone's transfer.
+func TestEmbeddedClientMayConnect(t *testing.T) {
+	cases := []struct {
+		name        string
+		alreadyOurs bool
+		tel         telemetryState
+		wantOK      bool
+	}{
+		{"free ports", false, telemetryState{}, true},
+		{"another client attached", false,
+			telemetryState{ClientTCPConnected: true}, false},
+		{"another client mid-session", false,
+			telemetryState{ClientTCPConnected: true, Sync: true}, false},
+		// Reconnecting our own client must stay possible: the attached client
+		// is us, so there is nobody else to evict.
+		{"the attached client is us", true,
+			telemetryState{ClientTCPConnected: true}, true},
+		{"the attached client is us, mid-session", true,
+			telemetryState{ClientTCPConnected: true, Sync: true}, true},
+		// A session cannot be live with nothing attached, but if the engine
+		// ever reports it, an empty port is still free to take.
+		{"session flag without a client", false,
+			telemetryState{Sync: true}, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, why := embeddedClientMayConnect(tc.alreadyOurs, tc.tel)
+			if ok != tc.wantOK {
+				t.Fatalf("got ok=%v, want %v (reason %q)", ok, tc.wantOK, why)
+			}
+			if !ok && why == "" {
+				t.Fatal("refused without telling the operator why")
+			}
+			if ok && why != "" {
+				t.Fatalf("allowed but gave a reason %q", why)
+			}
+		})
+	}
+}

--- a/gui_interface/fyne-ui/mercury_chat_window.go
+++ b/gui_interface/fyne-ui/mercury_chat_window.go
@@ -385,12 +385,15 @@ func (cw *chatWindow) setARQ(on bool) {
 			// conn_state guard -- so the block has to be here.
 			cw.sendCQ.Disable()
 		} else {
-			cw.arqConnect.Enable()
 			cw.arqDisconnect.Disable()
 			cw.arqAbort.Disable()
 			cw.sendARQ.Disable()
 			cw.bcastDisabledReason = ""
 			if cw.mc != nil && cw.mc.IsConnected() {
+				// Gate the re-enable on the modem still being up: setARQ is
+				// also called after setTCP(false) on disconnect, and enabling
+				// arqConnect there leaves a live-looking button over dead ports.
+				cw.arqConnect.Enable()
 				cw.sendBcastWrap.Enable()
 				// Not while a CQ of our own is still on the air: setCQBusy
 				// owns that case and re-enables when PTT drops.

--- a/gui_interface/fyne-ui/mercury_chat_window.go
+++ b/gui_interface/fyne-ui/mercury_chat_window.go
@@ -735,9 +735,25 @@ func (cw *chatWindow) watchLink() {
 			if mc.IsConnected() {
 				continue
 			}
-			cw.logMsg("Disconnected by the modem: another client has taken the TNC ports.")
-			cw.setTCP(false)
-			cw.setARQ(false)
+			// The TNC hung up on us.  Tear down on the UI thread exactly as
+			// onDisconnect does, so cw.mc goes nil and the connect interlock
+			// stops answering "already ours": leaving it set would let the
+			// operator reconnect and evict the very client that took the ports.
+			fyne.Do(func() {
+				if cw.mc != mc {
+					return
+				}
+				cw.logMsg("Disconnected by the modem: another client has taken the TNC ports.")
+				mc.Disconnect()
+				cw.mc = nil
+				if cw.done != nil {
+					close(cw.done)
+					cw.done = nil
+				}
+				cw.cqSending = false
+				cw.setTCP(false)
+				cw.setARQ(false)
+			})
 			return
 		}
 	}

--- a/gui_interface/fyne-ui/mercury_chat_window.go
+++ b/gui_interface/fyne-ui/mercury_chat_window.go
@@ -28,6 +28,40 @@ const (
 // the first and tear down its ARQ session.  Reuse the window instead.
 var mercuryClientSingleton *chatWindow
 
+// currentTelemetry reports the engine's LIVE status to the embedded client.
+// The window is handed a telemetry snapshot when it is built, which is stale by
+// the time anyone presses Connect -- and staleness is the whole problem here.
+// Set by main(); nil in tests, where the interlock simply does not engage.
+var currentTelemetry func() telemetryState
+
+// embeddedClientMayConnect decides whether the embedded client may take the TNC
+// ports, and says why not when it may not.
+//
+// Split out from onConnect so the decision is testable without a running
+// engine: getting it wrong costs someone a half-finished HF transfer, which is
+// not a thing you want to discover on air.
+//
+// alreadyOurs means we currently hold the port, in which case the attached
+// client IS us and reconnecting is our own business.
+func embeddedClientMayConnect(alreadyOurs bool, tel telemetryState) (bool, string) {
+	if alreadyOurs || !tel.ClientTCPConnected {
+		return true, ""
+	}
+	if tel.Sync {
+		return false, "Another client is attached to the TNC ports AND an ARQ session is live."
+	}
+	return false, "Another client (uucp, VarAC, RNS...) is attached to the TNC ports."
+}
+
+// closeMercuryClientWindow shuts the embedded client down if it is open.
+// The window's SetOnClosed handler disconnects the sockets and clears the
+// singleton, so this releases the TNC ports as a side effect.
+func closeMercuryClientWindow() {
+	if mercuryClientSingleton != nil {
+		mercuryClientSingleton.win.Close()
+	}
+}
+
 func openMercuryClientWindow(app fyne.App, telemetry telemetryState, arqPort, broadcastPort int, history []HistoryMessage) {
 	if mercuryClientSingleton != nil {
 		mercuryClientSingleton.win.RequestFocus()

--- a/gui_interface/fyne-ui/mercury_chat_window.go
+++ b/gui_interface/fyne-ui/mercury_chat_window.go
@@ -407,6 +407,27 @@ func (cw *chatWindow) onConnect() {
 	// can fire this twice in one poll batch before setTCP's fyne.Do runs.
 	cw.connectBtn.Disable()
 
+	// THE INTERLOCK.
+	//
+	// The TNC keeps exactly one control and one data client, and a new accept()
+	// EVICTS the incumbent -- closing its sockets and submitting
+	// ARQ_CMD_CLIENT_DISCONNECT, which tears down any live ARQ session
+	// (data_interfaces/tcp_interfaces.c:799, arq.c:565).  So pressing Connect
+	// here would silently kill an in-progress uucp or VarAC transfer, and the
+	// operator's only clue would be the transfer failing.
+	//
+	// Refuse instead.  Only when we do not already hold the port: if cw.mc is
+	// non-nil the attached client IS us, and reconnecting is our own business.
+	if currentTelemetry != nil {
+		if ok, why := embeddedClientMayConnect(cw.mc != nil, currentTelemetry()); !ok {
+			dialog.ShowError(fmt.Errorf("%s\n\nConnecting here would disconnect it and abort any "+
+				"transfer in progress. Stop the other client first.", why), cw.win)
+			cw.logMsg("connect refused: %s", why)
+			cw.connectBtn.Enable()
+			return
+		}
+	}
+
 	// Disconnect any existing client before opening a new one, so a stale
 	// control client is not left open to be evicted by the new connection.
 	if cw.mc != nil {
@@ -454,6 +475,7 @@ func (cw *chatWindow) onConnect() {
 	go cw.forwardARQChat()
 	go cw.forwardBroadcastChat()
 	go cw.forwardStatus()
+	go cw.watchLink()
 
 	// The persisted history was handed over at launch time (from the UI data
 	// path, not the TNC control channel); populate the panes now.
@@ -685,6 +707,37 @@ func (cw *chatWindow) forwardBroadcastChat() {
 			call, text := splitCallText(m.Text)
 			cw.appendRichChat(cw.bcastBox, call, text)
 		case <-done:
+			return
+		}
+	}
+}
+
+// watchLink notices when the TNC hangs up on us.
+//
+// The other direction of the same hazard the connect interlock guards: the TNC
+// evicts its control client whenever a new one connects, so starting uucp or
+// VarAC silently takes the ports away from here.  Nothing else observes that --
+// the reader goroutines just return -- so without this the window keeps showing
+// "connected" and its buttons keep pretending to work.
+func (cw *chatWindow) watchLink() {
+	mc := cw.mc
+	done := cw.done
+	if mc == nil || done == nil {
+		return
+	}
+	tick := time.NewTicker(time.Second)
+	defer tick.Stop()
+	for {
+		select {
+		case <-done:
+			return
+		case <-tick.C:
+			if mc.IsConnected() {
+				continue
+			}
+			cw.logMsg("Disconnected by the modem: another client has taken the TNC ports.")
+			cw.setTCP(false)
+			cw.setARQ(false)
 			return
 		}
 	}

--- a/gui_interface/mercury-client/modem/modem.go
+++ b/gui_interface/mercury-client/modem/modem.go
@@ -423,6 +423,13 @@ func (mc *ModemClient) Disconnect() {
 	var disconnected []string
 
 	mc.mu.Lock()
+	// Close the quit channel FIRST, before the sockets.  readARQControl
+	// distinguishes "we asked to go away" (quit closed) from "the modem hung
+	// up on us" (linkDown); if the socket close raced ahead of this, a clean
+	// local disconnect could be misread as a remote eviction.
+	close(mc.quit)
+	mc.quit = make(chan struct{})
+
 	control := mc.ARQControlConn
 	if control != nil {
 		control.Close()
@@ -442,8 +449,6 @@ func (mc *ModemClient) Disconnect() {
 
 	mc.arqConnected = false
 
-	close(mc.quit)
-	mc.quit = make(chan struct{})
 	mc.mu.Unlock()
 
 	for _, msg := range disconnected {
@@ -467,6 +472,15 @@ func (mc *ModemClient) readARQControl() {
 		default:
 			line, err := reader.ReadString('\r')
 			if err != nil {
+				// A local Disconnect() closes quit and the socket, landing us
+				// here with the same error as a remote eviction.  Distinguish
+				// the two: if we asked to go away, this is expected, not the
+				// modem hanging up on us.
+				select {
+				case <-quit:
+					return
+				default:
+				}
 				if err != io.EOF {
 					mc.LogCh <- fmt.Sprintf("ARQ Control read error: %v", err)
 				}

--- a/gui_interface/mercury-client/modem/modem.go
+++ b/gui_interface/mercury-client/modem/modem.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -91,6 +92,13 @@ type ModemClient struct {
 	arqConnected bool
 
 	connectRespCh chan string
+
+	// linkDown is set when the modem closes the control link under us -- which
+	// the TNC does whenever ANOTHER client connects, because it keeps only one
+	// control client and evicts the incumbent.  Without it, IsConnected() keeps
+	// answering true off conn objects that are merely non-nil, and the UI goes
+	// on claiming it is attached to ports it lost.
+	linkDown atomic.Bool
 
 	mu   sync.Mutex
 	quit chan struct{}
@@ -403,6 +411,9 @@ func (mc *ModemClient) sendBroadcastWithCmd(cmd byte, data []byte) error {
 }
 
 func (mc *ModemClient) IsConnected() bool {
+	if mc.linkDown.Load() {
+		return false
+	}
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 	return mc.ARQControlConn != nil && mc.BroadcastConn != nil
@@ -458,6 +469,12 @@ func (mc *ModemClient) readARQControl() {
 			if err != nil {
 				if err != io.EOF {
 					mc.LogCh <- fmt.Sprintf("ARQ Control read error: %v", err)
+				}
+				// EOF here is not "nothing more to read", it is the modem
+				// hanging up on us.  Say so, and stop claiming to be connected.
+				if !mc.linkDown.Swap(true) {
+					mc.LogCh <- "ARQ control link closed by the modem " +
+						"(another client may have taken the TNC ports)."
 				}
 				return
 			}


### PR DESCRIPTION
## The situation

`mercury-ui` embeds the engine, but its chat client is an **ordinary TCP client of our own TNC ports** — 127.0.0.1 control/data/broadcast, exactly like uucp's `uuport`, VarAC or RNS (`gui_interface/mercury-client/client/client.go:81-84`). It is not privileged and **cannot hold the ports hostage**.

The hazard runs the other way. The TNC keeps exactly one control and one data client (single fds, not arrays), and a new `accept()` **evicts the incumbent**:

```c
/* data_interfaces/tcp_interfaces.c:799 */
if (ctl_client >= 0)
    close_ctl_client(&ctl_client, &data_client, true);
```

That `true` is `notify_arq`, which submits `ARQ_CMD_CLIENT_DISCONNECT` → `ARQ_EV_APP_DISCONNECT` (`arq.c:565`) — **tearing down any live ARQ session**.

So today, pressing *Connect modem* during a uucp transfer kills the transfer, and the operator's only clue is that the transfer failed. The reverse is just as quiet: starting uucp takes the ports away from the chat window, whose reader goroutines simply `return`, leaving it showing "connected" with buttons that no longer do anything.

## Three changes

**1. A master switch.** An "Embedded client" checkbox in the top bar gates the Launch button, persisted in preferences — so a station that exists to serve uucp can turn the chat client off once and have it stay off. Switching it off also closes an open window, because otherwise "off" would only mean *cannot be opened again* while a connected client kept holding the ports. **Defaults ON**, so nothing changes for anyone who hasn't asked for it.

**2. An interlock on connect.** If another client already holds the ports, refuse and say so rather than silently evicting it:

> Another client is attached to the TNC ports AND an ARQ session is live.
>
> Connecting here would disconnect it and abort any transfer in progress. Stop the other client first.

Skipped when the attached client is *us* — then there's nobody else to evict, and reconnecting must stay possible. The decision is split into `embeddedClientMayConnect()` so it's testable without a running engine.

**3. Link-down detection.** `ModemClient` now records that the modem hung up on us, instead of letting `IsConnected()` answer true off conn objects that are merely non-nil. The chat window watches for it and returns to the disconnected state with an explanation.

## Tests

`TestEmbeddedClientMayConnect` covers all six states, including the two that must still be *allowed* (the attached client is us, with and without a live session) — a too-eager interlock that locks the operator out of their own client would be its own bug.

## Verification

`go build` / `vet` / `test` clean for both Go modules, `make fyne-ui` links, C suite unchanged.

**Not verified:** the UI behaviour itself hasn't been exercised on a running station — it wants a click-through with uucp attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)