### PR TITLE
utils: fix the MFSK sweeps, which compiled but never linked

### DIFF
--- a/utils/Makefile
+++ b/utils/Makefile
@@ -69,11 +69,19 @@ MFSK_DSP_SRC = ../modem/mfsk/mfsk.c ../modem/mfsk/mfsk_ofdm.c ../modem/mfsk/mfsk
                ../modem/mfsk/mfsk_ldpc.c ../modem/mfsk/mfsk_ldpc_1_16.c ../modem/mfsk/mfsk_ldpc_2_16.c \
                ../modem/mfsk/mfsk_ldpc_3_16.c ../modem/mfsk/mfsk_ldpc_5_16.c ../modem/mfsk/mfsk_ldpc_8_16.c
 
-shortframe_sweep: shortframe_sweep.c ../modem/mfsk/mfsk.c
-	$(CC) $(CFLAGS) -I../modem -I../modem/mfsk -o $@ $^ -lm
+# Both link libfreedvdata.a: they exercise the MFSK waveform against the
+# FreeDV LDPC codes, so they need encode(), run_ldpc_decoder() and
+# ldpc_codes_list() -- which live in codec2.c, mpdecode_core.c and
+# ldpc_codes.c respectively.  Without the archive these compile and then fail
+# at link, which is how they sat broken.
+shortframe_sweep: shortframe_sweep.c ../modem/mfsk/mfsk.c ../modem/freedv/libfreedvdata.a
+	$(CC) $(CFLAGS) -I../modem -I../modem/mfsk -I../modem/freedv -o $@ $^ -lm
 
-hail_suffix_sweep: hail_suffix_sweep.c ../modem/mfsk/mfsk.c ../modem/mfsk/mfsk_ofdm.c ../modem/mfsk/mfsk_sync.c
-	$(CC) $(CFLAGS) -I../modem -I../modem/mfsk -o $@ $^ -lm
+# Also needs chanutil (and the Watterson channel it drives), the same set
+# acquire_vs_decode links -- it sweeps the hail suffix over a faded channel.
+hail_suffix_sweep: hail_suffix_sweep.c ../modem/mfsk/mfsk.c ../modem/mfsk/mfsk_ofdm.c ../modem/mfsk/mfsk_sync.c \
+                   chanutil.c ../common/watterson.c ../common/mercury_prng.c ../modem/freedv/libfreedvdata.a
+	$(CC) $(CFLAGS) -I../modem -I../modem/mfsk -I../modem/freedv -o $@ $^ $(LDFLAGS) -lm
 
 mfsk_puncture_sweep: mfsk_puncture_sweep.c ../modem/mfsk/mfsk_ldpc.c ../modem/mfsk/mfsk_ldpc_8_16.c
 	$(CC) $(CFLAGS) -I../modem -I../modem/mfsk -o $@ $^ -lm


### PR DESCRIPTION
`shortframe_sweep` and `hail_suffix_sweep` have been unbuildable — both compile and then fail at link, so `make -C utils` has not actually been clean.

```
undefined reference to `encode'
undefined reference to `run_ldpc_decoder'
undefined reference to `ldpc_codes_list'
undefined reference to `chanutil_open' / `chanutil_run' / ...
```

Both sweeps exercise the MFSK waveform against the FreeDV LDPC codes, so they need `encode()`, `run_ldpc_decoder()` and `ldpc_codes_list()` — `codec2.c`, `mpdecode_core.c` and `ldpc_codes.c`, all already packaged in `libfreedvdata.a`, which their rules simply did not link. `hail_suffix_sweep` additionally drives a faded channel, so it also needs `chanutil.c`, `watterson.c` and `mercury_prng.c` — exactly the set `acquire_vs_decode` already links.

Found while moving the waveform into `modem/mfsk/` (#227). I checked whether the move had broken them and reproduced the identical failure on the branch *before* it, so this is long-standing rather than new — and it means #227's description claiming `make -C utils` clean was not accurate.

All three MFSK sweeps now build and run, and `make -C utils` completes with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxAhNoNeNS53dA67mCfUg6