### PR TITLE
audioio: keep IOProc ownership correct, and cap the reopen backoff where it says

### DIFF
--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -1635,9 +1635,18 @@ void *radio_capture_thread(void *device_ptr)
                         HLOGE("audio-cap", "capture reopen failed (attempt %u): %s",
                               attempt, b ? audio->error(b) : "alloc()");
                     if (b != NULL) { audio->free(b); b = NULL; }
-                    ffthread_sleep(delay_ms);
-                    if (delay_ms < 5000)
-                        delay_ms *= 2;
+                    /* Sleep in short steps so a shutdown during recovery is
+                     * still prompt: a single ffthread_sleep(5000) here makes
+                     * the user wait out the whole backoff before the process
+                     * will exit. */
+                    for (unsigned slept = 0; slept < delay_ms &&
+                                             !shutdown_ && !audio_shutdown_;
+                         slept += 100)
+                        ffthread_sleep(100);
+                    /* Double up to the ceiling, do not overshoot it: the old
+                     * form (`if (delay_ms < 5000) delay_ms *= 2`) stepped
+                     * 3200 -> 6400, past the 5 s cap it advertises. */
+                    delay_ms = (delay_ms < 2500) ? delay_ms * 2 : 5000;
                 }
                 if (b == NULL)   /* shutdown requested mid-reopen */
                 {

--- a/audioio/ffaudio/ffaudio/coreaudio.c
+++ b/audioio/ffaudio/ffaudio/coreaudio.c
@@ -265,9 +265,18 @@ void ffcoreaudio_free(ffaudio_buf *b)
 	if (b == NULL)
 		return;
 
-	ffring_free(b->ring);
-	if (b->aprocid != NULL)
+	/* Order matters: the IOProc writes into b->ring from CoreAudio's own
+	 * thread, so it has to be stopped and destroyed BEFORE the ring is freed.
+	 * Freeing first leaves a live callback writing into released memory --
+	 * rare, timing-dependent, and exactly the kind of fault that shows up as
+	 * an unrelated crash much later.  Stop first: destroying a running IOProc
+	 * is not defined to be safe. */
+	if (b->aprocid != NULL) {
+		AudioDeviceStop(b->dev, (AudioDeviceIOProcID)b->aprocid);
 		AudioDeviceDestroyIOProcID(b->dev, (AudioDeviceIOProcID)b->aprocid);
+		b->aprocid = NULL;
+	}
+	ffring_free(b->ring);
 	ffmem_free(b);
 }
 
@@ -391,8 +400,17 @@ end:
 		 * leaked proc per failed open.  A reopen loop retrying every 200 ms,
 		 * as in issue #254, leaks them at that rate. */
 		if (b->aprocid != NULL) {
-			AudioDeviceDestroyIOProcID(dev, (AudioDeviceIOProcID)b->aprocid);
-			b->aprocid = NULL;
+			/* Only drop the handle if the proc is really gone.  Clearing it
+			 * unconditionally discards the one reference we have to a proc
+			 * that is still registered on the device, so nothing can ever
+			 * clean it up -- the leak this block exists to prevent, arrived
+			 * at from the other side.  Keep it and let ffcoreaudio_free()
+			 * try again; b->dev is set below only on success, so record the
+			 * device the proc actually belongs to. */
+			if (0 == AudioDeviceDestroyIOProcID(dev, (AudioDeviceIOProcID)b->aprocid))
+				b->aprocid = NULL;
+			else
+				b->dev = dev;
 		}
 	}
 	return rc;


### PR DESCRIPTION
Follow-up to #260, addressing @N4EAC's review on #254. He raised three points; **all three were correct, and #260 was merged before I had read them.** That was my mistake — I checked the issue's comments when writing the PR and did not re-check before merging.

## What he caught

**1. `ffcoreaudio_free()` freed the ring before destroying the IOProc.**

The IOProc writes into `b->ring` from CoreAudio's own thread, so the callback could still be running against released memory. Rare, timing-dependent, and the kind of fault that surfaces later as an unrelated crash. Now stops and destroys the proc first, *then* frees the ring — stop before destroy, since destroying a running IOProc isn't defined to be safe.

**2. Failed-open cleanup cleared the handle even when destruction failed.**

```c
AudioDeviceDestroyIOProcID(dev, b->aprocid);
b->aprocid = NULL;              /* even if that failed */
```

If the destroy fails, that discards the only reference to a proc still registered on the device — the same leak the block exists to prevent, reached from the other side. Now the handle is kept when destruction fails, and `b->dev` records the device it belongs to so a later `free()` can try again.

**3. The backoff overshot its own ceiling.**

`if (delay_ms < 5000) delay_ms *= 2;` steps 3200 → **6400** ms, past the 5 s cap it advertises. Now doubles up to the cap, not past it: 200 / 400 / 800 / 1600 / 3200 / 5000 / 5000.

**4. His fourth point — shutdown responsiveness.**

The backoff slept in a single call, so a shutdown during recovery waited out the whole interval before the process would exit. Now sleeps in 100 ms steps and stops on the shutdown flags.

## Not in this PR

Eduardo is carrying separate shutdown fixes — a broadcast listener blocked in `accept()` across a thread join, and a disconnect race that can strand a sender in `read_buffer()` — with hardware-free regressions. Those are his and stay separate, as he proposed.

He also reports that a focused test confirms #260 reports the status correctly, and that local builds passed a ten-minute FT-710 receive-only observation plus restarts — while noting, correctly, that this does not establish the original stall's cause.

## Verification

Build green, unit suite green. `coreaudio.c` is only compiled on macOS, so the macOS arm64 CI job is the real check here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTdTF7sefPbDiFx1g5nt8k
