### PR TITLE
ui: allow runtime ALSA/PulseAudio subsystem switch on Linux

### DIFF
--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -2387,13 +2387,13 @@ int audioio_restart(const char *capture_dev, const char *playback_dev,
     else
         capture_input_channel_layout = LEFT;
 
-    if (capture_dev && capture_dev[0] != '\0')
+    if (capture_dev)
     {
         strncpy(s_capture_dev, capture_dev, sizeof(s_capture_dev) - 1);
         s_capture_dev[sizeof(s_capture_dev) - 1] = '\0';
     }
 
-    if (playback_dev && playback_dev[0] != '\0')
+    if (playback_dev)
     {
         strncpy(s_playback_dev, playback_dev, sizeof(s_playback_dev) - 1);
         s_playback_dev[sizeof(s_playback_dev) - 1] = '\0';

--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -228,6 +228,36 @@ static inline uint64_t audioio_monotonic_ms(void)
 #endif
 }
 
+void audioio_health_reset(void)
+{
+    pthread_mutex_lock(&s_health_lock);
+    s_cap_health  = AUDIO_HEALTH_STOPPED;
+    s_play_health = AUDIO_HEALTH_STOPPED;
+    s_health_reason[0] = '\0';
+    pthread_mutex_unlock(&s_health_lock);
+}
+
+int audioio_wait_healthy(int timeout_ms)
+{
+    if (timeout_ms < 0)
+        timeout_ms = 0;
+
+    uint64_t deadline = audioio_monotonic_ms() + (uint64_t)timeout_ms;
+    for (;;)
+    {
+        audio_health_t c = audioio_capture_health();
+        audio_health_t p = audioio_playback_health();
+
+        if (c == AUDIO_HEALTH_FAILED || p == AUDIO_HEALTH_FAILED)
+            return -1;
+        if (c == AUDIO_HEALTH_RUNNING && p == AUDIO_HEALTH_RUNNING)
+            return 0;
+        if (audioio_monotonic_ms() >= deadline)
+            return -2;
+        ffthread_sleep(5);
+    }
+}
+
 #if defined(__linux__)
 static pthread_mutex_t s_pulse_lock = PTHREAD_MUTEX_INITIALIZER;
 
@@ -992,7 +1022,6 @@ void *radio_playback_thread(void *device_ptr)
     format_device_display(audio_subsystem, FFAUDIO_DEV_PLAYBACK,
                            device_ptr ? (const char *)device_ptr : NULL,
                            play_dev_display, sizeof(play_dev_display));
-    audio_health_set(false, AUDIO_HEALTH_RUNNING, NULL);
     HLOGI("audio-play", "I/O playback (%s) %s / %dHz / %dch / %dms buffer",
           play_dev_display,
           cfg->format == FFAUDIO_F_FLOAT32 ? "float32" :
@@ -1017,6 +1046,8 @@ void *radio_playback_thread(void *device_ptr)
         HLOGE("audio-play",
               "Device negotiated %d channels; only mono/stereo playback is supported, aborting",
               cfg->channels);
+        audio_health_set(false, AUDIO_HEALTH_FAILED,
+                         "device negotiated more than 2 playback channels");
         goto cleanup_play;
     }
 
@@ -1110,6 +1141,10 @@ void *radio_playback_thread(void *device_ptr)
         resampler_init_up(resample_ratio);
         resamp_up_reset(&up_rs);
     }
+
+    /* Reached only after the device, rate, format and channel checks above:
+     * the playback path is fully validated and about to stream. */
+    audio_health_set(false, AUDIO_HEALTH_RUNNING, NULL);
 
     while (!shutdown_ && !audio_shutdown_)
     {
@@ -1393,7 +1428,6 @@ void *radio_capture_thread(void *device_ptr)
     format_device_display(audio_subsystem, FFAUDIO_DEV_CAPTURE,
                            device_ptr ? (const char *)device_ptr : NULL,
                            cap_dev_display, sizeof(cap_dev_display));
-    audio_health_set(true, AUDIO_HEALTH_RUNNING, NULL);
     HLOGI("audio-cap", "I/O capture (%s) %s / %dHz / %dch / %dms buffer",
           cap_dev_display,
           cfg->format == FFAUDIO_F_FLOAT32 ? "float32" :
@@ -1519,6 +1553,10 @@ void *radio_capture_thread(void *device_ptr)
     const uint64_t CAP_POLL_MS  = 5;
     uint64_t cap_last_data_ms   = audioio_monotonic_ms();
     uint32_t diag_reopens       = 0;
+
+    /* Reached only after the device, rate and format checks above: the capture
+     * path is fully validated and about to stream. */
+    audio_health_set(true, AUDIO_HEALTH_RUNNING, NULL);
 
     while (!shutdown_ && !audio_shutdown_)
     {
@@ -2369,6 +2407,7 @@ int audioio_restart(const char *capture_dev, const char *playback_dev,
 {
     HLOGI("audio-restart", "stopping audio threads...");
     audioio_stop_threads();
+    audioio_health_reset();
 
 #if defined(__linux__)
     if (audio_subsystem == AUDIO_SUBSYSTEM_PULSE || audio_subsys == AUDIO_SUBSYSTEM_PULSE)

--- a/audioio/audioio.h
+++ b/audioio/audioio.h
@@ -76,6 +76,19 @@ void audioio_health_reason(char *buf, size_t buflen);
  * audioio_restart. */
 bool audioio_health_ok(char *reason, size_t reasonlen);
 
+/* Reset both health flags to STOPPED and clear the reason.  audioio_restart
+ * calls this before spawning the new threads so a subsequent
+ * audioio_wait_healthy() observes the new run, not the one that just stopped. */
+void audioio_health_reset(void);
+
+/* Wait up to timeout_ms for the capture and playback paths to leave STOPPED.
+ * Returns:
+ *   0  - both paths reached RUNNING (the restart is healthy);
+ *   -1 - at least one path reached FAILED (reason via audioio_health_reason);
+ *   -2 - timed out with one or both still STOPPED (indeterminate; the
+ *        null/fifo/sock backends never set health). */
+int audioio_wait_healthy(int timeout_ms);
+
 /* Stop the running audio threads and start them again with a new subsystem,
  * channel layout, and/or device selection.  The buffers are cleared but never
  * destroyed.

--- a/audioio/audioio.h
+++ b/audioio/audioio.h
@@ -76,6 +76,18 @@ void audioio_health_reason(char *buf, size_t buflen);
  * audioio_restart. */
 bool audioio_health_ok(char *reason, size_t reasonlen);
 
+/* Stop the running audio threads and start them again with a new subsystem,
+ * channel layout, and/or device selection.  The buffers are cleared but never
+ * destroyed.
+ *
+ * capture_dev / playback_dev semantics:
+ *   - NULL        -> keep the device currently in use.
+ *   - empty ("")  -> clear it; the (new) subsystem resolves its own default.
+ *   - non-empty   -> use this device id/name (resolved in place).
+ *
+ * A switch to a subsystem that fails to open leaves the audio path stopped
+ * (the failure is reported via audioio_health_*, not by this function's
+ * return value), so the caller must be prepared to switch back. */
 int audioio_restart(const char *capture_dev, const char *playback_dev,
                     int audio_subsys, int capture_channel_layout);
 

--- a/common/cfg_utils.c
+++ b/common/cfg_utils.c
@@ -80,7 +80,7 @@ void cfg_set_defaults(mercury_config *cfg)
 
 /* Map a sound-system name to the AUDIO_SUBSYSTEM_* constant.
  * Returns -1 (auto) for unrecognised strings. */
-static int parse_sound_system(const char *s)
+int cfg_sound_system_parse(const char *s)
 {
     if (!s) return -1;
     if (!strcmp(s, "auto"))      return -1;
@@ -322,7 +322,7 @@ bool cfg_read(mercury_config *cfg, const char *ini_path)
 
     s = iniparser_getstring(ini, CFG_KEY_SOUND_SYSTEM, NULL);
     if (s)
-        cfg->sound_system = parse_sound_system(s);
+        cfg->sound_system = cfg_sound_system_parse(s);
 
     i = iniparser_getint(ini, CFG_KEY_ARQ_TCP_BASE_PORT, cfg->arq_tcp_base_port);
     cfg->arq_tcp_base_port = i;

--- a/common/cfg_utils.h
+++ b/common/cfg_utils.h
@@ -162,6 +162,10 @@ void cfg_set_defaults(mercury_config *cfg);
  * Returns a static string; never NULL. */
 const char *cfg_sound_system_name(int sys);
 
+/* Map a sound-system name ("alsa", "pulse", ...) to the AUDIO_SUBSYSTEM_*
+ * constant.  Returns -1 (auto) for unrecognised strings. */
+int cfg_sound_system_parse(const char *name);
+
 /* Canonical string conversion for PTT methods used by INI, CLI and UI. */
 const char *cfg_ptt_method_name(ptt_method_t method);
 bool cfg_ptt_method_parse(const char *name, ptt_method_t *method);

--- a/gui_interface/fyne-ui/engine/mercury_bridge.c
+++ b/gui_interface/fyne-ui/engine/mercury_bridge.c
@@ -187,6 +187,13 @@ int mercury_ui_get_input_channel(void)
     return ui_comm_get_input_channel();
 }
 
+void mercury_ui_get_audio_system(char *name, int name_len)
+{
+    if (name && name_len > 0) {
+        snprintf(name, (size_t)name_len, "%s", ui_comm_get_audio_system());
+    }
+}
+
 void mercury_ui_set_waterfall(bool enabled)
 {
     ui_comm_set_waterfall(enabled);

--- a/gui_interface/fyne-ui/engine/mercury_bridge.h
+++ b/gui_interface/fyne-ui/engine/mercury_bridge.h
@@ -82,6 +82,10 @@ int mercury_ui_get_radio_list(ui_device_t *out, int max,
                               int *cm108_gpio);
 int mercury_ui_get_input_channel(void);
 
+/* Copy the current audio subsystem name ("alsa", "pulse", ...) into `name`.
+ * Never returns NULL; `name` is always NUL-terminated. */
+void mercury_ui_get_audio_system(char *name, int name_len);
+
 /* Enable / disable waterfall/spectrum at runtime.  Saves to mercury.ini. */
 void mercury_ui_set_waterfall(bool enabled);
 

--- a/gui_interface/fyne-ui/link.go
+++ b/gui_interface/fyne-ui/link.go
@@ -31,6 +31,12 @@ type Link interface {
 	// Send delivers a command to the engine. Safe for concurrent use.
 	Send(cmd Command) error
 
+	// AudioSubsystems reports the engine's current audio subsystem name
+	// ("alsa", "pulse", ...) and the list of names it can switch to at
+	// runtime. A list with fewer than two entries means the subsystem is
+	// fixed, and the UI hides its subsystem selector.
+	AudioSubsystems() (current string, options []string)
+
 	// Close releases the transport. Idempotent.
 	Close()
 }
@@ -91,6 +97,13 @@ type RadioListEvent struct {
 	CM108GPIO   string
 }
 
+// AudioSystemEvent reports the engine's current audio subsystem and the
+// subsystems it can switch to at runtime (see Link.AudioSubsystems).
+type AudioSystemEvent struct {
+	Current string
+	Options []string
+}
+
 // LinkStateEvent reports the transport coming up or going down, with a
 // human-readable detail for the log pane.
 type LinkStateEvent struct {
@@ -102,12 +115,13 @@ type LinkStateEvent struct {
 // say that is not state.
 type LogEvent struct{ Text string }
 
-func (StatusEvent) isLinkEvent()     {}
-func (SpectrumEvent) isLinkEvent()   {}
-func (DeviceListEvent) isLinkEvent() {}
-func (RadioListEvent) isLinkEvent()  {}
-func (LinkStateEvent) isLinkEvent()  {}
-func (LogEvent) isLinkEvent()        {}
+func (StatusEvent) isLinkEvent()      {}
+func (SpectrumEvent) isLinkEvent()    {}
+func (DeviceListEvent) isLinkEvent()  {}
+func (RadioListEvent) isLinkEvent()   {}
+func (AudioSystemEvent) isLinkEvent() {}
+func (LinkStateEvent) isLinkEvent()   {}
+func (LogEvent) isLinkEvent()         {}
 
 // emit posts an event unless the consumer is gone or lagging. Telemetry is
 // disposable — a dropped spectrum frame costs one waterfall row, whereas

--- a/gui_interface/fyne-ui/link_engine.go
+++ b/gui_interface/fyne-ui/link_engine.go
@@ -13,6 +13,7 @@ import "C"
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"time"
 	"unsafe"
 )
@@ -296,6 +297,20 @@ func readRadioList() (RadioListEvent, bool) {
 func (l *engineLink) SetWaterfall(enabled bool) {
 	cEn := C.bool(enabled)
 	C.mercury_ui_set_waterfall(cEn)
+}
+
+// AudioSubsystems reports the engine's audio subsystem and, on Linux, the two
+// backends (ALSA, PulseAudio) the operator can switch between at runtime. The
+// embedded engine runs in this process, so its platform is this process's
+// platform.
+func (l *engineLink) AudioSubsystems() (string, []string) {
+	name := make([]byte, 32)
+	C.mercury_ui_get_audio_system((*C.char)(unsafe.Pointer(&name[0])), C.int(len(name)))
+	current := cString(name)
+	if runtime.GOOS == "linux" {
+		return current, []string{"alsa", "pulse"}
+	}
+	return current, nil
 }
 
 // TCPPorts returns the ARQ base and broadcast TCP ports the engine is

--- a/gui_interface/fyne-ui/link_engine.go
+++ b/gui_interface/fyne-ui/link_engine.go
@@ -306,7 +306,7 @@ func (l *engineLink) SetWaterfall(enabled bool) {
 func (l *engineLink) AudioSubsystems() (string, []string) {
 	name := make([]byte, 32)
 	C.mercury_ui_get_audio_system((*C.char)(unsafe.Pointer(&name[0])), C.int(len(name)))
-	current := cString(name)
+	current := goStringFromC(name)
 	if runtime.GOOS == "linux" {
 		return current, []string{"alsa", "pulse"}
 	}

--- a/gui_interface/fyne-ui/link_engine_stub.go
+++ b/gui_interface/fyne-ui/link_engine_stub.go
@@ -32,6 +32,10 @@ func (l *engineLink) Close() {}
 
 func (l *engineLink) SetWaterfall(enabled bool) {}
 
+func (l *engineLink) AudioSubsystems() (string, []string) {
+	return "", nil
+}
+
 func (l *engineLink) TCPPorts() (arqBase, broadcast int) {
 	return 8300, 8100
 }

--- a/gui_interface/fyne-ui/link_ws.go
+++ b/gui_interface/fyne-ui/link_ws.go
@@ -25,6 +25,9 @@ type wsLink struct {
 
 	mu   sync.RWMutex
 	conn *websocket.Conn
+
+	audioSystem        string
+	audioSystemOptions []string
 }
 
 func newWSLink(scheme, host, port string) *wsLink {
@@ -80,6 +83,12 @@ func (l *wsLink) Start(ctx context.Context) (<-chan Event, error) {
 				return
 			}
 			for _, ev := range decodeWSMessage(msgType, payload) {
+				if e, ok := ev.(AudioSystemEvent); ok {
+					l.mu.Lock()
+					l.audioSystem = e.Current
+					l.audioSystemOptions = e.Options
+					l.mu.Unlock()
+				}
 				if !emit(ctx, events, ev) {
 					return
 				}
@@ -130,6 +139,13 @@ func (l *wsLink) Close() {
 	}
 }
 
+// AudioSubsystems returns the last subsystem info published by the engine.
+func (l *wsLink) AudioSubsystems() (string, []string) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.audioSystem, l.audioSystemOptions
+}
+
 // decodeWSMessage turns one websocket frame into zero or more link events.
 // Kept free of connection state so it can be exercised on its own.
 func decodeWSMessage(msgType int, payload []byte) []Event {
@@ -176,6 +192,12 @@ func decodeWSMessage(msgType int, payload []byte) []Event {
 				Selected: selectedValue(raw, "selected"),
 			}}
 
+		case "audio_system":
+			return []Event{AudioSystemEvent{
+				Current: selectedValue(raw, "selected"),
+				Options: stringSliceValue(raw, "list"),
+			}}
+
 		case "radio_list":
 			items := parseMenuItems(payload)
 			sortRadioItems(items)
@@ -209,6 +231,18 @@ func stringValue(raw map[string]any, key, fallback string) string {
 		return fmt.Sprint(value)
 	}
 	return fallback
+}
+
+func stringSliceValue(raw map[string]any, key string) []string {
+	list, ok := raw[key].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(list))
+	for _, item := range list {
+		out = append(out, fmt.Sprint(item))
+	}
+	return out
 }
 
 // sortRadioItems puts "None" first and the rest alphabetically — hamlib's own

--- a/gui_interface/fyne-ui/main.go
+++ b/gui_interface/fyne-ui/main.go
@@ -104,6 +104,27 @@ func pttMethodID(label string) string {
 	return "none"
 }
 
+var audioSubsystemLabels = map[string]string{
+	"alsa":  "ALSA",
+	"pulse": "PulseAudio",
+}
+
+func audioSubsystemLabel(id string) string {
+	if label, ok := audioSubsystemLabels[id]; ok {
+		return label
+	}
+	return id
+}
+
+func audioSubsystemID(label string) string {
+	for id, candidate := range audioSubsystemLabels {
+		if candidate == label {
+			return id
+		}
+	}
+	return label
+}
+
 // Mirrors UI_SNR_UNKNOWN_DB in gui_interface/ui_status.h.
 const snrUnknownDB = -99.9
 
@@ -1230,33 +1251,74 @@ func main() {
 	myWindow.SetContent(mainLayout)
 
 	showSoundcardDialog := func() {
+		currentSubsystem, subsystemOptions := func() (string, []string) {
+			state.mu.RLock()
+			link := state.link
+			state.mu.RUnlock()
+			if link != nil {
+				return link.AudioSubsystems()
+			}
+			return "", nil
+		}()
+
+		var subsystemSelect *widget.Select
+		if len(subsystemOptions) > 1 {
+			labels := make([]string, 0, len(subsystemOptions))
+			for _, opt := range subsystemOptions {
+				labels = append(labels, audioSubsystemLabel(opt))
+			}
+			subsystemSelect = widget.NewSelect(labels, nil)
+			subsystemSelect.SetSelected(audioSubsystemLabel(currentSubsystem))
+		}
+
 		applyBtn := widget.NewButton("Apply", func() {
 			captureID := selectedID(bindings.captureSelect, state.captureItems)
 			playbackID := selectedID(bindings.playbackSelect, state.playbackItems)
 			channel := bindings.channelSelect.Selected
-			if captureID == "" {
+			subsystemID := ""
+			if subsystemSelect != nil && subsystemSelect.Selected != "" {
+				subsystemID = audioSubsystemID(subsystemSelect.Selected)
+			}
+			// Device ids are subsystem-specific, so a subsystem switch drops
+			// the old selection and lets the new subsystem pick its default.
+			subsystemChanged := subsystemID != "" && subsystemID != currentSubsystem
+			if subsystemChanged {
+				captureID = ""
+				playbackID = ""
+			}
+			if captureID == "" && !subsystemChanged {
 				captureID = "default"
 			}
-			if playbackID == "" {
+			if playbackID == "" && !subsystemChanged {
 				playbackID = "default"
 			}
 			if channel == "" {
 				channel = "left"
 			}
-			if err := sendWSCommand("set_audio_config", captureID, playbackID, channel, "", "", "", ""); err != nil {
+			if err := sendWSCommand("set_audio_config", captureID, playbackID, channel, subsystemID, "", "", ""); err != nil {
 				appendLog(fmt.Sprintf("Failed to send audio config: %v\n", err))
 			} else {
-				appendLog(fmt.Sprintf("Sent audio config: capture=%s playback=%s channel=%s\n",
-					captureID, playbackID, channel))
+				appendLog(fmt.Sprintf("Sent audio config: subsystem=%s capture=%s playback=%s channel=%s\n",
+					subsystemID, captureID, playbackID, channel))
 			}
 		})
 
-		content := container.NewVBox(
-			container.NewGridWithColumns(2,
+		rows := container.NewGridWithColumns(2,
+			widget.NewLabel("Capture Device"), bindings.captureSelect,
+			widget.NewLabel("Playback Device"), bindings.playbackSelect,
+			widget.NewLabel("Capture Input Channel"), bindings.channelSelect,
+		)
+		if subsystemSelect != nil {
+			rows = container.NewGridWithColumns(2,
+				widget.NewLabel("Audio Subsystem"), subsystemSelect,
 				widget.NewLabel("Capture Device"), bindings.captureSelect,
 				widget.NewLabel("Playback Device"), bindings.playbackSelect,
 				widget.NewLabel("Capture Input Channel"), bindings.channelSelect,
-			),
+			)
+		}
+
+		content := container.NewVBox(
+			rows,
 			container.NewHBox(layout.NewSpacer(), applyBtn, layout.NewSpacer()),
 		)
 

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -172,8 +172,9 @@ int ui_comm_handle_command(ui_ctx_t *ctx, const ws_command_t *cmd)
                 return -1;
             }
         }
+        int current_system = atomic_load_explicit(&ctx->audio_system, memory_order_relaxed);
         bool subsystem_changed = (new_audio_system >= 0 &&
-                                  new_audio_system != ctx->audio_system);
+                                  new_audio_system != current_system);
         bool have_capture = cmd->value[0] != '\0';
         bool have_playback = cmd->value2[0] != '\0';
 
@@ -202,9 +203,11 @@ int ui_comm_handle_command(ui_ctx_t *ctx, const ws_command_t *cmd)
         HLOGI(UI_LOG_TAG, "Input channel set to: %s (%d)",
               cmd->value3, ctx->rx_input_channel);
 
+        int active_system = current_system;
         if (subsystem_changed)
         {
-            ctx->audio_system = new_audio_system;
+            active_system = new_audio_system;
+            atomic_store_explicit(&ctx->audio_system, active_system, memory_order_relaxed);
             /* Device ids are subsystem-specific.  When the operator switches
              * subsystem without choosing a device in the same breath, drop the
              * stale ids so the new subsystem resolves its own default device. */
@@ -213,14 +216,14 @@ int ui_comm_handle_command(ui_ctx_t *ctx, const ws_command_t *cmd)
             if (!have_playback)
                 ctx->selected_playback_dev[0] = '\0';
             HLOGI(UI_LOG_TAG, "Audio subsystem switched to %s",
-                  cfg_sound_system_name(ctx->audio_system));
+                  cfg_sound_system_name(active_system));
         }
 
         HLOGI(UI_LOG_TAG, "Restarting audioio subsystem (subsystem=%s capture=%s playback=%s channel=%d)",
-              cfg_sound_system_name(ctx->audio_system),
+              cfg_sound_system_name(active_system),
               ctx->selected_capture_dev, ctx->selected_playback_dev, ctx->rx_input_channel);
         audioio_restart(ctx->selected_capture_dev, ctx->selected_playback_dev,
-                        ctx->audio_system, ctx->rx_input_channel);
+                        active_system, ctx->rx_input_channel);
         HLOGI(UI_LOG_TAG, "Audioio subsystem restarted successfully");
 
         // Persist audio config to INI
@@ -232,7 +235,7 @@ int ui_comm_handle_command(ui_ctx_t *ctx, const ws_command_t *cmd)
                 sizeof(ctx->cfg.output_device) - 1);
         ctx->cfg.output_device[sizeof(ctx->cfg.output_device) - 1] = '\0';
         ctx->cfg.capture_channel = ctx->rx_input_channel;
-        ctx->cfg.sound_system = ctx->audio_system;
+        ctx->cfg.sound_system = active_system;
         if (ctx->cfg_path[0] && cfg_write(&ctx->cfg, ctx->cfg_path))
             HLOGI(UI_LOG_TAG, "Config saved to %s", ctx->cfg_path);
         pthread_mutex_unlock(&ctx->cfg_mutex);
@@ -425,7 +428,9 @@ int ui_comm_get_audio_devices(ui_device_kind_t kind, ui_device_t *out, int max,
     }
 
     int cap = (max < 32) ? max : 32;
-    int count = get_soundcard_list(ctx->audio_system, mode, ids, names, cap);
+    int count = get_soundcard_list(
+        atomic_load_explicit(&ctx->audio_system, memory_order_relaxed),
+        mode, ids, names, cap);
     if (count < 0)
         count = 0;
 
@@ -529,7 +534,8 @@ const char *ui_comm_get_audio_system(void)
     ui_ctx_t *ctx = g_ui_ctx;
     if (!ctx)
         return "";
-    return cfg_sound_system_name(ctx->audio_system);
+    return cfg_sound_system_name(
+        atomic_load_explicit(&ctx->audio_system, memory_order_relaxed));
 }
 
 void ui_comm_preload_radio_list(void)
@@ -753,7 +759,8 @@ void *ui_publisher_thread(void *arg)
             // and PulseAudio at runtime; everywhere else the subsystem is
             // fixed and the list carries the single active backend so a UI can
             // hide a selector it cannot act on.
-            const char *audio_sys = cfg_sound_system_name(ctx->audio_system);
+            const char *audio_sys = cfg_sound_system_name(
+                atomic_load_explicit(&ctx->audio_system, memory_order_relaxed));
             char as_buf[256];
 #if defined(__linux__)
             snprintf(as_buf, sizeof(as_buf),
@@ -922,7 +929,7 @@ int ui_comm_init(ui_ctx_t *ctx, uint16_t ws_port, bool tls_enabled,
     pthread_mutex_init(&ctx->cfg_mutex, NULL);
 
     ctx->waterfall_enabled = waterfall_enabled;
-    ctx->audio_system = audio_system;
+    atomic_store_explicit(&ctx->audio_system, audio_system, memory_order_relaxed);
     ctx->rx_input_channel = rx_input_channel;
     ctx->ws_port = ws_port;
     ctx->tls_enabled = tls_enabled;

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -65,6 +65,8 @@ _Static_assert(AUDIO_DEV_STR_MAX >= UI_DEV_ID_MAX,
 /* Audio path health; see audioio.h.  Declared here rather than included for
  * the same reason audioio_restart is: audioio.h drags in ffbase. */
 extern bool audioio_health_ok(char *reason, size_t reasonlen);
+extern void audioio_health_reason(char *buf, size_t buflen);
+extern int  audioio_wait_healthy(int timeout_ms);
 
 extern int audioio_restart(const char *capture_dev, const char *playback_dev,
                            int audio_subsys, int capture_channel_layout);
@@ -224,21 +226,43 @@ int ui_comm_handle_command(ui_ctx_t *ctx, const ws_command_t *cmd)
               ctx->selected_capture_dev, ctx->selected_playback_dev, ctx->rx_input_channel);
         audioio_restart(ctx->selected_capture_dev, ctx->selected_playback_dev,
                         active_system, ctx->rx_input_channel);
-        HLOGI(UI_LOG_TAG, "Audioio subsystem restarted successfully");
 
-        // Persist audio config to INI
-        pthread_mutex_lock(&ctx->cfg_mutex);
-        strncpy(ctx->cfg.input_device, ctx->selected_capture_dev,
-                sizeof(ctx->cfg.input_device) - 1);
-        ctx->cfg.input_device[sizeof(ctx->cfg.input_device) - 1] = '\0';
-        strncpy(ctx->cfg.output_device, ctx->selected_playback_dev,
-                sizeof(ctx->cfg.output_device) - 1);
-        ctx->cfg.output_device[sizeof(ctx->cfg.output_device) - 1] = '\0';
-        ctx->cfg.capture_channel = ctx->rx_input_channel;
-        ctx->cfg.sound_system = active_system;
-        if (ctx->cfg_path[0] && cfg_write(&ctx->cfg, ctx->cfg_path))
-            HLOGI(UI_LOG_TAG, "Config saved to %s", ctx->cfg_path);
-        pthread_mutex_unlock(&ctx->cfg_mutex);
+        /* Don't write a configuration that demonstrably failed into
+         * mercury.ini: the operator would restart straight back into the
+         * broken state.  audioio_restart reset the health flags before
+         * spawning the new threads, so wait for them to reach RUNNING or
+         * FAILED. */
+        int health = audioio_wait_healthy(3000);
+        if (health == 0)
+        {
+            HLOGI(UI_LOG_TAG, "Audioio subsystem restarted successfully");
+
+            // Persist audio config to INI
+            pthread_mutex_lock(&ctx->cfg_mutex);
+            strncpy(ctx->cfg.input_device, ctx->selected_capture_dev,
+                    sizeof(ctx->cfg.input_device) - 1);
+            ctx->cfg.input_device[sizeof(ctx->cfg.input_device) - 1] = '\0';
+            strncpy(ctx->cfg.output_device, ctx->selected_playback_dev,
+                    sizeof(ctx->cfg.output_device) - 1);
+            ctx->cfg.output_device[sizeof(ctx->cfg.output_device) - 1] = '\0';
+            ctx->cfg.capture_channel = ctx->rx_input_channel;
+            ctx->cfg.sound_system = active_system;
+            if (ctx->cfg_path[0] && cfg_write(&ctx->cfg, ctx->cfg_path))
+                HLOGI(UI_LOG_TAG, "Config saved to %s", ctx->cfg_path);
+            pthread_mutex_unlock(&ctx->cfg_mutex);
+        }
+        else
+        {
+            char why[192] = "";
+            audioio_health_reason(why, sizeof(why));
+            if (health == -1)
+                HLOGE(UI_LOG_TAG, "Audio subsystem %s failed to start: %s",
+                      cfg_sound_system_name(active_system),
+                      why[0] ? why : "unknown error");
+            else
+                HLOGW(UI_LOG_TAG, "Audio subsystem %s did not report health in time; "
+                                  "not persisting config", cfg_sound_system_name(active_system));
+        }
 
         /* The device list depends on the subsystem; republish it for any
          * remote UI so it reflects the new selection (and new device set). */

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -160,8 +160,24 @@ int ui_comm_handle_command(ui_ctx_t *ctx, const ws_command_t *cmd)
           cmd->value5, cmd->value6, cmd->value7);
 
     if (strcmp(cmd->command, "set_audio_config") == 0) {
-        // value = capture_dev, value2 = playback_dev, value3 = input_channel
-        if (cmd->value[0])
+        // value = capture_dev, value2 = playback_dev, value3 = input_channel,
+        // value4 = audio subsystem name ("alsa", "pulse", ...; optional).
+        int new_audio_system = -1;
+        if (cmd->value4[0])
+        {
+            new_audio_system = cfg_sound_system_parse(cmd->value4);
+            if (new_audio_system < 0)
+            {
+                HLOGE(UI_LOG_TAG, "Invalid audio subsystem from UI: %s", cmd->value4);
+                return -1;
+            }
+        }
+        bool subsystem_changed = (new_audio_system >= 0 &&
+                                  new_audio_system != ctx->audio_system);
+        bool have_capture = cmd->value[0] != '\0';
+        bool have_playback = cmd->value2[0] != '\0';
+
+        if (have_capture)
         {
             strncpy(ctx->selected_capture_dev, cmd->value,
                     sizeof(ctx->selected_capture_dev) - 1);
@@ -169,7 +185,7 @@ int ui_comm_handle_command(ui_ctx_t *ctx, const ws_command_t *cmd)
         }
         HLOGI(UI_LOG_TAG, "Capture device set to: %s", ctx->selected_capture_dev);
 
-        if (cmd->value2[0])
+        if (have_playback)
         {
             strncpy(ctx->selected_playback_dev, cmd->value2,
                     sizeof(ctx->selected_playback_dev) - 1);
@@ -186,7 +202,22 @@ int ui_comm_handle_command(ui_ctx_t *ctx, const ws_command_t *cmd)
         HLOGI(UI_LOG_TAG, "Input channel set to: %s (%d)",
               cmd->value3, ctx->rx_input_channel);
 
-        HLOGI(UI_LOG_TAG, "Restarting audioio subsystem (capture=%s playback=%s channel=%d)",
+        if (subsystem_changed)
+        {
+            ctx->audio_system = new_audio_system;
+            /* Device ids are subsystem-specific.  When the operator switches
+             * subsystem without choosing a device in the same breath, drop the
+             * stale ids so the new subsystem resolves its own default device. */
+            if (!have_capture)
+                ctx->selected_capture_dev[0] = '\0';
+            if (!have_playback)
+                ctx->selected_playback_dev[0] = '\0';
+            HLOGI(UI_LOG_TAG, "Audio subsystem switched to %s",
+                  cfg_sound_system_name(ctx->audio_system));
+        }
+
+        HLOGI(UI_LOG_TAG, "Restarting audioio subsystem (subsystem=%s capture=%s playback=%s channel=%d)",
+              cfg_sound_system_name(ctx->audio_system),
               ctx->selected_capture_dev, ctx->selected_playback_dev, ctx->rx_input_channel);
         audioio_restart(ctx->selected_capture_dev, ctx->selected_playback_dev,
                         ctx->audio_system, ctx->rx_input_channel);
@@ -201,9 +232,14 @@ int ui_comm_handle_command(ui_ctx_t *ctx, const ws_command_t *cmd)
                 sizeof(ctx->cfg.output_device) - 1);
         ctx->cfg.output_device[sizeof(ctx->cfg.output_device) - 1] = '\0';
         ctx->cfg.capture_channel = ctx->rx_input_channel;
+        ctx->cfg.sound_system = ctx->audio_system;
         if (ctx->cfg_path[0] && cfg_write(&ctx->cfg, ctx->cfg_path))
             HLOGI(UI_LOG_TAG, "Config saved to %s", ctx->cfg_path);
         pthread_mutex_unlock(&ctx->cfg_mutex);
+
+        /* The device list depends on the subsystem; republish it for any
+         * remote UI so it reflects the new selection (and new device set). */
+        ctx->soundcard_list_pending = 1;
 
     } else if (strcmp(cmd->command, "set_ptt_config") == 0) {
         ptt_config_t config;
@@ -488,6 +524,14 @@ int ui_comm_get_input_channel(void)
     return ctx ? ctx->rx_input_channel : 0;
 }
 
+const char *ui_comm_get_audio_system(void)
+{
+    ui_ctx_t *ctx = g_ui_ctx;
+    if (!ctx)
+        return "";
+    return cfg_sound_system_name(ctx->audio_system);
+}
+
 void ui_comm_preload_radio_list(void)
 {
 #ifdef HAVE_HAMLIB
@@ -704,6 +748,23 @@ void *ui_publisher_thread(void *arg)
                 "{\"type\":\"input_channel\",\"selected\":\"%s\","
                 "\"list\":[\"left\",\"right\",\"stereo\"]}", ch_str);
             ws_broadcast_json(&ctx->ws, ch_buf);
+
+            // Audio subsystem selection.  Only Linux can switch between ALSA
+            // and PulseAudio at runtime; everywhere else the subsystem is
+            // fixed and the list carries the single active backend so a UI can
+            // hide a selector it cannot act on.
+            const char *audio_sys = cfg_sound_system_name(ctx->audio_system);
+            char as_buf[256];
+#if defined(__linux__)
+            snprintf(as_buf, sizeof(as_buf),
+                "{\"type\":\"audio_system\",\"selected\":\"%s\","
+                "\"list\":[\"alsa\",\"pulse\"]}", audio_sys);
+#else
+            snprintf(as_buf, sizeof(as_buf),
+                "{\"type\":\"audio_system\",\"selected\":\"%s\","
+                "\"list\":[\"%s\"]}", audio_sys, audio_sys);
+#endif
+            ws_broadcast_json(&ctx->ws, as_buf);
         }
 
         // --- Send PTT/Hamlib choices at startup and after config changes ---

--- a/gui_interface/ui_communication.h
+++ b/gui_interface/ui_communication.h
@@ -165,6 +165,10 @@ int  ui_comm_get_radio_list(ui_device_t *out, int max, char *selected, size_t se
 /* Current RX input channel: 0 = left, 1 = right, 2 = stereo. */
 int  ui_comm_get_input_channel(void);
 
+/* Current audio subsystem name ("alsa", "pulse", ...).  Returns a static
+ * string; never NULL.  Empty string when no UI context is running. */
+const char *ui_comm_get_audio_system(void);
+
 /* Pre-load the radio model list from the main thread.  The embedded UI calls
  * this during mercury_init() so hamlib backend loading happens on a regular
  * POSIX thread, not a CGo goroutine. */

--- a/gui_interface/ui_communication.h
+++ b/gui_interface/ui_communication.h
@@ -73,8 +73,10 @@ struct ui_ctx {
     _Atomic bool spec_run;      // drives the spectrum publisher loop (0 = stop)
     int waterfall_enabled;      // 1 = send spectrum data to UI, 0 = disabled
 
-    // Audio subsystem info for soundcard enumeration
-    int audio_system;                // AUDIO_SUBSYSTEM_* constant
+    // Audio subsystem info for soundcard enumeration.  Written by the command
+    // handler (websocket server thread or embedded UI goroutine) and read by
+    // the publisher thread, so it is atomic.
+    _Atomic int audio_system;        // AUDIO_SUBSYSTEM_* constant
     char selected_capture_dev[UI_DEV_ID_MAX];   // currently active capture (input) device
     char selected_playback_dev[UI_DEV_ID_MAX];  // currently active playback (output) device
     int rx_input_channel;            // LEFT=0, RIGHT=1, STEREO=2


### PR DESCRIPTION
Add an Audio Subsystem selector to the Fyne Soundcards dialog that is
only shown when the engine reports a changeable subsystem (Linux). The
selection is sent as value4 of set_audio_config; the engine restarts
just the audioio subsystem (not the whole engine) and persists the new
sound_system to mercury.ini. Device ids are dropped on a switch so the
new backend resolves its own default device.