### PR TITLE
arq: only send an ACCEPT in answer to a CALL we actually heard

### DIFF
--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -1343,7 +1343,6 @@ static void fsm_accepting(arq_session_t *sess, const arq_event_t *ev)
         sess->tx_retries_left   = ARQ_ACCEPT_RETRY_SLOTS;
         sess->accept_tx_pending = true;   /* answering a CALL we just heard */
         sess->deadline_ms       = time_now_ms() + ARQ_CHANNEL_GUARD_MS;
-        sess->deadline_event    = ARQ_EV_TIMER_RETRY;
         break;
 
     case ARQ_EV_TX_COMPLETE:
@@ -1361,11 +1360,11 @@ static void fsm_accepting(arq_session_t *sess, const arq_event_t *ev)
          * because that is the only moment we know the caller has dropped PTT
          * and is listening.  Firing one when this window expires has no phase
          * relationship to the caller at all, and lands in the middle of its
-         * next CALL, where a half-duplex radio is deaf.  Measured on the
-         * Watterson harness at SNR3k -9.8 dB: the answerer keyed an unprompted
-         * ACCEPT at +37.67 s while the caller transmitted CALL#4 from +34.55 to
-         * +38.27 s; two of the three ACCEPTs in that connect were destroyed
-         * that way and the call went unanswered.  4/20 connects failed.
+         * next CALL, where a half-duplex radio is deaf.
+         *
+         * This is a protocol invariant, not a reliability fix: the caller is
+         * deaf over its own transmission, so a blind ACCEPT is wrong whether
+         * or not it happens to collide in any given run.
          *
          * So mark the pending timer as "window", not "ACCEPT".  If the caller
          * is still calling we will hear it and answer that; if we cannot hear

--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -165,6 +165,10 @@ static void sess_enter(arq_session_t *sess, arq_conn_state_t new_state,
      * release. */
     if (new_state == ARQ_CONN_DISCONNECTED || new_state == ARQ_CONN_LISTENING)
         sess->deferred_listen_off = false;
+    /* The right to key an ACCEPT is earned by hearing a CALL, and it does not
+     * survive leaving ACCEPTING. */
+    if (new_state != ARQ_CONN_ACCEPTING)
+        sess->accept_tx_pending = false;
     if (new_state != ARQ_CONN_CONNECTED)
     {
         sess->pending_connect_confirm = false;
@@ -1088,6 +1092,7 @@ static void fsm_listening(arq_session_t *sess, const arq_event_t *ev)
         snprintf(sess->local_call, CALLSIGN_MAX_SIZE, "%s", ev->local_call);
         sess->session_id      = ev->session_id;
         sess->tx_retries_left = ARQ_ACCEPT_RETRY_SLOTS;
+        sess->accept_tx_pending = true;   /* answering a CALL we just heard */
         /* Reset mode state so the payload decoder matches the new caller's
          * initial DATAC15.  This must happen here (not in sess_enter for
          * DISCONNECTED/LISTENING) because LISTENING needs peer_tx_mode to
@@ -1317,8 +1322,28 @@ static void fsm_accepting(arq_session_t *sess, const arq_event_t *ev)
     case ARQ_EV_RX_CALL:
         /* Caller is still retrying CALL (our previous ACCEPT was lost). Reset
          * the retry counter so the ACCEPTING window stays open long enough for
-         * the caller to decode the next ACCEPT and start sending data. */
-        sess->tx_retries_left = ARQ_ACCEPT_RETRY_SLOTS;
+         * the caller to decode the next ACCEPT and start sending data.
+         *
+         * ...and re-anchor the retry to NOW, rather than letting the deadline
+         * set at TX_COMPLETE run its full course.  That deadline is sized to
+         * hold the RX window open for the caller's first DATA burst, so it is
+         * many seconds long.  Waiting it out here is wrong twice over:
+         *
+         *   - It is the wrong question.  A CALL just arrived, which is proof
+         *     the caller is still in CALLING and has NOT begun a data burst,
+         *     so there is nothing for the long window to protect.
+         *   - It desynchronises us from the caller.  The caller retries CALL
+         *     every arq_protocol_call_interval_s(), so a retransmitted ACCEPT
+         *     drifts into the middle of a CALL, and the caller is deaf over
+         *     its own transmission.
+         *
+         * Answering one channel guard after the CALL puts the ACCEPT in the
+         * gap the caller has just opened by dropping PTT -- the same schedule
+         * fsm_listening uses for the first ACCEPT, and for the same reason. */
+        sess->tx_retries_left   = ARQ_ACCEPT_RETRY_SLOTS;
+        sess->accept_tx_pending = true;   /* answering a CALL we just heard */
+        sess->deadline_ms       = time_now_ms() + ARQ_CHANNEL_GUARD_MS;
+        sess->deadline_event    = ARQ_EV_TIMER_RETRY;
         break;
 
     case ARQ_EV_TX_COMPLETE:
@@ -1331,6 +1356,21 @@ static void fsm_accepting(arq_session_t *sess, const arq_event_t *ev)
          * a full ARQ_ACCEPT_RX_WINDOW_MS window (guard + DATAC15 frame +
          * margin) measured from the moment our TX actually ends. */
         sess->deadline_ms = time_now_ms() + ARQ_ACCEPT_RX_WINDOW_MS;
+        /* This deadline is a LISTENING window, not a retransmission timer.  An
+         * ACCEPT is only ever correct one channel guard after a CALL we heard,
+         * because that is the only moment we know the caller has dropped PTT
+         * and is listening.  Firing one when this window expires has no phase
+         * relationship to the caller at all, and lands in the middle of its
+         * next CALL, where a half-duplex radio is deaf.  Measured on the
+         * Watterson harness at SNR3k -9.8 dB: the answerer keyed an unprompted
+         * ACCEPT at +37.67 s while the caller transmitted CALL#4 from +34.55 to
+         * +38.27 s; two of the three ACCEPTs in that connect were destroyed
+         * that way and the call went unanswered.  4/20 connects failed.
+         *
+         * So mark the pending timer as "window", not "ACCEPT".  If the caller
+         * is still calling we will hear it and answer that; if we cannot hear
+         * it, transmitting blind only destroys someone else's burst. */
+        sess->accept_tx_pending = false;
         break;
 
     case ARQ_EV_TIMER_RETRY:
@@ -1347,6 +1387,18 @@ static void fsm_accepting(arq_session_t *sess, const arq_event_t *ev)
         if (sess->tx_retries_left > 0)
         {
             sess->tx_retries_left--;
+            if (!sess->accept_tx_pending)
+            {
+                /* The RX window closed without the caller coming back.  Stay
+                 * off the air -- see the TX_COMPLETE comment above -- and wait
+                 * again, so the budget still bounds how long we hold the
+                 * pending call open. */
+                sess->deadline_ms = retry_deadline_from_s(sess, arq_protocol_call_interval_s());
+                break;
+            }
+            /* Answering a CALL we heard: the caller dropped PTT one channel
+             * guard ago and is listening now. */
+            sess->accept_tx_pending = false;
             send_call_accept(sess, true);
             /* deadline is now managed via TX_COMPLETE above; set a generous
              * fallback here in case TX_COMPLETE is missed for any reason */

--- a/datalink_arq/arq_fsm.h
+++ b/datalink_arq/arq_fsm.h
@@ -224,6 +224,13 @@ typedef struct
                                         * LISTENING vs DISCONNECTED, so an ARQ
                                         * call always returns to where it was   */
 
+    /* --- Connect handshake --- */
+    bool     accept_tx_pending;        /* the pending TIMER_RETRY is an ACCEPT
+                                        * answering a CALL we actually heard,
+                                        * not the RX-window timer.  Only the
+                                        * former may key the transmitter -- see
+                                        * fsm_accepting's TIMER_RETRY.        */
+
     /* --- Teardown flags --- */
     bool     deferred_listen_off;      /* LISTEN OFF received during grace period;
                                         * will be honoured once the grace expires    */

--- a/datalink_arq/arq_fsm.h
+++ b/datalink_arq/arq_fsm.h
@@ -193,7 +193,11 @@ typedef struct
                                         * from ev->mode on every DATA frame    */
 
     /* --- Retry/timeout bookkeeping --- */
-    int      tx_retries_left;          /* retries remaining for current frame  */
+    int      tx_retries_left;          /* retries remaining for current frame.
+                                        * In ACCEPTING this counts TIMER_RETRY
+                                        * slots, not transmissions: a slot may be
+                                        * spent silently when the RX window closes
+                                        * without a CALL (see fsm_accepting).    */
     uint64_t state_enter_ms;          /* when current conn_state was entered   */
     uint64_t startup_deadline_ms;     /* end of control-mode-only startup      */
 

--- a/tests/datalink_arq/test_arq_fsm.c
+++ b/tests/datalink_arq/test_arq_fsm.c
@@ -969,6 +969,57 @@ void test_wait_ack_deadline_stagger_is_exact(void)
     TEST_ASSERT_EQUAL_UINT64(base, sess.deadline_ms);
 }
 
+/* An ACCEPT is only correct one channel guard after a CALL we actually heard:
+ * that is the only moment we know the caller has dropped PTT and is listening.
+ *
+ * The RX window armed at TX_COMPLETE is a LISTENING window, not a retry timer.
+ * Firing an ACCEPT when it expires has no phase relationship to the caller and
+ * lands inside its next CALL, where a half-duplex radio is deaf.  Measured on
+ * the Watterson harness at SNR3k -9.8 dB: an unprompted ACCEPT keyed at
+ * +37.67 s while the caller transmitted CALL#4 from +34.55 to +38.27 s; two of
+ * the three ACCEPTs in that connect were destroyed that way, and 4 of 20
+ * connect attempts failed outright.
+ *
+ * tx_retries_left is spent whether we transmit or merely wait, so the frame
+ * counter is what distinguishes the two. */
+void test_accept_is_only_sent_in_answer_to_a_heard_call(void)
+{
+    enter_accepting();
+
+    /* The CALL that put us here earns one ACCEPT. */
+    int sent = (int)fake_send_tx_frame_fake.call_count;
+    arq_event_t ev = make_event(ARQ_EV_TIMER_RETRY);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(sent + 1, (int)fake_send_tx_frame_fake.call_count);
+
+    /* Our ACCEPT finishes: the deadline now guards the caller's reply. */
+    ev = make_event(ARQ_EV_TX_COMPLETE);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_FALSE(sess.accept_tx_pending);
+
+    /* That window expiring means the caller never came back.  Stay off the air
+     * -- but keep spending the budget, so a pending call stays bounded. */
+    sent = (int)fake_send_tx_frame_fake.call_count;
+    int budget = (int)sess.tx_retries_left;
+    ev = make_event(ARQ_EV_TIMER_RETRY);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(sent, (int)fake_send_tx_frame_fake.call_count);
+    TEST_ASSERT_EQUAL_INT(budget - 1, (int)sess.tx_retries_left);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_ACCEPTING, sess.conn_state);
+
+    /* A fresh CALL re-arms both the budget and the right to transmit, and
+     * re-anchors the ACCEPT to the gap the caller just opened. */
+    arq_event_t call = make_event(ARQ_EV_RX_CALL);
+    call.session_id = 0x42;
+    strncpy(call.remote_call, "REMOTE1", CALLSIGN_MAX_SIZE);
+    arq_fsm_dispatch(&sess, &call);
+    TEST_ASSERT_TRUE(sess.accept_tx_pending);
+
+    ev = make_event(ARQ_EV_TIMER_RETRY);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(sent + 1, (int)fake_send_tx_frame_fake.call_count);
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -1011,5 +1062,6 @@ int main(void)
     RUN_TEST(test_default_call_accept_slots_are_short);
     RUN_TEST(test_stop_listen);
     RUN_TEST(test_timeout_ms_idle);
+    RUN_TEST(test_accept_is_only_sent_in_answer_to_a_heard_call);
     return UNITY_END();
 }

--- a/tests/datalink_arq/test_arq_fsm.c
+++ b/tests/datalink_arq/test_arq_fsm.c
@@ -974,11 +974,9 @@ void test_wait_ack_deadline_stagger_is_exact(void)
  *
  * The RX window armed at TX_COMPLETE is a LISTENING window, not a retry timer.
  * Firing an ACCEPT when it expires has no phase relationship to the caller and
- * lands inside its next CALL, where a half-duplex radio is deaf.  Measured on
- * the Watterson harness at SNR3k -9.8 dB: an unprompted ACCEPT keyed at
- * +37.67 s while the caller transmitted CALL#4 from +34.55 to +38.27 s; two of
- * the three ACCEPTs in that connect were destroyed that way, and 4 of 20
- * connect attempts failed outright.
+ * lands inside its next CALL, where a half-duplex radio is deaf.  This is a
+ * protocol invariant — the caller cannot hear anything over its own
+ * transmission — independent of any measured connect outcome.
  *
  * tx_retries_left is spent whether we transmit or merely wait, so the frame
  * counter is what distinguishes the two. */
@@ -996,6 +994,7 @@ void test_accept_is_only_sent_in_answer_to_a_heard_call(void)
     ev = make_event(ARQ_EV_TX_COMPLETE);
     arq_fsm_dispatch(&sess, &ev);
     TEST_ASSERT_FALSE(sess.accept_tx_pending);
+    TEST_ASSERT_EQUAL_UINT64(1000 + ARQ_ACCEPT_RX_WINDOW_MS, sess.deadline_ms);
 
     /* That window expiring means the caller never came back.  Stay off the air
      * -- but keep spending the budget, so a pending call stays bounded. */
@@ -1008,16 +1007,49 @@ void test_accept_is_only_sent_in_answer_to_a_heard_call(void)
     TEST_ASSERT_EQUAL_INT(ARQ_CONN_ACCEPTING, sess.conn_state);
 
     /* A fresh CALL re-arms both the budget and the right to transmit, and
-     * re-anchors the ACCEPT to the gap the caller just opened. */
+     * re-anchors the ACCEPT to the gap the caller just opened — one channel
+     * guard after NOW, not a leftover RX-window deadline. */
     arq_event_t call = make_event(ARQ_EV_RX_CALL);
     call.session_id = 0x42;
     strncpy(call.remote_call, "REMOTE1", CALLSIGN_MAX_SIZE);
     arq_fsm_dispatch(&sess, &call);
     TEST_ASSERT_TRUE(sess.accept_tx_pending);
+    TEST_ASSERT_EQUAL_UINT64(1000 + ARQ_CHANNEL_GUARD_MS, sess.deadline_ms);
 
     ev = make_event(ARQ_EV_TIMER_RETRY);
     arq_fsm_dispatch(&sess, &ev);
     TEST_ASSERT_EQUAL_INT(sent + 1, (int)fake_send_tx_frame_fake.call_count);
+}
+
+/* The silent-wait give-up path: after the RX window armed at TX_COMPLETE
+ * closes without another CALL, we must hold the pending call open for the
+ * remaining budget WITHOUT transmitting again, then return to LISTENING. */
+void test_accepting_silent_wait_gives_up_after_budget(void)
+{
+    enter_accepting();
+
+    /* First (and only) ACCEPT, anchored to the CALL that put us here. */
+    arq_event_t ev = make_event(ARQ_EV_TIMER_RETRY);
+    arq_fsm_dispatch(&sess, &ev);
+    int sent = (int)fake_send_tx_frame_fake.call_count;
+    TEST_ASSERT_EQUAL_INT(1, sent);
+
+    /* ACCEPT finishes; the caller never comes back. */
+    ev = make_event(ARQ_EV_TX_COMPLETE);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_FALSE(sess.accept_tx_pending);
+
+    /* Exhaust the remaining budget through silent waits: every slot must be
+     * spent off the air, and the give-up must still arrive. */
+    for (int i = 0; i < ARQ_ACCEPT_RETRY_SLOTS + 2; i++) {
+        ev = make_event(ARQ_EV_TIMER_RETRY);
+        mock_set_uptime_ms(1000 + (uint64_t)(i + 1) * 10000);
+        arq_fsm_dispatch(&sess, &ev);
+        TEST_ASSERT_EQUAL_INT(sent, (int)fake_send_tx_frame_fake.call_count);
+        if (sess.conn_state == ARQ_CONN_LISTENING)
+            break;
+    }
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_LISTENING, sess.conn_state);
 }
 
 int main(void)
@@ -1063,5 +1095,6 @@ int main(void)
     RUN_TEST(test_stop_listen);
     RUN_TEST(test_timeout_ms_idle);
     RUN_TEST(test_accept_is_only_sent_in_answer_to_a_heard_call);
+    RUN_TEST(test_accepting_silent_wait_gives_up_after_budget);
     return UNITY_END();
 }


### PR DESCRIPTION
> **Correction, 2026-09-08.** The original description of this PR claimed these changes fix connect failures at the fringe, and cited a measured 4/20 baseline. **That evidence does not hold** and I have rewritten the description below. The code change is, I believe, still correct — but it should be judged as a protocol invariant, not as a reliability fix. See "Why the original evidence was wrong".

## What this changes

Half-duplex: the caller is deaf while it transmits. An ACCEPT is therefore only correct in the gap the caller opens by dropping PTT, and the only evidence we have that the gap is open is having just decoded a CALL.

Two paths in `ACCEPTING` did not respect that:

- **`ARQ_EV_RX_CALL`** reset the retry counter but left the deadline alone, so a retransmitted ACCEPT still fired relative to *our own* previous transmission rather than to the caller's. Now re-anchored to one channel guard after the heard CALL — the same schedule `fsm_listening` already uses for the first ACCEPT, and for the same reason.
- **`ARQ_EV_TX_COMPLETE`** arms the same `TIMER_RETRY` with `ARQ_ACCEPT_RX_WINDOW_MS` to hold the RX window open for the caller's first data burst. That is a *listening* window — but its expiry also transmitted an ACCEPT, one with no phase relationship to the caller at all. `accept_tx_pending` now records which of the two armed the pending timer; only a CALL-anchored one may key the transmitter. When the window expires we spend a retry slot and stay silent.

If the caller is still calling, we hear it and answer that. If we cannot hear it, transmitting blind only destroys someone else's burst.

This is arithmetic on protocol constants plus the CALL we decoded — **no carrier sense, no `channel_busy`**. It works against a hidden terminal, which sensing would not.

Unit test `test_accept_is_only_sent_in_answer_to_a_heard_call` pins the invariant: the CALL-anchored timer transmits, the window timer spends budget and stays silent, a fresh CALL re-arms both.

## Why the original evidence was wrong

The original description said two of three ACCEPTs in a failing connect were destroyed by the caller transmitting over them, and quoted a 4/20 connect-failure baseline.

The collision I traced was real. What was not real was the inference that it causes connect failures:

- Those runs were measured on the FIFO bridge, where **the same seed and binary gave 2995 / 3811 / 3523 blocks** across three consecutive runs. Any per-run comparison on that harness is noise. (Fixed since, in #259.)
- The A/B I ran gave **base 4/20 vs fix 5/20** — no improvement, well inside the noise for n=20.
- On the deterministic bench, **every ACCEPT in the failing runs goes out in clear air** with the caller listening. There is no collision to fix in the failures we actually have.

The real cause is that the handshake needs two marginal acquisitions to both succeed. Measured on the deterministic bench with a calibrated SNR axis, at −9.7 dB SNR3k:

| | acquired | delivered |
|---|---|---|
| DATAC16 standalone (`utils/acquire_vs_decode`, 100 bursts) | 80% | **61%** |
| Mercury, answerer decoding CALLs (10 windows) | 70% | **60%** |

Mercury matches the waveform's ceiling. Connect needs a CALL *and* an ACCEPT to survive at p≈0.6, which produces the ~20–25% failure rate we measure. It is DATAC16's cliff, not a bug.

## The second commit, with the same caveat

`tests/integration: drop audio the peer is not reading, like a radio does` — the FIFO bridge retried on `EAGAIN` until the peer drained, which makes the pipe a buffer holding a burst back through the peer's transmission and delivering it afterwards. A radio has no such buffer.

The principle is right. The specific measurement quoted in that commit message (an answerer raising `RX_CALL` 5.86 s late) came from overlaying two processes' traces that were **not on a common clock** — the trace stamps were process uptime, and the stations start at different times. Treat that number as unreliable; the argument stands on the mismatch with how a radio behaves, not on that figure.

## What I would do with this PR

Merge it if you agree the invariant is right — "never key over a burst you cannot hear, and only answer a CALL you actually heard" is correct regardless of whether it moves the failure rate. Do not merge it expecting better connect reliability at the fringe; that needs a more robust control exchange, and the deterministic bench can now measure such a change honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTdTF7sefPbDiFx1g5nt8k
