### PR TITLE
audioio: follow a device that comes back under a new id

### DIFF
--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -1987,9 +1987,27 @@ int get_soundcard_list(int audio_system, int mode,
  * enumerable devices (NULL/FIFO/SOCK/SHM), enumeration fails, or a
  * substring match is ambiguous, buf is left untouched -- callers get
  * exactly today's behavior. */
+/* Display name of the device each direction last resolved to.
+ *
+ * A native device id is not necessarily stable: CoreAudio AudioDeviceIDs are
+ * assigned per enumeration and a USB interface that drops off the bus and
+ * comes back gets a NEW one.  A config holding a numeric id (which is what the
+ * UI writes) then points at nothing, and every reopen fails in
+ * AudioObjectGetPropertyData -- reported, before the diagnostics landed, as a
+ * bare "AudioStreamBasicDescription" and, with them, as '!obj'
+ * (kAudioHardwareBadObjectError).  Verified on macOS: an id that is not in the
+ * device list produces exactly that.
+ *
+ * Names survive re-enumeration where ids do not, so remember the name we
+ * opened and fall back to it when the id stops resolving.  This is the reopen
+ * path for issue #254's failure shape, and it costs nothing on the ordinary
+ * path where the id is still valid. */
+static char s_resolved_name[2][160];
+
 static void resolve_device_string(int audio_subsys, int mode, char *buf, size_t bufsz,
                                   const char *log_tag, bool pulse_lock_held)
 {
+    const int dirslot = (mode == FFAUDIO_DEV_CAPTURE) ? 0 : 1;
     /* An empty device means "the default".  Most backends take that as NULL and
      * choose sensibly, but OSS cannot: ffaudio falls back to /dev/dsp for BOTH
      * directions, and on OSSv4 /dev/dsp is one node -- commonly playback-only.
@@ -2032,6 +2050,10 @@ static void resolve_device_string(int audio_subsys, int mode, char *buf, size_t 
     for (int i = 0; i < n; i++) {
         if (strcmp(buf, ids[i]) == 0) {
             already_native = true;   // already a valid native id
+            /* Remember what this id is called, so a later re-enumeration can
+             * be followed by name.  See s_resolved_name. */
+            snprintf(s_resolved_name[dirslot], sizeof(s_resolved_name[dirslot]),
+                     "%s", names[i] ? names[i] : "");
             break;
         }
     }
@@ -2068,13 +2090,36 @@ static void resolve_device_string(int audio_subsys, int mode, char *buf, size_t 
     } else if (matches > 1) {
         HLOGW(log_tag, "device name '%s' is ambiguous (%d matches) -- use an exact id from -z instead", buf, matches);
     } else {
-        /* Not a prediction of failure: enumeration does not see every valid
-         * node.  Every /dev/dsp* symlink is a working OSS device that never
-         * appears in SNDCTL_AUDIOINFO_EX under that name, and ALSA takes
-         * plughw:/hw: strings that are absent from the list too.  If the open
-         * really does fail, that is reported with the driver's own reason. */
-        HLOGI(log_tag, "device '%s' is not in the enumerated list -- passing it to the "
-                       "driver as given (-z lists the enumerated devices)", buf);
+        /* The id we were given is gone.  If we have opened this direction
+         * before, the device it named may simply have come back under a new
+         * id -- follow it by name rather than handing the driver a stale
+         * number that cannot resolve. */
+        int rematch = -1, rematches = 0;
+        if (s_resolved_name[dirslot][0] != '\0') {
+            for (int i = 0; i < n; i++) {
+                if (ffsz_ieq(s_resolved_name[dirslot], names[i])) {
+                    if (rematches == 0)
+                        rematch = i;
+                    rematches++;
+                }
+            }
+        }
+        if (rematches == 1) {
+            HLOGW(log_tag, "device id '%s' is gone; '%s' is now id=%s -- following it "
+                           "(the device re-enumerated)",
+                  buf, names[rematch], ids[rematch]);
+            strncpy(buf, ids[rematch], bufsz - 1);
+            buf[bufsz - 1] = '\0';
+        } else {
+            /* Not a prediction of failure: enumeration does not see every
+             * valid node.  Every /dev/dsp* symlink is a working OSS device
+             * that never appears in SNDCTL_AUDIOINFO_EX under that name, and
+             * ALSA takes plughw:/hw: strings absent from the list too.  If the
+             * open really does fail, that is reported with the driver's own
+             * reason. */
+            HLOGI(log_tag, "device '%s' is not in the enumerated list -- passing it to the "
+                           "driver as given (-z lists the enumerated devices)", buf);
+        }
     }
 
 done:


### PR DESCRIPTION
> **Scope correction.** This fixes re-enumeration **within a running process** only. It does **not** fix the across-restarts case, which is probably the more common one. See "What this does not fix".

Addresses part of the reopen half of #254.

## The mechanism

CoreAudio assigns `AudioDeviceID`s per enumeration, so a USB interface that drops off the bus and comes back gets a **new** one. The UI sends the numeric id and it is stored verbatim (`input_device = "124"`), so once the id moves it points at nothing and the open fails inside `AudioObjectGetPropertyData`.

**Verified on macOS 15.7.9**: an id absent from the device list fails exactly that call, reported by the new diagnostics as `'!obj'` (`kAudioHardwareBadObjectError`, 560947818) — the same call whose bare name appears in #254's reopen loop.

## What this fixes

Within one process: record the name each direction resolved to, and if that id later stops appearing in the device list, follow the name to whatever id it holds now. Only on an unambiguous match, since duplicate display names are common and binding the wrong one would key the wrong radio.

That covers "the device glitched mid-session and came back", which is the shape of #254's stall-then-reopen loop.

## What this does NOT fix

The name is held in a process-local static. On a **fresh start** it is empty, and the config still holds a numeric id. So if the device was re-enumerated while Mercury was not running — unplug the radio, reboot, start Mercury — the id is stale, there is nothing to fall back to, and the open fails exactly as before.

That case needs a **stable identifier persisted in the config**, not a volatile index. The resolver already accepts a name, so the missing piece is on the writing side. Sketch:

- persist the device **name** alongside the id (e.g. `input_device_name`), written when a device is selected or successfully opened
- at open: use the id if it still resolves *and* still carries that name; otherwise re-resolve by name
- keep the id as a fast path and a tie-break for duplicate names

That is a config-schema and UI change, so it is deliberately not in this PR.

## Risk

Narrow. On the normal path nothing changes but recording a name. The new branch is reached only where the old code was already passing through an id that could not resolve.

## Tested

macOS 15.7.9 (x86_64 VM, BlackHole 2ch): open by id, open by name, capture runs, clean shutdown; bogus id fails with `'!obj'`. Linux and CI green including macOS arm64.

**Not tested: the fallback branch itself** — it needs a device to genuinely disappear between opens, which that VM cannot stage. It wants the reporter's hardware or a USB device unplugged mid-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTdTF7sefPbDiFx1g5nt8k
