### PR TITLE
audioio: report the CoreAudio OSStatus, and stop leaking IOProcs on failure

### DIFF
--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -1592,8 +1592,14 @@ void *radio_capture_thread(void *device_ptr)
         r = audio->read(b, (const void **)&buffer);
         if (r < 0)
         {
+            /* A device that fails every read fails it hundreds of times a
+             * second.  Log the first, then thin out: the useful information is
+             * the error text and that it is persisting, not one line per
+             * attempt drowning the rest of the session (issue #254). */
             diag_read_errors++;
-            HLOGE("audio-cap", "ffaudio.read: %s", audio->error(b));
+            if (diag_read_errors == 1 || (diag_read_errors % 256) == 0)
+                HLOGE("audio-cap", "ffaudio.read: %s (error %u)",
+                      audio->error(b), diag_read_errors);
         }
         if (r <= 0)
         {
@@ -1607,15 +1613,31 @@ void *radio_capture_thread(void *device_ptr)
                       (unsigned long long)(now - cap_last_data_ms), ++diag_reopens);
                 audio->free(b);
                 b = NULL;
+                /* Keep trying -- a USB radio interface can come back -- but
+                 * back off instead of hammering the device every 200 ms, and
+                 * do not print a line per attempt.  The old loop produced an
+                 * unbounded error stream that buried the reason it was
+                 * failing (issue #254). */
+                unsigned attempt = 0;
+                unsigned delay_ms = 200;
                 while (!shutdown_ && !audio_shutdown_)
                 {
                     b = audio->alloc();
                     if (b != NULL && audio->open(b, cfg, conf.flags) == 0)
+                    {
+                        if (attempt != 0)
+                            HLOGI("audio-cap", "capture reopened after %u attempts",
+                                  attempt + 1);
                         break;
-                    HLOGE("audio-cap", "capture reopen failed: %s",
-                          b ? audio->error(b) : "alloc()");
+                    }
+                    attempt++;
+                    if (attempt == 1 || (attempt % 16) == 0)
+                        HLOGE("audio-cap", "capture reopen failed (attempt %u): %s",
+                              attempt, b ? audio->error(b) : "alloc()");
                     if (b != NULL) { audio->free(b); b = NULL; }
-                    ffthread_sleep(200);
+                    ffthread_sleep(delay_ms);
+                    if (delay_ms < 5000)
+                        delay_ms *= 2;
                 }
                 if (b == NULL)   /* shutdown requested mid-reopen */
                 {

--- a/audioio/ffaudio/ffaudio/coreaudio.c
+++ b/audioio/ffaudio/ffaudio/coreaudio.c
@@ -222,7 +222,35 @@ struct ffaudio_buf {
 	ffring_head rhead;
 
 	const char *errfunc;
+	/* CoreAudio reports every failure as an OSStatus, and the reason lives in
+	 * that code -- device gone, format refused, permission, hardware not
+	 * running.  Recording only the function name (as this did) turns a
+	 * diagnosable fault into "AudioDeviceStart failed" with nothing to act on;
+	 * see issue #254, where that is exactly what happened. */
+	char errbuf[96];
 };
+
+/* Format "func: 'four' (-10851)".  Most CoreAudio statuses are four-character
+ * codes ('nope', '!dat', 'stop'); the numeric form is kept for the ones that
+ * are not printable. */
+static void coreaudio_err(ffaudio_buf *b, const char *func, OSStatus st)
+{
+	unsigned char c[4] = {
+		(unsigned char)(st >> 24), (unsigned char)(st >> 16),
+		(unsigned char)(st >> 8),  (unsigned char)st,
+	};
+	int printable = 1;
+	for (int i = 0; i != 4; i++) {
+		if (c[i] < 0x20 || c[i] > 0x7e)
+			printable = 0;
+	}
+	if (printable)
+		snprintf(b->errbuf, sizeof(b->errbuf), "%s: '%c%c%c%c' (%d)",
+			 func, c[0], c[1], c[2], c[3], (int)st);
+	else
+		snprintf(b->errbuf, sizeof(b->errbuf), "%s: (%d)", func, (int)st);
+	b->errfunc = b->errbuf;
+}
 
 ffaudio_buf* ffcoreaudio_alloc()
 {
@@ -238,7 +266,8 @@ void ffcoreaudio_free(ffaudio_buf *b)
 		return;
 
 	ffring_free(b->ring);
-	AudioDeviceDestroyIOProcID(b->dev, b->aprocid);
+	if (b->aprocid != NULL)
+		AudioDeviceDestroyIOProcID(b->dev, (AudioDeviceIOProcID)b->aprocid);
 	ffmem_free(b);
 }
 
@@ -308,9 +337,10 @@ int ffcoreaudio_open(ffaudio_buf *b, ffaudio_conf *conf, ffuint flags)
 	AudioStreamBasicDescription asbd = {};
 	ffuint size = sizeof(asbd);
 	const AudioObjectPropertyAddress *a = (capture) ? &prop_idev_fmt : &prop_odev_fmt;
-	if (0 != AudioObjectGetPropertyData(dev, a, 0, NULL, &size, &asbd)) {
-		b->errfunc = "AudioStreamBasicDescription";
-		return -1;
+	OSStatus st;
+	if (0 != (st = AudioObjectGetPropertyData(dev, a, 0, NULL, &size, &asbd))) {
+		coreaudio_err(b, "AudioStreamBasicDescription", st);
+		return FFAUDIO_ERROR;
 	}
 
 	int new_format = 0;
@@ -333,9 +363,10 @@ int ffcoreaudio_open(ffaudio_buf *b, ffaudio_conf *conf, ffuint flags)
 		return FFAUDIO_EFORMAT;
 
 	void *proc = (capture) ? coreaudio_ioproc_capture : coreaudio_ioproc_playback;
-	if (0 != AudioDeviceCreateIOProcID(dev, proc, b, (AudioDeviceIOProcID*)&b->aprocid)
+	b->aprocid = NULL;
+	if (0 != (st = AudioDeviceCreateIOProcID(dev, proc, b, (AudioDeviceIOProcID*)&b->aprocid))
 		|| b->aprocid == NULL) {
-		b->errfunc = "AudioDeviceCreateIOProcID";
+		coreaudio_err(b, "AudioDeviceCreateIOProcID", st);
 		goto end;
 	}
 
@@ -352,15 +383,26 @@ int ffcoreaudio_open(ffaudio_buf *b, ffaudio_conf *conf, ffuint flags)
 	rc = 0;
 
 end:
-	if (rc != 0)
-		AudioDeviceDestroyIOProcID(b->dev, b->aprocid);
+	if (rc != 0) {
+		/* Destroy the proc on the device it was CREATED on.  b->dev is only
+		 * assigned on the success path above, so it still holds 0 (first open)
+		 * or the previous device (a reopen) -- destroying against it leaves the
+		 * new proc registered on `dev` for the lifetime of the process, one
+		 * leaked proc per failed open.  A reopen loop retrying every 200 ms,
+		 * as in issue #254, leaks them at that rate. */
+		if (b->aprocid != NULL) {
+			AudioDeviceDestroyIOProcID(dev, (AudioDeviceIOProcID)b->aprocid);
+			b->aprocid = NULL;
+		}
+	}
 	return rc;
 }
 
 int ffcoreaudio_start(ffaudio_buf *b)
 {
-	if (0 != AudioDeviceStart(b->dev, b->aprocid)) {
-		b->errfunc = "AudioDeviceStart";
+	OSStatus st;
+	if (0 != (st = AudioDeviceStart(b->dev, b->aprocid))) {
+		coreaudio_err(b, "AudioDeviceStart", st);
 		return FFAUDIO_ERROR;
 	}
 	return 0;
@@ -368,8 +410,9 @@ int ffcoreaudio_start(ffaudio_buf *b)
 
 int ffcoreaudio_stop(ffaudio_buf *b)
 {
-	if (0 != AudioDeviceStop(b->dev, b->aprocid)) {
-		b->errfunc = "AudioDeviceStop";
+	OSStatus st;
+	if (0 != (st = AudioDeviceStop(b->dev, b->aprocid))) {
+		coreaudio_err(b, "AudioDeviceStop", st);
 		return FFAUDIO_ERROR;
 	}
 	return 0;


### PR DESCRIPTION
Addresses #254 (macOS Tahoe: CoreAudio capture opens, then `AudioDeviceStart` fails and reopen loops forever).

## What this does and does not claim

It does **not** claim to fix the Tahoe failure. I have no Tahoe machine and the report contains no `OSStatus`, so any root cause I proposed would be a guess.

What it does is make that failure diagnosable, and fix two real defects found while reading the path.

## The report can't be acted on, and that's our fault

CoreAudio puts the reason in the `OSStatus` — device gone, format refused, hardware not running, permission. Every call site in `coreaudio.c` discarded it and recorded only the name of the function that failed, so the logs in #254 say:

```
[ERR] [audio-cap] ffaudio.read: AudioDeviceStart
[ERR] [audio-cap] capture reopen failed: AudioStreamBasicDescription
```

which restates the symptom. Now they say:

```
[ERR] [audio-cap] ffaudio.read: AudioDeviceStart: 'nope' (-10851)
```

Most CoreAudio statuses are four-character codes, so it prints that when the bytes are printable and the number otherwise. **The next report on this issue should identify the cause.**

## Two defects fixed

**IOProc leaked on every failed open.** `ffcoreaudio_open()`'s cleanup destroyed the proc against `b->dev` — but `b->dev` is only assigned on the success path a few lines further down:

```c
b->dev = dev;      // success path only
rc = 0;
end:
    if (rc != 0)
        AudioDeviceDestroyIOProcID(b->dev, b->aprocid);   // stale
```

So on a first open `b->dev` is 0, and on a reopen it is the *previous* device. A proc created on `dev` was never destroyed and stayed registered for the life of the process — one leak per failed open, and #254's reopen loop retries every 200 ms. Now destroyed on `dev`, with `aprocid` cleared so nothing acts on a stale id later.

**`ffcoreaudio_free()` destroyed unconditionally**, including for a buffer whose open never got as far as creating a proc.

Neither is the Tahoe failure itself — they are what makes it worse once it starts.

## Recovery no longer spins loudly

A device that fails every read fails it hundreds of times a second, and the reopen loop retried at a fixed 200 ms printing a line each time, burying the one line worth reading. Now: log the first occurrence then thin out, and back the reopen off from 200 ms to a 5 s ceiling.

It still retries **indefinitely**, deliberately. The issue asks for no "unbounded error loop"; I read that as the log flood and the hammering, not as a request to give up — a USB radio interface can come back, and abandoning it silently would be worse than waiting. A successful reopen now logs how many attempts it took.

## Verification

Linux/Windows builds are unaffected (`coreaudio.c` isn't compiled there); the macOS arm64 CI job is the real check on this diff. The `audioio.c` changes build clean on Linux.

I can't exercise the failure path without the hardware, so the useful next step is for the reporter to run a build from this branch and post the `OSStatus` — with that, the actual bug is likely a short fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTdTF7sefPbDiFx1g5nt8k
