### PR TITLE
macos: wait longer for notarization than rcodesign's default

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -30,7 +30,10 @@ jobs:
   macos:
     name: Build and notarize macOS .dmg
     runs-on: macos-latest
-    timeout-minutes: 90
+    # Must exceed the universal build plus MACOS_NOTARY_WAIT (3600s), or the
+    # runner kills a job that is only waiting on Apple.  90 was exactly the
+    # sum, leaving no margin for a slow build.
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -580,6 +580,13 @@ fyne-ui-macos-universal-dmg:
 #
 # then:  make macos-notarize-dmg MACOS_NOTARY_KEY=~/.mercury-notary.json
 MACOS_NOTARY_KEY ?=
+# Apple's notary service is not quick, and rcodesign gives up after 600s by
+# default -- which fails the build even though the submission is still
+# progressing perfectly well.  Measured on a 52 MB .dmg: still "InProgress"
+# past 600s, so the default is not a safe margin, it is a coin toss.  Waiting
+# longer costs nothing when the service is fast.
+MACOS_NOTARY_WAIT ?= 3600
+
 macos-notarize-dmg:
 	@[ -n "$(MACOS_NOTARY_KEY)" ] || { \
 		echo "error: set MACOS_NOTARY_KEY to an encoded App Store Connect key"; \
@@ -589,6 +596,7 @@ macos-notarize-dmg:
 		echo "error: $(MACOS_DMG_UNIVERSAL) not built yet"; exit 1; }
 	$(RCODESIGN) notary-submit \
 		--api-key-file "$(MACOS_NOTARY_KEY)" --staple \
+		--max-wait-seconds $(MACOS_NOTARY_WAIT) \
 		"$(MACOS_DMG_UNIVERSAL)"
 	@echo "  -> $(abspath $(MACOS_DMG_UNIVERSAL))  (notarized + stapled)"
 

--- a/docs/MACOS-SIGNING.md
+++ b/docs/MACOS-SIGNING.md
@@ -201,8 +201,12 @@ make macos-notarize-dmg \
 Signing is **opt-in**: with `MACOS_SIGN_P12` unset the build still completes and
 prints `WARNING: ... is unsigned`, so ordinary developer builds are unchanged.
 
-Notarization takes a few minutes; `--staple` writes the ticket into the `.dmg`
-so it validates even when the user is offline. Verify on a Mac:
+Notarization is **slow and variable** — a 52 MB `.dmg` was still `InProgress`
+past 600 s, which is rcodesign's default wait, so the Makefile passes
+`--max-wait-seconds $(MACOS_NOTARY_WAIT)` (default 3600). Hitting the limit is
+not a rejection: the submission carries on server-side, and
+`rcodesign notary-wait <submission-id>` resumes waiting on it. `--staple` writes
+the ticket into the `.dmg` so it validates even when the user is offline. Verify on a Mac:
 
 ```sh
 codesign --verify --deep --strict --verbose=2 /Applications/Mercury.app


### PR DESCRIPTION
Found by running the real notarization on a real Mac, which is the only way this shows up.

`macos-notarize-dmg` called `notary-submit` without `--max-wait-seconds`, so it used rcodesign's **600 s default**. Apple's notary service routinely needs longer — a 52 MB universal `.dmg` was still `InProgress` past 600 s:

```
created submission ID: bf600d74-0cc8-43ab-84dd-4dd014f22e31
S3 upload completed successfully
waiting up to 600s for package upload ... to finish processing
reached wait limit after 603s
Error: reached time limit waiting for notarization to complete
make: *** [macos-notarize-dmg] Error 1
```

The submission had uploaded cleanly and was progressing normally. In a release this is a failed build with nothing actually wrong — and worse, the `.dmg` never gets stapled even once Apple finishes, so it would ship unstapled if the error were ignored.

## Changes

- `MACOS_NOTARY_WAIT ?= 3600`, passed as `--max-wait-seconds`. Overridable; waiting longer costs nothing when the service is quick. The old default was not a margin, it was a coin toss.
- The CI job's `timeout-minutes` goes 90 → 150. 90 was *exactly* the build plus the new wait, so a slow build would have the runner kill a job that was only waiting on Apple.
- Docs record that hitting the limit is **not** a rejection, and that `rcodesign notary-wait <submission-id>` resumes waiting on an existing submission — not obvious from the error text.

This is the fourth issue in this path that only surfaced by executing the next step, after the PKCS#12 encryption, the leaf-vs-intermediate ordering, and the stale-object architecture clash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U142eCU1eL4ZnyXF4EJh8N