### PR TITLE
ui: derive the audio subsystem picker from the compiled-in backends

### DIFF
--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -312,6 +312,35 @@ int audioio_pick_default_subsystem(void)
 #endif
 }
 
+int audioio_available_subsystems(int *subsystems, int max)
+{
+    int n = 0;
+    if (!subsystems || max <= 0)
+        return 0;
+
+#define ADD(s) do { if (n < max) subsystems[n] = (s); n++; } while (0)
+#if defined(__linux__)
+    ADD(AUDIO_SUBSYSTEM_ALSA);
+    ADD(AUDIO_SUBSYSTEM_PULSE);
+    if (OSS_IFACE != NULL)
+        ADD(AUDIO_SUBSYSTEM_OSS);
+#elif defined(_WIN32)
+    ADD(AUDIO_SUBSYSTEM_WASAPI);
+    ADD(AUDIO_SUBSYSTEM_DSOUND);
+#elif defined(__FreeBSD__)
+    ADD(AUDIO_SUBSYSTEM_OSS);
+#elif defined(__APPLE__)
+    ADD(AUDIO_SUBSYSTEM_COREAUDIO);
+#elif defined(__ANDROID__)
+    ADD(AUDIO_SUBSYSTEM_AAUDIO);
+#else
+    ADD(AUDIO_SUBSYSTEM_ALSA);
+#endif
+#undef ADD
+
+    return n;
+}
+
 static void *null_capture_thread(void *unused)
 {
     (void) unused;

--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -318,7 +318,7 @@ int audioio_available_subsystems(int *subsystems, int max)
     if (!subsystems || max <= 0)
         return 0;
 
-#define ADD(s) do { if (n < max) subsystems[n] = (s); n++; } while (0)
+#define ADD(s) do { if (n < max) subsystems[n++] = (s); } while (0)
 #if defined(__linux__)
     ADD(AUDIO_SUBSYSTEM_ALSA);
     ADD(AUDIO_SUBSYSTEM_PULSE);

--- a/audioio/audioio.h
+++ b/audioio/audioio.h
@@ -107,6 +107,12 @@ int audioio_restart(const char *capture_dev, const char *playback_dev,
 int audioio_deinit(pthread_t *radio_capture, pthread_t *radio_playback);
 int audioio_pick_default_subsystem(void);
 
+/* Fill subsystems[0..max-1] with the AUDIO_SUBSYSTEM_* constants this build
+ * can actually run, in the order a UI should offer them.  Returns the number
+ * written.  A build with only one entry (e.g. CoreAudio on macOS) has no
+ * runtime choice; a UI should hide its subsystem picker then. */
+int audioio_available_subsystems(int *subsystems, int max);
+
 int tx_transfer(double *buffer, size_t len);
 int rx_transfer(double *buffer, size_t len);
 

--- a/gui_interface/fyne-ui/engine/mercury_bridge.c
+++ b/gui_interface/fyne-ui/engine/mercury_bridge.c
@@ -194,6 +194,13 @@ void mercury_ui_get_audio_system(char *name, int name_len)
     }
 }
 
+void mercury_ui_get_audio_subsystems(char *names, int names_len)
+{
+    if (names && names_len > 0) {
+        (void) ui_comm_get_audio_subsystems(names, (size_t)names_len);
+    }
+}
+
 void mercury_ui_set_waterfall(bool enabled)
 {
     ui_comm_set_waterfall(enabled);

--- a/gui_interface/fyne-ui/engine/mercury_bridge.h
+++ b/gui_interface/fyne-ui/engine/mercury_bridge.h
@@ -86,6 +86,10 @@ int mercury_ui_get_input_channel(void);
  * Never returns NULL; `name` is always NUL-terminated. */
 void mercury_ui_get_audio_system(char *name, int name_len);
 
+/* Copy the space-separated list of audio subsystems this build can run
+ * ("alsa pulse", "wasapi dsound", ...) into `names`; always NUL-terminated. */
+void mercury_ui_get_audio_subsystems(char *names, int names_len);
+
 /* Enable / disable waterfall/spectrum at runtime.  Saves to mercury.ini. */
 void mercury_ui_set_waterfall(bool enabled);
 

--- a/gui_interface/fyne-ui/link_engine.go
+++ b/gui_interface/fyne-ui/link_engine.go
@@ -13,7 +13,7 @@ import "C"
 import (
 	"context"
 	"fmt"
-	"runtime"
+	"strings"
 	"time"
 	"unsafe"
 )
@@ -299,18 +299,18 @@ func (l *engineLink) SetWaterfall(enabled bool) {
 	C.mercury_ui_set_waterfall(cEn)
 }
 
-// AudioSubsystems reports the engine's audio subsystem and, on Linux, the two
-// backends (ALSA, PulseAudio) the operator can switch between at runtime. The
-// embedded engine runs in this process, so its platform is this process's
-// platform.
+// AudioSubsystems reports the engine's audio subsystem and the set of
+// subsystems this build compiled in. The embedded engine runs in this process,
+// so its platform is this process's platform; a single-entry list means the
+// backend is fixed and the UI hides its subsystem selector.
 func (l *engineLink) AudioSubsystems() (string, []string) {
 	name := make([]byte, 32)
 	C.mercury_ui_get_audio_system((*C.char)(unsafe.Pointer(&name[0])), C.int(len(name)))
 	current := goStringFromC(name)
-	if runtime.GOOS == "linux" {
-		return current, []string{"alsa", "pulse"}
-	}
-	return current, nil
+
+	names := make([]byte, 64)
+	C.mercury_ui_get_audio_subsystems((*C.char)(unsafe.Pointer(&names[0])), C.int(len(names)))
+	return current, strings.Fields(goStringFromC(names))
 }
 
 // TCPPorts returns the ARQ base and broadcast TCP ports the engine is

--- a/gui_interface/fyne-ui/main.go
+++ b/gui_interface/fyne-ui/main.go
@@ -105,8 +105,13 @@ func pttMethodID(label string) string {
 }
 
 var audioSubsystemLabels = map[string]string{
-	"alsa":  "ALSA",
-	"pulse": "PulseAudio",
+	"alsa":      "ALSA",
+	"pulse":     "PulseAudio",
+	"wasapi":    "WASAPI",
+	"dsound":    "DirectSound",
+	"coreaudio": "CoreAudio",
+	"oss":       "OSS",
+	"aaudio":    "AAudio",
 }
 
 func audioSubsystemLabel(id string) string {

--- a/gui_interface/ui_communication.c
+++ b/gui_interface/ui_communication.c
@@ -56,6 +56,8 @@ extern int get_soundcard_list(int audio_system, int mode,
                               char ids[][AUDIO_DEV_STR_MAX], char dev_names[][AUDIO_DEV_STR_MAX],
                               int max_count);
 
+extern int audioio_available_subsystems(int *subsystems, int max);
+
 /* The enumerator writes rows this wide and we copy them straight into
  * ui_device_t; if the UI struct were ever the narrower of the two, long
  * PulseAudio node names would be cut again exactly as in issue #185. */
@@ -562,6 +564,27 @@ const char *ui_comm_get_audio_system(void)
         atomic_load_explicit(&ctx->audio_system, memory_order_relaxed));
 }
 
+int ui_comm_get_audio_subsystems(char *names, size_t names_len)
+{
+    int subsystems[8];
+    int n = audioio_available_subsystems(subsystems, 8);
+
+    if (!names || names_len == 0)
+        return n;
+
+    size_t off = 0;
+    for (int i = 0; i < n; i++)
+    {
+        int w = snprintf(names + off, names_len - off, "%s%s",
+                         i ? " " : "", cfg_sound_system_name(subsystems[i]));
+        if (w < 0 || (size_t)w >= names_len - off)
+            break;
+        off += (size_t)w;
+    }
+    names[off] = '\0';
+    return n;
+}
+
 void ui_comm_preload_radio_list(void)
 {
 #ifdef HAVE_HAMLIB
@@ -779,22 +802,22 @@ void *ui_publisher_thread(void *arg)
                 "\"list\":[\"left\",\"right\",\"stereo\"]}", ch_str);
             ws_broadcast_json(&ctx->ws, ch_buf);
 
-            // Audio subsystem selection.  Only Linux can switch between ALSA
-            // and PulseAudio at runtime; everywhere else the subsystem is
-            // fixed and the list carries the single active backend so a UI can
-            // hide a selector it cannot act on.
+            // Audio subsystem selection.  The list is the set of subsystems
+            // this build actually compiled in; a single-entry list means the
+            // backend is fixed and the UI can hide a selector it cannot act on.
             const char *audio_sys = cfg_sound_system_name(
                 atomic_load_explicit(&ctx->audio_system, memory_order_relaxed));
+            int  subsystems[8];
+            int  n_subsys = audioio_available_subsystems(subsystems, 8);
             char as_buf[256];
-#if defined(__linux__)
-            snprintf(as_buf, sizeof(as_buf),
-                "{\"type\":\"audio_system\",\"selected\":\"%s\","
-                "\"list\":[\"alsa\",\"pulse\"]}", audio_sys);
-#else
-            snprintf(as_buf, sizeof(as_buf),
-                "{\"type\":\"audio_system\",\"selected\":\"%s\","
-                "\"list\":[\"%s\"]}", audio_sys, audio_sys);
-#endif
+            int  pos = snprintf(as_buf, sizeof(as_buf),
+                "{\"type\":\"audio_system\",\"selected\":\"%s\",\"list\":[",
+                audio_sys);
+            for (int i = 0; i < n_subsys && pos < (int)sizeof(as_buf) - 16; i++)
+                pos += snprintf(as_buf + pos, sizeof(as_buf) - pos, "%s\"%s\"",
+                                i ? "," : "", cfg_sound_system_name(subsystems[i]));
+            if (pos < (int)sizeof(as_buf) - 4)
+                pos += snprintf(as_buf + pos, sizeof(as_buf) - pos, "]}");
             ws_broadcast_json(&ctx->ws, as_buf);
         }
 

--- a/gui_interface/ui_communication.h
+++ b/gui_interface/ui_communication.h
@@ -171,6 +171,11 @@ int  ui_comm_get_input_channel(void);
  * string; never NULL.  Empty string when no UI context is running. */
 const char *ui_comm_get_audio_system(void);
 
+/* Fill names with the audio subsystems this build can run, space-separated
+ * and NUL-terminated (e.g. "alsa pulse", "wasapi dsound").  Returns the
+ * number of subsystems written. */
+int  ui_comm_get_audio_subsystems(char *names, size_t names_len);
+
 /* Pre-load the radio model list from the main thread.  The embedded UI calls
  * this during mercury_init() so hamlib backend loading happens on a regular
  * POSIX thread, not a CGo goroutine. */


### PR DESCRIPTION
Follow up for PR #240 

Replace the #ifdef __linux__ subsystem list with audioio_available_subsystems(),
which reports the backends this build actually compiled in, in display order:
Linux (ALSA/PulseAudio/OSS when built), Windows (WASAPI/DirectSound), macOS
(CoreAudio), Android (AAudio). A single-entry list keeps the picker hidden on
macOS/Android while Windows now gets the WASAPI/DirectSound choice for free.

The websocket audio_system message and the embedded UI's AudioSubsystems()
both read this list, so the picker is driven by the build rather than by the
UI's own platform.