### PR TITLE
gui: make client window scrollable and persist chat window geometry

### DIFF
--- a/gui_interface/fyne-ui/mercury_chat_window.go
+++ b/gui_interface/fyne-ui/mercury_chat_window.go
@@ -227,8 +227,11 @@ func (cw *chatWindow) build(app fyne.App, telemetry telemetryState, arqPort, bro
 	)
 
 	cw.win.SetContent(container.NewHSplit(left, right))
-	cw.win.Resize(fyne.NewSize(800, 600))
+	// Restore previously saved geometry (or fall back to sensible defaults)
+	restoreWindowGeometry(cw.win, app.Preferences())
 	cw.win.SetOnClosed(func() {
+		// Save window geometry so the user's resize/position persists.
+		saveWindowGeometry(cw.win, app.Preferences())
 		if cw.bcastFile != nil {
 			cw.bcastFile.stopForShutdown()
 		}

--- a/gui_interface/fyne-ui/mercury_chat_window.go
+++ b/gui_interface/fyne-ui/mercury_chat_window.go
@@ -226,7 +226,9 @@ func (cw *chatWindow) build(app fyne.App, telemetry telemetryState, arqPort, bro
 		),
 	)
 
-	cw.win.SetContent(container.NewHSplit(left, right))
+	// Make the whole client window scrollable so small displays can access
+	// the Broadcast file panel and other controls by scrolling.
+	cw.win.SetContent(container.NewScroll(container.NewHSplit(left, right)))
 	// Restore previously saved geometry (or fall back to sensible defaults)
 	restoreWindowGeometry(cw.win, app.Preferences())
 	cw.win.SetOnClosed(func() {


### PR DESCRIPTION
## Summary

- Makes the whole chat client window scrollable so small displays can reach the Broadcast file panel and other controls by scrolling.
- Restores previously saved window geometry on startup and saves it on close so the user's resize/position persists across sessions.