### PR TITLE
macos: sign with entitlements, and staple the .app as well as the .dmg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -424,7 +424,14 @@ MACOS_CLI_PARK       = mercury-cli-universal
 # pinned by indygreg/apple-code-sign-action.
 RCODESIGN ?= rcodesign
 
-# $(call macos_sign,<mach-o | bundle dir | dmg>)
+# Hardened runtime entitlements for the .app.  The runtime is mandatory for
+# notarization and denies audio input and USB HID by default, so without these
+# a perfectly notarized Mercury cannot hear the radio or key it over CM108 --
+# a failure that appears on the user's machine, never in the build.  The CLI
+# binary and the .dmg do not take entitlements.
+MACOS_ENTITLEMENTS ?= $(CURDIR)/macos/entitlements.plist
+
+# $(call macos_sign,<mach-o | bundle dir | dmg>[,<identifier>][,<entitlements>])
 # --code-signature-flags runtime is the hardened runtime, which notarization
 # requires; Apple rejects the upload without it.
 define macos_sign
@@ -439,6 +446,7 @@ define macos_sign
 			--p12-password "$(MACOS_SIGN_P12_PASSWORD)" \
 			--code-signature-flags runtime \
 			$(if $(2),--binary-identifier "$(2)",) \
+			$(if $(3),--entitlements-xml-file "$(3)",) \
 			"$(1)" || exit 1; \
 	else \
 		echo "WARNING: MACOS_SIGN_P12 unset — $(1) is unsigned"; \
@@ -560,7 +568,17 @@ fyne-ui-macos-universal-dmg:
 	@# Seal the bundle before it goes into the image: rcodesign recurses into
 	@# nested Mach-Os and writes Contents/_CodeSignature/CodeResources.
 	@# Signing the image afterwards does NOT sign what is inside it.
-	$(call macos_sign,$(FYNE_UI_DIR)/dmg-stage/$(MACOS_APP_NAME).app)
+	$(call macos_sign,$(FYNE_UI_DIR)/dmg-stage/$(MACOS_APP_NAME).app,,$(MACOS_ENTITLEMENTS))
+	@# Staple BEFORE hdiutil: once the .dmg is built it is read-only, and the
+	@# app inside it can never be given a ticket.  Skipped when no notary key
+	@# is configured, so an ordinary developer build is unaffected.
+	@if [ -n "$(MACOS_NOTARY_KEY)" ] && [ "$(MACOS_STAPLE_APP)" != "0" ]; then \
+		RCODESIGN="$(RCODESIGN)" $(CURDIR)/macos/notarize.sh \
+			"$(FYNE_UI_DIR)/dmg-stage/$(MACOS_APP_NAME).app" "$(MACOS_NOTARY_KEY)" \
+			$(MACOS_NOTARY_WAIT) $(MACOS_NOTARY_RETRIES) || exit 1; \
+	else \
+		echo "NOTE: .app not stapled (no MACOS_NOTARY_KEY); Gatekeeper will check online"; \
+	fi
 	hdiutil create -volname "$(MACOS_APP_NAME) $(MERCURY_VERSION)" \
 		-srcfolder $(FYNE_UI_DIR)/dmg-stage \
 		-ov -format UDZO "$(abspath $(MACOS_DMG_UNIVERSAL))"
@@ -609,6 +627,13 @@ MACOS_NOTARY_WAIT ?= 3600
 MACOS_NOTARY_RETRIES ?= 5
 MACOS_NOTARY_SUBMISSION ?=
 
+# Notarize + staple the .app as well as the .dmg.  Stapling only the .dmg
+# leaves the app the user drags out with no ticket, so Gatekeeper has to ask
+# Apple online at first launch -- exactly the wrong failure mode for stations
+# deployed on poor or no connectivity.  Costs a second Apple round trip; set
+# to 0 to skip it.
+MACOS_STAPLE_APP ?= 1
+
 macos-notarize-dmg:
 	@[ -n "$(MACOS_NOTARY_KEY)" ] || { \
 		echo "error: set MACOS_NOTARY_KEY to an encoded App Store Connect key"; \
@@ -616,43 +641,9 @@ macos-notarize-dmg:
 		exit 1; }
 	@[ -f "$(MACOS_DMG_UNIVERSAL)" ] || { \
 		echo "error: $(MACOS_DMG_UNIVERSAL) not built yet"; exit 1; }
-	@set -e; \
-	sub="$(MACOS_NOTARY_SUBMISSION)"; \
-	if [ -z "$$sub" ]; then \
-		out=$$($(RCODESIGN) notary-submit --api-key-file "$(MACOS_NOTARY_KEY)" \
-			"$(MACOS_DMG_UNIVERSAL)" 2>&1); \
-		echo "$$out"; \
-		sub=$$(printf '%s\n' "$$out" | sed -n 's/^created submission ID: //p' | head -1); \
-	fi; \
-	if [ -z "$$sub" ]; then echo "error: no submission ID from notary-submit"; exit 1; fi; \
-	echo "notarization submission: $$sub"; \
-	echo "  resume with: make macos-notarize-dmg MACOS_NOTARY_SUBMISSION=$$sub"; \
-	n=0; ok=0; \
-	while [ $$n -lt $(MACOS_NOTARY_RETRIES) ]; do \
-		n=$$((n+1)); \
-		if w=$$($(RCODESIGN) notary-wait --api-key-file "$(MACOS_NOTARY_KEY)" \
-			--max-wait-seconds $(MACOS_NOTARY_WAIT) "$$sub" 2>&1); then \
-			echo "$$w"; ok=1; break; \
-		fi; \
-		echo "$$w"; \
-		if printf '%s\n' "$$w" | grep -q "Invalid"; then \
-			echo "error: Apple REJECTED the submission -- not retrying"; \
-			$(RCODESIGN) notary-log --api-key-file "$(MACOS_NOTARY_KEY)" "$$sub" || true; \
-			exit 1; \
-		fi; \
-		if [ $$n -lt $(MACOS_NOTARY_RETRIES) ]; then \
-			echo "notary-wait attempt $$n/$(MACOS_NOTARY_RETRIES) did not complete; retrying in 60s"; \
-			sleep 60; \
-		fi; \
-	done; \
-	if [ $$ok -ne 1 ]; then \
-		echo "error: notarization did not complete for submission $$sub"; \
-		echo "  it may still be processing; resume with:"; \
-		echo "  make macos-notarize-dmg MACOS_NOTARY_SUBMISSION=$$sub"; \
-		exit 1; \
-	fi; \
-	$(RCODESIGN) staple "$(MACOS_DMG_UNIVERSAL)"
-	@echo "  -> $(abspath $(MACOS_DMG_UNIVERSAL))  (notarized + stapled)"
+	RCODESIGN="$(RCODESIGN)" $(CURDIR)/macos/notarize.sh \
+		"$(abspath $(MACOS_DMG_UNIVERSAL))" "$(MACOS_NOTARY_KEY)" \
+		$(MACOS_NOTARY_WAIT) $(MACOS_NOTARY_RETRIES) $(MACOS_NOTARY_SUBMISSION)
 
 # ---- Authenticode signing (Windows binaries) ----
 # Two modes:

--- a/docs/MACOS-SIGNING.md
+++ b/docs/MACOS-SIGNING.md
@@ -213,6 +213,40 @@ codesign --verify --deep --strict --verbose=2 /Applications/Mercury.app
 spctl -a -t open --context context:primary-signature -v Mercury-*.dmg
 ```
 
+## 4b. Entitlements and what actually gets stapled
+
+Two things are easy to get wrong here, and **notarization passes either way** —
+they fail on the user's machine instead.
+
+**The hardened runtime needs entitlements.** Notarization requires the hardened
+runtime, and the runtime denies protected resources by default. An
+`Info.plist` usage string only supplies the prompt text; it grants nothing. So
+`macos/entitlements.plist` declares what Mercury genuinely needs:
+
+| entitlement | why |
+|---|---|
+| `com.apple.security.device.audio-input` | capture audio from the radio — without it the modem cannot hear |
+| `com.apple.security.device.usb` | CM108 USB HID PTT (`radio_io/cm108_ptt.c`) |
+
+Nothing else: every entry widens what the signed binary may do. Check the
+result rather than trusting the flag —
+
+```sh
+codesign -d --entitlements - /Volumes/Mercury*/Mercury.app
+```
+
+**Staple the `.app`, not just the `.dmg`.** A ticket stapled to the `.dmg`
+covers the `.dmg`. The app the user drags to /Applications carries no ticket,
+so Gatekeeper has to ask Apple online at first launch — the wrong failure mode
+for a station on a poor or absent link. The recipe therefore notarizes and
+staples the `.app` **before** `hdiutil` seals it (a `.dmg` is read-only
+afterwards, so it is the last chance), then notarizes and staples the `.dmg`.
+That is two Apple round trips; `MACOS_STAPLE_APP=0` skips the first.
+
+```sh
+xcrun stapler validate /Volumes/Mercury*/Mercury.app   # must NOT say "does not have a ticket"
+```
+
 ## 5. Wire it into CI
 
 The release workflow signs and notarizes the macOS artifact when three

--- a/macos/entitlements.plist
+++ b/macos/entitlements.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Hardened runtime entitlements for Mercury.
+
+         The hardened runtime is required for notarization, and it denies
+         these resources by default.  An Info.plist usage string supplies the
+         prompt text only; it does not grant access.  Keep this list minimal:
+         every entry widens what the signed binary is allowed to do. -->
+
+    <!-- Capture audio from the radio.  Without this the modem cannot hear,
+         and NSMicrophoneUsageDescription alone will not help. -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+
+    <!-- CM108 style USB HID PTT (radio_io/cm108_ptt.c via the vendored
+         hidapi).  IOKit HID access to a USB device is gated by this. -->
+    <key>com.apple.security.device.usb</key>
+    <true/>
+</dict>
+</plist>

--- a/macos/notarize.sh
+++ b/macos/notarize.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Notarize one artifact and staple the ticket to it.
+#
+# Submitting and waiting are deliberately separate operations.  rcodesign's
+# combined `notary-submit --staple` aborts everything if a single poll request
+# fails, and Apple's service is slow enough that an hour-long poll makes one
+# bad request likely rather than unlucky.  Observed on CI:
+#
+#   waiting up to 3600s for package upload 80db453b... to finish processing
+#   Error: error sending request for url (.../notary/v2/submissions/80db453b...)
+#
+# which threw away a 30 minute universal build for a submission Apple was
+# still processing happily.  So: submit once, retry only the waiting, staple
+# as its own step, and print the submission id so a lost run can be resumed
+# rather than rebuilt.
+#
+# A rejection is NOT retried: "Invalid" is Apple's verdict, not a hiccup.
+#
+# usage: notarize.sh <artifact> <api-key-file> [max_wait] [retries] [submission_id]
+set -u
+
+ART=${1:?artifact path required}
+KEY=${2:?api key file required}
+WAIT=${3:-3600}
+RETRIES=${4:-5}
+SUB=${5:-}
+RCODESIGN=${RCODESIGN:-rcodesign}
+
+[ -e "$ART" ] || { echo "error: $ART does not exist"; exit 1; }
+[ -f "$KEY" ] || { echo "error: notary key $KEY does not exist"; exit 1; }
+
+# Apple's notary API takes an archive, not a bundle directory, so a .app is
+# submitted as a ditto zip -- but the TICKET is stapled to the .app itself,
+# never to the throwaway zip.
+UPLOAD="$ART"
+TMPZIP=""
+case "$ART" in
+  *.app)
+    TMPZIP=$(mktemp -d)/$(basename "$ART").zip
+    echo "archiving $(basename "$ART") for submission"
+    ditto -c -k --keepParent "$ART" "$TMPZIP" || exit 1
+    UPLOAD="$TMPZIP"
+    ;;
+esac
+cleanup() { [ -n "$TMPZIP" ] && rm -rf "$(dirname "$TMPZIP")"; }
+trap cleanup EXIT
+
+if [ -z "$SUB" ]; then
+    out=$("$RCODESIGN" notary-submit --api-key-file "$KEY" "$UPLOAD" 2>&1)
+    echo "$out"
+    SUB=$(printf '%s\n' "$out" | sed -n 's/^created submission ID: //p' | head -1)
+fi
+[ -n "$SUB" ] || { echo "error: no submission ID from notary-submit"; exit 1; }
+
+echo "notarization submission: $SUB  ($(basename "$ART"))"
+echo "  resume with: macos/notarize.sh '$ART' '$KEY' $WAIT $RETRIES $SUB"
+
+n=0
+while [ "$n" -lt "$RETRIES" ]; do
+    n=$((n + 1))
+    if w=$("$RCODESIGN" notary-wait --api-key-file "$KEY" --max-wait-seconds "$WAIT" "$SUB" 2>&1); then
+        echo "$w"
+        "$RCODESIGN" staple "$ART" || exit 1
+        echo "  -> $ART (notarized + stapled)"
+        exit 0
+    fi
+    echo "$w"
+    if printf '%s\n' "$w" | grep -q "Invalid"; then
+        echo "error: Apple REJECTED the submission -- not retrying"
+        "$RCODESIGN" notary-log --api-key-file "$KEY" "$SUB" || true
+        exit 1
+    fi
+    if [ "$n" -lt "$RETRIES" ]; then
+        echo "notary-wait attempt $n/$RETRIES did not complete; retrying in 60s"
+        sleep 60
+    fi
+done
+
+echo "error: notarization did not complete for submission $SUB"
+echo "  it may still be processing; resume with:"
+echo "  macos/notarize.sh '$ART' '$KEY' $WAIT $RETRIES $SUB"
+exit 1


### PR DESCRIPTION
Two gaps found by inspecting the notarized artifact rather than trusting that notarization passing means it is right. **Both fail on the user's machine, not in the build** — the pipeline is green either way.

## 1. Hardened runtime with no entitlements

```
$ codesign -d --entitlements - Mercury.app
Executable=/Volumes/Mercury 1.9.13/Mercury.app/Contents/MacOS/mercury-ui
   (nothing else)
```

The hardened runtime is mandatory for notarization and **denies protected resources by default**. `NSMicrophoneUsageDescription` — already in the Info.plist, reading *"Mercury needs access to the radio audio to listen for data signals"* — only supplies the prompt text. It grants nothing.

So a fully signed, fully notarized Mercury could not capture audio. A modem that cannot hear the radio, shipped green.

`macos/entitlements.plist` now declares exactly two things:

| entitlement | why |
|---|---|
| `com.apple.security.device.audio-input` | capture audio from the radio |
| `com.apple.security.device.usb` | CM108 USB HID PTT (`radio_io/cm108_ptt.c`) |

Nothing else — each entry widens what the signed binary may do.

## 2. Only the `.dmg` was stapled

```
$ xcrun stapler validate Mercury.app
Mercury.app does not have a ticket stapled to it.
```

A ticket on the `.dmg` covers the `.dmg`. The app the user drags to /Applications has none, so Gatekeeper must reach Apple **online at first launch** — the wrong failure mode for stations deployed on poor or absent connectivity.

The `.app` is now notarized and stapled **before** `hdiutil` seals it; a `.dmg` is read-only afterwards, so that is the last opportunity. `MACOS_STAPLE_APP=0` skips the extra round trip.

## Refactor

The notarize/retry logic moves from the Makefile into `macos/notarize.sh`, so the `.app` and the `.dmg` share one implementation instead of two that drift. It keeps everything from #250 — submit once, retry only the wait, never retry an `Invalid` verdict, print a resume command — and adds the archiving Apple's API requires for a bundle, while stapling the `.app` itself rather than the throwaway zip.

## Verified on a Mac

```
[Key] com.apple.security.device.audio-input → true
[Key] com.apple.security.device.usb         → true
flags=0x10000(runtime)
Authority=Developer ID Application: Rhizomatica Communications (2QA3ZKXV24)
codesign --verify --strict → exit 0
```

and the script's bundle path archives, submits, and reports a resume command against the `.app`:

```
archiving Mercury.app for submission
created submission ID: 2ba0efe7-...
notarization submission: 2ba0efe7-...  (Mercury.app)
  resume with: macos/notarize.sh 'gui_interface/fyne-ui/Mercury.app' ... 2ba0efe7-...
```

Make's `$(call macos_sign,path,,entitlements)` expansion with an empty middle argument was checked separately, since that is the fiddly part.

**Not verified:** the success path (Apple returning `Accepted` → staple), because Apple has not returned a verdict on any submission yet tonight. It fails closed — a staple failure fails the build and the artifact upload is skipped, so nothing unstapled can ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U142eCU1eL4ZnyXF4EJh8N