### PR TITLE
macOS: Developer ID signing and notarization, wired into releases

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -1,0 +1,138 @@
+# Build, Developer ID sign, notarize and staple the macOS universal .dmg.
+#
+# Reusable on purpose.  release.yml calls it so every release ships a signed,
+# notarized .dmg; it is also dispatchable on its own so the whole path can be
+# exercised WITHOUT cutting a release -- the artifact is uploaded and nothing
+# is published.  Keeping one copy means the thing we test is the thing that
+# ships, rather than two definitions that drift.
+#
+# See docs/MACOS-SIGNING.md.
+
+name: macOS signed DMG
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to build'
+        required: false
+        default: mercuryv2
+        type: string
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to build (branch, tag or SHA)'
+        required: false
+        default: mercuryv2
+        type: string
+
+jobs:
+  macos:
+    name: Build and notarize macOS .dmg
+    runs-on: macos-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 1
+
+      - uses: actions/setup-go@v5
+        with: { go-version: 'stable' }
+
+      # Fail before spending 40 minutes on a build we could not ship.  An
+      # unsigned .dmg on a release page is worse than no .dmg: it teaches
+      # people to click through Gatekeeper.
+      - name: Require signing credentials
+        env:
+          P12:   ${{ secrets.MACOS_SIGN_P12_BASE64 }}
+          PASS:  ${{ secrets.MACOS_SIGN_P12_PASSWORD }}
+          NOTARY: ${{ secrets.MACOS_NOTARY_KEY_BASE64 }}
+        run: |
+          # The password is deliberately NOT required.  PKCS#12 permits an
+          # empty password, and protecting the .p12 with one adds nothing when
+          # the certificate is already a bearer credential held in a secret
+          # store -- so an empty MACOS_SIGN_P12_PASSWORD is a valid setup, and
+          # demanding a non-empty one would fail a correct configuration.
+          missing=
+          [ -n "$P12" ]    || missing="$missing MACOS_SIGN_P12_BASE64"
+          [ -n "$NOTARY" ] || missing="$missing MACOS_NOTARY_KEY_BASE64"
+          if [ -n "$missing" ]; then
+            echo "::error::missing repository secret(s):$missing"
+            echo "See docs/MACOS-SIGNING.md for how to create and set them."
+            exit 1
+          fi
+
+      # rcodesign has no Homebrew formula, and `cargo install` would compile it
+      # from source on every release.  Pinned pre-built binary + checksum: the
+      # version is the one the Makefile documents as verified (0.28.0), and the
+      # checksum means a replaced asset fails the job instead of signing with
+      # something we did not intend.
+      - name: Install fyne and rcodesign
+        env:
+          RCODESIGN_VERSION: '0.28.0'
+          RCODESIGN_SHA256: 'fdad0c03e3a33ac7676c3641547f0cf9adad2cd52919033e3866b551bc9aae12'
+        run: |
+          go install fyne.io/tools/cmd/fyne@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+          TARBALL="apple-codesign-${RCODESIGN_VERSION}-macos-universal.tar.gz"
+          curl -fsSLO "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${RCODESIGN_VERSION}/${TARBALL}"
+          echo "${RCODESIGN_SHA256}  ${TARBALL}" | shasum -a 256 -c -
+          tar xzf "$TARBALL"
+          mkdir -p "$HOME/.local/bin"
+          mv apple-codesign-*/rcodesign "$HOME/.local/bin/"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/rcodesign" --version
+
+      # Written to the runner's temp dir, not the workspace, so they cannot be
+      # picked up by a later packaging step or an artifact upload.
+      - name: Materialise credentials
+        env:
+          P12:    ${{ secrets.MACOS_SIGN_P12_BASE64 }}
+          NOTARY: ${{ secrets.MACOS_NOTARY_KEY_BASE64 }}
+        run: |
+          umask 077
+          printf '%s' "$P12"    | base64 --decode > "$RUNNER_TEMP/developer_id.p12"
+          printf '%s' "$NOTARY" | base64 --decode > "$RUNNER_TEMP/notary_key.json"
+
+      # Catches the commonest setup mistake -- an "Apple Development" or
+      # "Developer ID Installer" certificate -- with a clear message, rather
+      # than as a Gatekeeper failure on a user's machine weeks later.
+      - name: Check certificate type
+        env: { PASS: "${{ secrets.MACOS_SIGN_P12_PASSWORD }}" }
+        run: |
+          subj=$(openssl pkcs12 -in "$RUNNER_TEMP/developer_id.p12" -nodes -passin env:PASS \
+                 | openssl x509 -noout -subject)
+          echo "certificate: $subj"
+          case "$subj" in
+            *"Developer ID Application"*) ;;
+            *) echo "::error::not a Developer ID Application certificate: $subj"; exit 1 ;;
+          esac
+
+      - name: Build, sign and package
+        env: { PASS: "${{ secrets.MACOS_SIGN_P12_PASSWORD }}" }
+        run: |
+          make fyne-ui-macos-universal-dmg \
+            MACOS_SIGN_P12="$RUNNER_TEMP/developer_id.p12" \
+            MACOS_SIGN_P12_PASSWORD="$PASS"
+
+      - name: Notarize and staple
+        run: |
+          make macos-notarize-dmg MACOS_NOTARY_KEY="$RUNNER_TEMP/notary_key.json"
+
+      # Gatekeeper's own verdict, on the artifact we are about to publish.
+      - name: Verify Gatekeeper accepts it
+        run: |
+          DMG=$(ls Mercury-*-universal.dmg)
+          spctl -a -t open --context context:primary-signature -v "$DMG"
+
+      - name: Shred credentials
+        if: always()
+        run: rm -f "$RUNNER_TEMP/developer_id.p12" "$RUNNER_TEMP/notary_key.json"
+
+      - name: Upload signed .dmg
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-dmg
+          path: Mercury-*-universal.dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,119 +317,17 @@ jobs:
           if-no-files-found: ignore
 
   # ---- macOS universal .dmg: build, sign (Developer ID), notarize, staple ----
-  # Runs on macOS only because hdiutil builds the .dmg and is Apple-only.
-  # Signing and notarization are rcodesign, not Apple's codesign/notarytool:
-  # no keychain to unlock, and the same command works on a Linux box by hand.
-  # See docs/MACOS-SIGNING.md.
+  # Defined in its own reusable workflow so the exact same job can be run on
+  # demand without cutting a release (Actions -> "macOS signed DMG" -> Run
+  # workflow).  What gets tested is then literally what ships.
   macos:
     name: Build and notarize macOS .dmg
     needs: bump
     if: ${{ inputs.build_macos }}
-    runs-on: macos-latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-        with: { ref: mercuryv2, fetch-depth: 1 }
-
-      - uses: actions/setup-go@v5
-        with: { go-version: 'stable' }
-
-      # Fail before spending 40 minutes on a build we could not ship.  An
-      # unsigned .dmg on a release page is worse than no .dmg: it teaches
-      # people to click through Gatekeeper.
-      - name: Require signing credentials
-        env:
-          P12:   ${{ secrets.MACOS_SIGN_P12_BASE64 }}
-          PASS:  ${{ secrets.MACOS_SIGN_P12_PASSWORD }}
-          NOTARY: ${{ secrets.MACOS_NOTARY_KEY_BASE64 }}
-        run: |
-          # The password is deliberately NOT required.  PKCS#12 permits an
-          # empty password, and protecting the .p12 with one adds nothing when
-          # the certificate is already a bearer credential held in a secret
-          # store -- so an empty MACOS_SIGN_P12_PASSWORD is a valid setup, and
-          # demanding a non-empty one would fail a correct configuration.
-          missing=
-          [ -n "$P12" ]    || missing="$missing MACOS_SIGN_P12_BASE64"
-          [ -n "$NOTARY" ] || missing="$missing MACOS_NOTARY_KEY_BASE64"
-          if [ -n "$missing" ]; then
-            echo "::error::missing repository secret(s):$missing"
-            echo "See docs/MACOS-SIGNING.md for how to create and set them."
-            exit 1
-          fi
-
-      # rcodesign has no Homebrew formula, and `cargo install` would compile it
-      # from source on every release.  Pinned pre-built binary + checksum: the
-      # version is the one the Makefile documents as verified (0.28.0), and the
-      # checksum means a replaced asset fails the job instead of signing with
-      # something we did not intend.
-      - name: Install fyne and rcodesign
-        env:
-          RCODESIGN_VERSION: '0.28.0'
-          RCODESIGN_SHA256: 'fdad0c03e3a33ac7676c3641547f0cf9adad2cd52919033e3866b551bc9aae12'
-        run: |
-          go install fyne.io/tools/cmd/fyne@latest
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
-
-          TARBALL="apple-codesign-${RCODESIGN_VERSION}-macos-universal.tar.gz"
-          curl -fsSLO "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${RCODESIGN_VERSION}/${TARBALL}"
-          echo "${RCODESIGN_SHA256}  ${TARBALL}" | shasum -a 256 -c -
-          tar xzf "$TARBALL"
-          mkdir -p "$HOME/.local/bin"
-          mv apple-codesign-*/rcodesign "$HOME/.local/bin/"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/rcodesign" --version
-
-      # Written to the runner's temp dir, not the workspace, so they cannot be
-      # picked up by a later packaging step or an artifact upload.
-      - name: Materialise credentials
-        env:
-          P12:    ${{ secrets.MACOS_SIGN_P12_BASE64 }}
-          NOTARY: ${{ secrets.MACOS_NOTARY_KEY_BASE64 }}
-        run: |
-          umask 077
-          printf '%s' "$P12"    | base64 --decode > "$RUNNER_TEMP/developer_id.p12"
-          printf '%s' "$NOTARY" | base64 --decode > "$RUNNER_TEMP/notary_key.json"
-
-      # Catches the commonest setup mistake -- an "Apple Development" or
-      # "Developer ID Installer" certificate -- with a clear message, rather
-      # than as a Gatekeeper failure on a user's machine weeks later.
-      - name: Check certificate type
-        env: { PASS: "${{ secrets.MACOS_SIGN_P12_PASSWORD }}" }
-        run: |
-          subj=$(openssl pkcs12 -in "$RUNNER_TEMP/developer_id.p12" -nodes -passin env:PASS \
-                 | openssl x509 -noout -subject)
-          echo "certificate: $subj"
-          case "$subj" in
-            *"Developer ID Application"*) ;;
-            *) echo "::error::not a Developer ID Application certificate: $subj"; exit 1 ;;
-          esac
-
-      - name: Build, sign and package
-        env: { PASS: "${{ secrets.MACOS_SIGN_P12_PASSWORD }}" }
-        run: |
-          make fyne-ui-macos-universal-dmg \
-            MACOS_SIGN_P12="$RUNNER_TEMP/developer_id.p12" \
-            MACOS_SIGN_P12_PASSWORD="$PASS"
-
-      - name: Notarize and staple
-        run: |
-          make macos-notarize-dmg MACOS_NOTARY_KEY="$RUNNER_TEMP/notary_key.json"
-
-      # Gatekeeper's own verdict, on the artifact we are about to publish.
-      - name: Verify Gatekeeper accepts it
-        run: |
-          DMG=$(ls Mercury-*-universal.dmg)
-          spctl -a -t open --context context:primary-signature -v "$DMG"
-
-      - name: Shred credentials
-        if: always()
-        run: rm -f "$RUNNER_TEMP/developer_id.p12" "$RUNNER_TEMP/notary_key.json"
-
-      - name: Upload signed .dmg
-        uses: actions/upload-artifact@v4
-        with:
-          name: macos-dmg
-          path: Mercury-*-universal.dmg
+    uses: ./.github/workflows/macos-dmg.yml
+    with:
+      ref: mercuryv2
+    secrets: inherit
 
   # ---- Create GitHub release ----
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -343,9 +343,13 @@ jobs:
           PASS:  ${{ secrets.MACOS_SIGN_P12_PASSWORD }}
           NOTARY: ${{ secrets.MACOS_NOTARY_KEY_BASE64 }}
         run: |
+          # The password is deliberately NOT required.  PKCS#12 permits an
+          # empty password, and protecting the .p12 with one adds nothing when
+          # the certificate is already a bearer credential held in a secret
+          # store -- so an empty MACOS_SIGN_P12_PASSWORD is a valid setup, and
+          # demanding a non-empty one would fail a correct configuration.
           missing=
           [ -n "$P12" ]    || missing="$missing MACOS_SIGN_P12_BASE64"
-          [ -n "$PASS" ]   || missing="$missing MACOS_SIGN_P12_PASSWORD"
           [ -n "$NOTARY" ] || missing="$missing MACOS_NOTARY_KEY_BASE64"
           if [ -n "$missing" ]; then
             echo "::error::missing repository secret(s):$missing"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ on:
         required: false
         default: true
         type: boolean
+      build_macos:
+        description: 'Build+sign+notarize the macOS universal .dmg'
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   # ---- Version bump + commit ----
@@ -311,10 +316,124 @@ jobs:
           path: /tmp/mercury-signing-diag
           if-no-files-found: ignore
 
+  # ---- macOS universal .dmg: build, sign (Developer ID), notarize, staple ----
+  # Runs on macOS only because hdiutil builds the .dmg and is Apple-only.
+  # Signing and notarization are rcodesign, not Apple's codesign/notarytool:
+  # no keychain to unlock, and the same command works on a Linux box by hand.
+  # See docs/MACOS-SIGNING.md.
+  macos:
+    name: Build and notarize macOS .dmg
+    needs: bump
+    if: ${{ inputs.build_macos }}
+    runs-on: macos-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with: { ref: mercuryv2, fetch-depth: 1 }
+
+      - uses: actions/setup-go@v5
+        with: { go-version: 'stable' }
+
+      # Fail before spending 40 minutes on a build we could not ship.  An
+      # unsigned .dmg on a release page is worse than no .dmg: it teaches
+      # people to click through Gatekeeper.
+      - name: Require signing credentials
+        env:
+          P12:   ${{ secrets.MACOS_SIGN_P12_BASE64 }}
+          PASS:  ${{ secrets.MACOS_SIGN_P12_PASSWORD }}
+          NOTARY: ${{ secrets.MACOS_NOTARY_KEY_BASE64 }}
+        run: |
+          missing=
+          [ -n "$P12" ]    || missing="$missing MACOS_SIGN_P12_BASE64"
+          [ -n "$PASS" ]   || missing="$missing MACOS_SIGN_P12_PASSWORD"
+          [ -n "$NOTARY" ] || missing="$missing MACOS_NOTARY_KEY_BASE64"
+          if [ -n "$missing" ]; then
+            echo "::error::missing repository secret(s):$missing"
+            echo "See docs/MACOS-SIGNING.md for how to create and set them."
+            exit 1
+          fi
+
+      # rcodesign has no Homebrew formula, and `cargo install` would compile it
+      # from source on every release.  Pinned pre-built binary + checksum: the
+      # version is the one the Makefile documents as verified (0.28.0), and the
+      # checksum means a replaced asset fails the job instead of signing with
+      # something we did not intend.
+      - name: Install fyne and rcodesign
+        env:
+          RCODESIGN_VERSION: '0.28.0'
+          RCODESIGN_SHA256: 'fdad0c03e3a33ac7676c3641547f0cf9adad2cd52919033e3866b551bc9aae12'
+        run: |
+          go install fyne.io/tools/cmd/fyne@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+          TARBALL="apple-codesign-${RCODESIGN_VERSION}-macos-universal.tar.gz"
+          curl -fsSLO "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${RCODESIGN_VERSION}/${TARBALL}"
+          echo "${RCODESIGN_SHA256}  ${TARBALL}" | shasum -a 256 -c -
+          tar xzf "$TARBALL"
+          mkdir -p "$HOME/.local/bin"
+          mv apple-codesign-*/rcodesign "$HOME/.local/bin/"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/rcodesign" --version
+
+      # Written to the runner's temp dir, not the workspace, so they cannot be
+      # picked up by a later packaging step or an artifact upload.
+      - name: Materialise credentials
+        env:
+          P12:    ${{ secrets.MACOS_SIGN_P12_BASE64 }}
+          NOTARY: ${{ secrets.MACOS_NOTARY_KEY_BASE64 }}
+        run: |
+          umask 077
+          printf '%s' "$P12"    | base64 --decode > "$RUNNER_TEMP/developer_id.p12"
+          printf '%s' "$NOTARY" | base64 --decode > "$RUNNER_TEMP/notary_key.json"
+
+      # Catches the commonest setup mistake -- an "Apple Development" or
+      # "Developer ID Installer" certificate -- with a clear message, rather
+      # than as a Gatekeeper failure on a user's machine weeks later.
+      - name: Check certificate type
+        env: { PASS: "${{ secrets.MACOS_SIGN_P12_PASSWORD }}" }
+        run: |
+          subj=$(openssl pkcs12 -in "$RUNNER_TEMP/developer_id.p12" -nodes -passin env:PASS \
+                 | openssl x509 -noout -subject)
+          echo "certificate: $subj"
+          case "$subj" in
+            *"Developer ID Application"*) ;;
+            *) echo "::error::not a Developer ID Application certificate: $subj"; exit 1 ;;
+          esac
+
+      - name: Build, sign and package
+        env: { PASS: "${{ secrets.MACOS_SIGN_P12_PASSWORD }}" }
+        run: |
+          make fyne-ui-macos-universal-dmg \
+            MACOS_SIGN_P12="$RUNNER_TEMP/developer_id.p12" \
+            MACOS_SIGN_P12_PASSWORD="$PASS"
+
+      - name: Notarize and staple
+        run: |
+          make macos-notarize-dmg MACOS_NOTARY_KEY="$RUNNER_TEMP/notary_key.json"
+
+      # Gatekeeper's own verdict, on the artifact we are about to publish.
+      - name: Verify Gatekeeper accepts it
+        run: |
+          DMG=$(ls Mercury-*-universal.dmg)
+          spctl -a -t open --context context:primary-signature -v "$DMG"
+
+      - name: Shred credentials
+        if: always()
+        run: rm -f "$RUNNER_TEMP/developer_id.p12" "$RUNNER_TEMP/notary_key.json"
+
+      - name: Upload signed .dmg
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-dmg
+          path: Mercury-*-universal.dmg
+
   # ---- Create GitHub release ----
   release:
     name: Create GitHub release
-    needs: sign
+    needs: [sign, macos]
+    # The macOS job is opt-in; without this the whole release is skipped when
+    # it is, because a skipped dependency skips its dependents.
+    if: ${{ always() && needs.sign.result == 'success' && needs.macos.result != 'failure' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -329,6 +448,11 @@ jobs:
         uses: actions/download-artifact@v4
         with: { name: windows-installer-signed }
 
+      - name: Download notarized .dmg
+        if: ${{ inputs.build_macos }}
+        uses: actions/download-artifact@v4
+        with: { name: macos-dmg }
+
       - name: Create release
         env: { GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
         run: |
@@ -340,6 +464,8 @@ jobs:
           # Not `[ -n ... ] && ASSETS=...`: the runner shell has -e, so the
           # false test would end the step and no release would be created.
           if [ -n "$SETUP" ]; then ASSETS="$ASSETS ./${SETUP}"; fi
+          DMG=$(ls Mercury-*-universal.dmg 2>/dev/null | head -1 || true)
+          if [ -n "$DMG" ]; then ASSETS="$ASSETS ./${DMG}"; fi
           gh release create "v${{ inputs.version }}" $ASSETS \
             --repo Rhizomatica/mercury --target mercuryv2 --generate-notes \
             --title "Mercury ${{ inputs.version }}"

--- a/datalink_broadcast/Makefile
+++ b/datalink_broadcast/Makefile
@@ -31,5 +31,14 @@ broadcast.o: broadcast.c
 	$(CC) $(CFLAGS) -c broadcast.c
 
 
+# The vendored RaptorQ tree builds into its own subdirectories, so a flat
+# `rm -f *.o` leaves those objects behind.  That is not cosmetic: the universal
+# macOS build runs `make clean` between its x86_64 and arm64 slices, so stale
+# objects from the first slice survive into the second and `ar` then refuses
+# the archive -- "cputype (16777223) does not match previous archive members
+# cputype (16777228)".  Same trap for a Windows cross build after a native one,
+# which is why those objects are named .w64.o; clean them here too.
 clean:
-	rm -f *.o
+	rm -f *.o *.w64.o *.d
+	rm -f raptorq/lib/*.o raptorq/lib/*.w64.o raptorq/lib/*.d
+	rm -f raptorq/deps/obl/*.o raptorq/deps/obl/*.w64.o raptorq/deps/obl/*.d

--- a/docs/MACOS-SIGNING.md
+++ b/docs/MACOS-SIGNING.md
@@ -73,7 +73,17 @@ At <https://developer.apple.com/account/resources/certificates>:
 5. Download the issued `developerID_application.cer`.
 
 Then combine the certificate with the private key into the `.p12` rcodesign
-wants. **Choose your own password** and keep it with the file:
+wants. `-certfile` is the part that matters: it bundles the intermediate so the
+`.p12` carries leaf **+** chain. Without it you get a leaf-only signature, which
+signs fine and then fails to validate on machines that do not already have the
+intermediate cached — a bug that shows up on other people's Macs, not yours.
+
+**An empty password (`-passout pass:`) is fine**, and is what this project
+uses. PKCS#12 permits it, rcodesign accepts it, and a password protects
+nothing here: the key generated in §1 is already unencrypted on disk beside it,
+and in CI the `.p12` is a bearer credential inside a secret store either way.
+Use one only if you also encrypt or delete that private key. If you do set one,
+keep it with the file — the certificate is valid for 5 years.
 
 ```sh
 cd ~/.config/mercury-signing
@@ -81,15 +91,22 @@ openssl x509 -inform DER -in developerID_application.cer -out apple_developer_id
 openssl pkcs12 -export \
   -inkey apple_developer_id.key \
   -in apple_developer_id.pem \
-  -out apple_developer_id.p12
+  -certfile certs/DeveloperIDG2CA.pem \
+  -name "Developer ID Application: <Team Name>" \
+  -out apple_developer_id.p12 \
+  -passout pass:
 chmod 600 apple_developer_id.p12
+
+# it must contain TWO certificates: the leaf and the G2 intermediate
+openssl pkcs12 -in apple_developer_id.p12 -passin pass: -nokeys 2>/dev/null \
+  | grep -c "BEGIN CERTIFICATE"
 ```
 
 Check it is the certificate you think it is — the common name must start with
 `Developer ID Application:`:
 
 ```sh
-openssl pkcs12 -in apple_developer_id.p12 -nodes -passin pass:YOURPASS \
+openssl pkcs12 -in apple_developer_id.p12 -nodes -passin pass: \
   | openssl x509 -noout -subject -dates
 ```
 
@@ -162,6 +179,8 @@ the key JSON are binary/multiline, so base64 them:
 ```sh
 cd ~/.config/mercury-signing
 gh secret set MACOS_SIGN_P12_BASE64   --repo Rhizomatica/mercury < <(base64 -w0 apple_developer_id.p12)
+# Only if the .p12 has a password.  The job treats it as optional, so an
+# unset secret means "empty password" and is a valid configuration.
 gh secret set MACOS_SIGN_P12_PASSWORD --repo Rhizomatica/mercury   # prompts, does not echo
 gh secret set MACOS_NOTARY_KEY_BASE64 --repo Rhizomatica/mercury < <(base64 -w0 apple_notary_key.json)
 ```

--- a/docs/MACOS-SIGNING.md
+++ b/docs/MACOS-SIGNING.md
@@ -27,7 +27,11 @@ is signing and notarization.
 
 **Keep all of it OUTSIDE the git tree**, same rule as
 [WINDOWS-SIGNING.md](WINDOWS-SIGNING.md). `.gitignore` blocks `*.p12` as a
-backstop, but the rule is: secrets live in `~/.config/mercury-signing/`.
+backstop, but the rule is that the material never enters the repository at all.
+The paths below are a suggestion; anywhere outside the tree works, and the
+maintainer's copies live in `hermes/apple/` alongside Apple's public
+intermediate certificates (`certs/DeveloperIDG2CA.cer` and the WWDR CAs), which
+are **not** secret and are what lets a signing tool build the full chain.
 
 A Developer ID certificate can only be created by the team's **Account Holder**
 (Admins cannot), and Apple caps them at **5 per team** — they are not

--- a/docs/MACOS-SIGNING.md
+++ b/docs/MACOS-SIGNING.md
@@ -1,0 +1,179 @@
+# macOS code signing and notarization
+
+Gatekeeper on a current macOS refuses to open a downloaded `.app` unless it is
+**signed with a Developer ID Application certificate** *and* **notarized by
+Apple**. Signing alone is not enough — an unnotarized build still gets
+"Apple could not verify ... free of malware", and the only way past it is a
+right-click → Open, which most people will not do and should not be asked to.
+
+Both steps are done with [`rcodesign`](https://github.com/indygreg/apple-platform-rs)
+(the `apple-codesign` crate), not Apple's `codesign`/`notarytool`. It signs
+Mach-O binaries, bundles, `.dmg` images and `.pkg` archives, and notarizes and
+staples, **without a Mac, Xcode or a keychain**. See the rationale in the
+Makefile's *macOS code signing* section.
+
+`hdiutil` still needs macOS to build the `.dmg` itself; what moves off the Mac
+is signing and notarization.
+
+---
+
+## What you need
+
+| thing | what it is | where it lives |
+|---|---|---|
+| Developer ID Application certificate | signs the CLI, the `.app` and the `.dmg` | `~/.config/mercury-signing/apple_developer_id.p12` |
+| its private key | generated here, never leaves the machine | `~/.config/mercury-signing/apple_developer_id.key` |
+| App Store Connect API key | authenticates the notarization upload | `~/.config/mercury-signing/apple_notary_key.json` |
+
+**Keep all of it OUTSIDE the git tree**, same rule as
+[WINDOWS-SIGNING.md](WINDOWS-SIGNING.md). `.gitignore` blocks `*.p12` as a
+backstop, but the rule is: secrets live in `~/.config/mercury-signing/`.
+
+A Developer ID certificate can only be created by the team's **Account Holder**
+(Admins cannot), and Apple caps them at **5 per team** — they are not
+disposable, so keep the `.p12` and its password somewhere you will still have
+them in three years. Losing the private key means revoking and reissuing.
+
+---
+
+## 1. Generate a key and CSR (on Linux — no Mac needed)
+
+Apple's own instructions say to use Keychain Access on a Mac. You do not have
+to; a CSR is a CSR. Apple requires RSA 2048.
+
+```sh
+mkdir -p ~/.config/mercury-signing && chmod 700 ~/.config/mercury-signing
+cd ~/.config/mercury-signing
+openssl req -new -newkey rsa:2048 -nodes \
+  -keyout apple_developer_id.key \
+  -out apple_developer_id.csr \
+  -subj "/CN=Rhizomatica/emailAddress=you@example.org/C=BR"
+chmod 600 apple_developer_id.key
+```
+
+The subject barely matters — Apple overwrites it, and the issued certificate
+comes back as `Developer ID Application: <Team Name> (<TEAMID>)`. The `.csr` is
+**not secret**; the `.key` is the whole certificate's security.
+
+## 2. Get the certificate from Apple
+
+At <https://developer.apple.com/account/resources/certificates>:
+
+1. **Certificates** → **+**
+2. Under **Software**, choose **Developer ID Application**
+   — *not* "Developer ID Installer" (that signs `.pkg`, which we do not ship),
+   and *not* "Apple Development"/"Apple Distribution" (those are for the App
+   Store and Gatekeeper will not accept them for direct download).
+3. If it asks for a **Profile Type**, choose **G2 Sub-CA**.
+4. Upload `apple_developer_id.csr`.
+5. Download the issued `developerID_application.cer`.
+
+Then combine the certificate with the private key into the `.p12` rcodesign
+wants. **Choose your own password** and keep it with the file:
+
+```sh
+cd ~/.config/mercury-signing
+openssl x509 -inform DER -in developerID_application.cer -out apple_developer_id.pem
+openssl pkcs12 -export \
+  -inkey apple_developer_id.key \
+  -in apple_developer_id.pem \
+  -out apple_developer_id.p12
+chmod 600 apple_developer_id.p12
+```
+
+Check it is the certificate you think it is — the common name must start with
+`Developer ID Application:`:
+
+```sh
+openssl pkcs12 -in apple_developer_id.p12 -nodes -passin pass:YOURPASS \
+  | openssl x509 -noout -subject -dates
+```
+
+Apple's Developer ID certificates are valid for 5 years. Note the expiry: a
+lapsed certificate does not break already-notarized downloads (the notarization
+ticket is what Gatekeeper checks), but it stops you signing new ones.
+
+## 3. Get an App Store Connect API key (for notarization)
+
+This is **not** in the developer portal's *Keys* tab — those are service keys
+(APNs, DeviceCheck). Notarization uses an App Store Connect team key:
+
+1. <https://appstoreconnect.apple.com> → **Users and Access** → **Integrations**
+   → **App Store Connect API** → **Team Keys**
+2. **+**, give it a name, role **Developer** (enough to notarize)
+3. Download `AuthKey_<KEYID>.p8` — **Apple lets you download it once.**
+4. Note the **Issuer ID** (a UUID at the top of the page) and the **Key ID**.
+
+Encode all three into the single JSON file rcodesign uses. rcodesign has **no
+Homebrew formula**; install the pinned pre-built binary (the version the
+Makefile documents as verified) or build it with `cargo install apple-codesign`:
+
+```sh
+V=0.28.0
+curl -fsSLO "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F$V/apple-codesign-$V-x86_64-unknown-linux-musl.tar.gz"
+tar xzf apple-codesign-$V-x86_64-unknown-linux-musl.tar.gz
+install -m755 apple-codesign-*/rcodesign ~/.local/bin/
+```
+
+Then:
+
+```sh
+rcodesign encode-app-store-connect-api-key \
+  -o ~/.config/mercury-signing/apple_notary_key.json \
+  <ISSUER_ID> <KEY_ID> AuthKey_<KEYID>.p8
+chmod 600 ~/.config/mercury-signing/apple_notary_key.json
+```
+
+## 4. Sign and notarize locally
+
+`hdiutil` is macOS-only, so the `.dmg` itself is built on a Mac; the signing
+happens through the Makefile either way:
+
+```sh
+make fyne-ui-macos-universal-dmg \
+  MACOS_SIGN_P12=~/.config/mercury-signing/apple_developer_id.p12 \
+  MACOS_SIGN_P12_PASSWORD='...'
+
+make macos-notarize-dmg \
+  MACOS_NOTARY_KEY=~/.config/mercury-signing/apple_notary_key.json
+```
+
+Signing is **opt-in**: with `MACOS_SIGN_P12` unset the build still completes and
+prints `WARNING: ... is unsigned`, so ordinary developer builds are unchanged.
+
+Notarization takes a few minutes; `--staple` writes the ticket into the `.dmg`
+so it validates even when the user is offline. Verify on a Mac:
+
+```sh
+codesign --verify --deep --strict --verbose=2 /Applications/Mercury.app
+spctl -a -t open --context context:primary-signature -v Mercury-*.dmg
+```
+
+## 5. Wire it into CI
+
+The release workflow signs and notarizes the macOS artifact when three
+repository secrets are present. Set them from the files above — the `.p12` and
+the key JSON are binary/multiline, so base64 them:
+
+```sh
+cd ~/.config/mercury-signing
+gh secret set MACOS_SIGN_P12_BASE64   --repo Rhizomatica/mercury < <(base64 -w0 apple_developer_id.p12)
+gh secret set MACOS_SIGN_P12_PASSWORD --repo Rhizomatica/mercury   # prompts, does not echo
+gh secret set MACOS_NOTARY_KEY_BASE64 --repo Rhizomatica/mercury < <(base64 -w0 apple_notary_key.json)
+```
+
+With the secrets absent the macOS job **fails loudly** rather than publishing an
+unsigned `.dmg`: an unsigned build on a release page is worse than no build,
+because it teaches people to click through Gatekeeper warnings.
+
+---
+
+## Troubleshooting
+
+| symptom | cause |
+|---|---|
+| `rcodesign` rejects the `.p12` | wrong certificate type — must be *Developer ID Application*, check with the `openssl x509 -subject` command in §2 |
+| Notarization rejected: "The signature does not include a secure timestamp" | signing ran without network; rcodesign timestamps by default, so this means the timestamp server was unreachable |
+| Notarization rejected: "The executable does not have the hardened runtime enabled" | `--code-signature-flags runtime` missing — the Makefile always passes it, so this means something was signed outside `macos_sign` |
+| Gatekeeper still warns after notarizing | the ticket was not stapled, or the `.dmg` was rebuilt after stapling — staple last |
+| `Team Keys` tab absent in App Store Connect | your Apple ID is not Account Holder/Admin on the team |

--- a/docs/MACOS-SIGNING.md
+++ b/docs/MACOS-SIGNING.md
@@ -73,17 +73,47 @@ At <https://developer.apple.com/account/resources/certificates>:
 5. Download the issued `developerID_application.cer`.
 
 Then combine the certificate with the private key into the `.p12` rcodesign
-wants. `-certfile` is the part that matters: it bundles the intermediate so the
-`.p12` carries leaf **+** chain. Without it you get a leaf-only signature, which
-signs fine and then fails to validate on machines that do not already have the
-intermediate cached — a bug that shows up on other people's Macs, not yours.
+wants. **Two details here are not optional, and both were found the hard way by
+signing a real binary and asking Apple's own `codesign` what it thought.**
 
-**An empty password (`-passout pass:`) is fine**, and is what this project
-uses. PKCS#12 permits it, rcodesign accepts it, and a password protects
-nothing here: the key generated in §1 is already unencrypted on disk beside it,
-and in CI the `.p12` is a bearer credential inside a secret store either way.
-Use one only if you also encrypt or delete that private key. If you do set one,
-keep it with the file — the certificate is valid for 5 years.
+**1. The `.p12` must hold the leaf ONLY — do not add the intermediate.**
+rcodesign takes the *first* certificate in the bundle as the signing
+certificate, and it reads an OpenSSL-written bundle CA-first. Adding
+`-certfile certs/DeveloperIDG2CA.pem` therefore makes it sign with the
+*Developer ID Certification Authority*, producing `TeamIdentifier=G2`,
+`Authority=(unavailable)` and a signature Apple rejects as
+`invalid signature (code or signature have been modified)`. rcodesign registers
+Apple's CA chain by itself:
+
+```
+automatically registered Apple CA certificate: Developer ID Certification Authority
+automatically registered Apple CA certificate: Apple Root CA
+```
+
+so a leaf-only bundle yields the full `Authority` chain anyway.
+
+**2. It must use the legacy PKCS#12 algorithms.** OpenSSL 3 defaults to
+AES-256-CBC + PBKDF2, which rcodesign's PFX parser cannot read — and the error
+it gives points at entirely the wrong thing:
+
+```
+Error: incorrect password given when decrypting PFX data
+```
+
+That message means *unsupported encryption*, not a wrong password. Measured:
+
+| bundle | password | rcodesign |
+|---|---|---|
+| legacy (SHA1/3DES) | empty | accepted |
+| legacy (SHA1/3DES) | set | accepted |
+| OpenSSL 3 default | set | rejected |
+| OpenSSL 3 default | empty | rejected |
+
+**An empty password is fine** — the table shows it is the algorithm that
+matters, not the password. It is what this project uses: the key generated in
+§1 is already unencrypted on disk beside the bundle, and in CI the `.p12` is a
+bearer credential inside a secret store either way, so a password protects
+nothing unless that private key is also encrypted or deleted.
 
 ```sh
 cd ~/.config/mercury-signing
@@ -91,23 +121,32 @@ openssl x509 -inform DER -in developerID_application.cer -out apple_developer_id
 openssl pkcs12 -export \
   -inkey apple_developer_id.key \
   -in apple_developer_id.pem \
-  -certfile certs/DeveloperIDG2CA.pem \
   -name "Developer ID Application: <Team Name>" \
+  -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -macalg sha1 \
   -out apple_developer_id.p12 \
   -passout pass:
 chmod 600 apple_developer_id.p12
-
-# it must contain TWO certificates: the leaf and the G2 intermediate
-openssl pkcs12 -in apple_developer_id.p12 -passin pass: -nokeys 2>/dev/null \
-  | grep -c "BEGIN CERTIFICATE"
 ```
 
-Check it is the certificate you think it is — the common name must start with
-`Developer ID Application:`:
+Verify it end to end rather than by inspection — sign a throwaway Mach-O and
+let Apple judge it. This is the only check that catches both traps above:
 
 ```sh
-openssl pkcs12 -in apple_developer_id.p12 -nodes -passin pass: \
-  | openssl x509 -noout -subject -dates
+cp /bin/echo /tmp/sigtest && chmod +w /tmp/sigtest
+rcodesign sign --p12-file apple_developer_id.p12 --p12-password "" \
+  --code-signature-flags runtime /tmp/sigtest
+codesign -dv --verbose=4 /tmp/sigtest 2>&1 | grep -E "^Authority|TeamIdentifier"
+codesign --verify --strict --verbose=2 /tmp/sigtest
+```
+
+Correct output names your organisation, not the CA, and ends with
+`valid on disk` / `satisfies its Designated Requirement`:
+
+```
+Authority=Developer ID Application: <Your Org> (<TEAMID>)
+Authority=Developer ID Certification Authority
+Authority=Apple Root CA
+TeamIdentifier=<TEAMID>
 ```
 
 Apple's Developer ID certificates are valid for 5 years. Note the expiry: a
@@ -195,7 +234,9 @@ because it teaches people to click through Gatekeeper warnings.
 
 | symptom | cause |
 |---|---|
-| `rcodesign` rejects the `.p12` | wrong certificate type — must be *Developer ID Application*, check with the `openssl x509 -subject` command in §2 |
+| `Error: incorrect password given when decrypting PFX data` | **Not a password problem.** The `.p12` uses OpenSSL 3's default AES-256/PBKDF2, which rcodesign cannot read. Rebuild it with `-keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -macalg sha1` (§2). |
+| Signature has `TeamIdentifier=G2` and `Authority=(unavailable)`; `codesign --verify` says `invalid signature (code or signature have been modified)` | The `.p12` contains the intermediate as well as the leaf, so rcodesign signed with the CA. Rebuild it leaf-only, without `-certfile` (§2). |
+| `rcodesign` rejects the certificate type | must be *Developer ID Application*, check with the `openssl x509 -subject` command in §2 |
 | Notarization rejected: "The signature does not include a secure timestamp" | signing ran without network; rcodesign timestamps by default, so this means the timestamp server was unreachable |
 | Notarization rejected: "The executable does not have the hardened runtime enabled" | `--code-signature-flags runtime` missing — the Makefile always passes it, so this means something was signed outside `macos_sign` |
 | Gatekeeper still warns after notarizing | the ticket was not stapled, or the `.dmg` was rebuilt after stapling — staple last |


### PR DESCRIPTION
The Makefile has had working macOS signing and notarization for a while — `macos_sign` on the CLI binary, the `.app` and the `.dmg`, plus `macos-notarize-dmg`. Nothing ever invoked it: every job in `release.yml` was `ubuntu-latest`, so no macOS artifact was built, let alone signed. A Developer ID is now in hand, so this connects the two.

## What lands

- A **reusable** `macos-dmg.yml` that builds the universal `.dmg`, signs it with the Developer ID certificate, notarizes, staples, runs `spctl`, and uploads it. `release.yml` calls it, so every release ships a signed+notarized DMG (opt-out via `build_macos`), and it is **also dispatchable on its own** so the whole path can be exercised without cutting a release. One definition, two entry points — what gets tested is what ships.
- `docs/MACOS-SIGNING.md`: creating the certificate from Linux with openssl (no Mac, no Keychain Access), the App Store Connect key, the exact `.p12` recipe, and a troubleshooting table.
- A build fix that is **not** macOS-specific (see below).

## Three real bugs, found by rehearsing the procedure on a real Mac first

None was visible by inspection; each needed the next step to actually run. All three would have hit CI identically.

**1. `.p12` encryption.** rcodesign cannot read OpenSSL 3's default AES-256/PBKDF2 bundle, and reports it as `incorrect password given when decrypting PFX data` — pointing at entirely the wrong thing. Measured across four bundles:

| bundle | password | rcodesign |
|---|---|---|
| legacy SHA1/3DES | empty | accepted |
| legacy SHA1/3DES | set | accepted |
| OpenSSL 3 default | set | rejected |
| OpenSSL 3 default | empty | rejected |

Needs `-keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -macalg sha1`. An empty password is fine.

**2. Certificate ordering.** The `.p12` must hold the **leaf only**. rcodesign takes the first certificate in the bundle and reads an OpenSSL-written one CA-first, so adding the intermediate made it sign with the *Certificate Authority*: `TeamIdentifier=G2`, `Authority=(unavailable)`, and Apple's verdict `invalid signature (code or signature have been modified)`. rcodesign registers Apple's CA chain itself, so leaf-only yields the full chain anyway.

**3. Stale objects across architectures** (`4f2473f`, affects any universal build, not just this PR). `datalink_broadcast`'s clean was a flat `rm -f *.o`, so the vendored RaptorQ objects in `raptorq/lib/` and `raptorq/deps/obl/` were never removed. The universal build runs `make clean` between its x86_64 and arm64 slices, so the first slice's objects survived into the second and `ar` refused the archive:

```
ranlib: archive member: libmercury_core.a(nanorq.o) cputype (16777223)
  does not match previous archive members cputype (16777228)
```

`16777223` is `CPU_TYPE_X86_64`, `16777228` is `CPU_TYPE_ARM64`.

## Verified locally

On a real Mac (macOS 15.7.7), signing is proven end to end — Apple's own `codesign` on a signed Mach-O:

```
Authority=Developer ID Application: Rhizomatica Communications (2QA3ZKXV24)
Authority=Developer ID Certification Authority
Authority=Apple Root CA
flags=0x10000(runtime)
valid on disk / satisfies its Designated Requirement
```

The universal DMG builds clean after the RaptorQ fix (`Mercury-1.9.13-universal.dmg`, 52.7 MB).

## Not yet verified

Notarization was submitted and **accepted for processing** by Apple (so the App Store Connect key authenticates), but had not returned a final verdict at the time of writing, and the CI job has not yet been run on a GitHub runner. Both are next; `macos-dmg.yml` can be dispatched to do the latter without publishing.

Repository secrets `MACOS_SIGN_P12_BASE64` and `MACOS_NOTARY_KEY_BASE64` are set. `MACOS_SIGN_P12_PASSWORD` is deliberately optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U142eCU1eL4ZnyXF4EJh8N