### PR TITLE
audioio: identify CoreAudio devices by UID, not by enumeration index

### DIFF
--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -2073,19 +2073,18 @@ static void resolve_device_string(int audio_subsys, int mode, char *buf, size_t 
          * appears in SNDCTL_AUDIOINFO_EX under that name, and ALSA takes
          * plughw:/hw: strings that are absent from the list too.  If the open
          * really does fail, that is reported with the driver's own reason. */
-        /* A CoreAudio config from an older build holds an enumeration index.
-         * It still opens (the driver takes it), but it is not an identity: the
-         * next replug or reboot can move it, and then it addresses nothing.
-         * Say so once, with the fix, rather than let it fail silently later. */
+        /* A CoreAudio config holding a bare number is an enumeration index
+         * from an older build.  Indices are not identities -- say so with the
+         * fix, because the open below will refuse it rather than quietly bind
+         * some other device. */
         bool numeric = buf[0] != '\0';
         for (const char *p = buf; numeric && *p != '\0'; p++)
             if (*p < '0' || *p > '9')
                 numeric = false;
         if (numeric && audio_subsys == AUDIO_SUBSYSTEM_COREAUDIO)
-            HLOGW(log_tag, "device '%s' looks like a CoreAudio enumeration index, "
-                           "which changes when the device is replugged or the machine "
-                           "reboots -- re-select the device (or use the id from -z, "
-                           "now a stable UID) so it keeps working", buf);
+            HLOGW(log_tag, "device '%s' is an old CoreAudio enumeration index and is no "
+                           "longer accepted -- re-select the device, or use the id from "
+                           "-z (a stable UID)", buf);
         else
             HLOGI(log_tag, "device '%s' is not in the enumerated list -- passing it to the "
                            "driver as given (-z lists the enumerated devices)", buf);

--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -2073,8 +2073,22 @@ static void resolve_device_string(int audio_subsys, int mode, char *buf, size_t 
          * appears in SNDCTL_AUDIOINFO_EX under that name, and ALSA takes
          * plughw:/hw: strings that are absent from the list too.  If the open
          * really does fail, that is reported with the driver's own reason. */
-        HLOGI(log_tag, "device '%s' is not in the enumerated list -- passing it to the "
-                       "driver as given (-z lists the enumerated devices)", buf);
+        /* A CoreAudio config from an older build holds an enumeration index.
+         * It still opens (the driver takes it), but it is not an identity: the
+         * next replug or reboot can move it, and then it addresses nothing.
+         * Say so once, with the fix, rather than let it fail silently later. */
+        bool numeric = buf[0] != '\0';
+        for (const char *p = buf; numeric && *p != '\0'; p++)
+            if (*p < '0' || *p > '9')
+                numeric = false;
+        if (numeric && audio_subsys == AUDIO_SUBSYSTEM_COREAUDIO)
+            HLOGW(log_tag, "device '%s' looks like a CoreAudio enumeration index, "
+                           "which changes when the device is replugged or the machine "
+                           "reboots -- re-select the device (or use the id from -z, "
+                           "now a stable UID) so it keeps working", buf);
+        else
+            HLOGI(log_tag, "device '%s' is not in the enumerated list -- passing it to the "
+                           "driver as given (-z lists the enumerated devices)", buf);
     }
 
 done:

--- a/audioio/ffaudio/ffaudio/coreaudio.c
+++ b/audioio/ffaudio/ffaudio/coreaudio.c
@@ -388,28 +388,25 @@ int ffcoreaudio_open(ffaudio_buf *b, ffaudio_conf *conf, ffuint flags)
 	ffuint capture = (flags & 0x0f) == FFAUDIO_DEV_CAPTURE;
 	b->nonblock = !!(flags & FFAUDIO_O_NONBLOCK);
 
+	/* Devices are addressed by UID.  An AudioDeviceID is an enumeration
+	 * index, not an identity -- replug the interface or reboot and it moves,
+	 * which is how a stored index ends up addressing nothing (issue #254).
+	 * kAudioDevicePropertyDeviceUID is stable for the device and distinct
+	 * between two units of the same model, so it is what enumeration reports
+	 * and what a config holds; resolve it fresh on every open. */
 	int dev = -1;
-	if (conf->device_id != NULL) {
-		/* Validate the parse: strtoul() returns 0 on a string it cannot read,
-		 * which would silently select device 0 instead of falling back to the
-		 * default. A config written by an older build holds exactly such an
-		 * unparsable id (it stored the raw AudioDeviceID bytes), so this is the
-		 * upgrade path, not a hypothetical. */
-		/* A UID first: that is what enumeration now reports and what a
-		 * config written by this build holds.  Resolving it every open is the
-		 * point -- the index behind it changes when the device is replugged
-		 * or the machine reboots, which is why a stored index eventually
-		 * addresses nothing (issue #254). */
+	if (conf->device_id != NULL && conf->device_id[0] != '\0') {
 		dev = coreaudio_dev_by_uid(conf->device_id);
-
 		if (dev < 0) {
-			char *end = NULL;
-			unsigned long v = strtoul(conf->device_id, &end, 10);
-			if (end != conf->device_id && *end == '\0' && v <= 0x7fffffffUL)
-				dev = (int)v;   /* config from an older build */
+			/* An explicitly chosen device that is not present is an error, not
+			 * an invitation to open something else.  Falling back to the
+			 * default here would quietly bind the built-in microphone and the
+			 * modem would sit there hearing nothing -- far worse to diagnose
+			 * than a refusal. */
+			b->errfunc = "device UID not found (run -z to list devices)";
+			return FFAUDIO_ERROR;
 		}
-	}
-	if (dev < 0) {
+	} else {
 		dev = coreaudio_dev_default(capture);
 		if (dev < 0) {
 			b->errfunc = "get default device";

--- a/audioio/ffaudio/ffaudio/coreaudio.c
+++ b/audioio/ffaudio/ffaudio/coreaudio.c
@@ -30,7 +30,7 @@ struct ffaudio_dev {
 
 	ffuint err;
 	char *errmsg;
-	char id_str[16];
+	char id_str[256];
 };
 
 ffaudio_dev* ffcoreaudio_dev_alloc(ffuint mode)
@@ -54,6 +54,9 @@ void ffcoreaudio_dev_free(ffaudio_dev *d)
 
 static const AudioObjectPropertyAddress prop_dev_list = {
 	kAudioHardwarePropertyDevices, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMaster
+};
+static const AudioObjectPropertyAddress prop_dev_uid = {
+	kAudioDevicePropertyDeviceUID, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMaster
 };
 static const AudioObjectPropertyAddress prop_dev_outname = {
 	kAudioObjectPropertyName, kAudioDevicePropertyScopeOutput, kAudioObjectPropertyElementMaster
@@ -187,6 +190,29 @@ int ffcoreaudio_dev_next(ffaudio_dev *d)
 	}
 }
 
+/* A device's persistent unique id.
+ *
+ * AudioDeviceID is an enumeration index, not an identity: unplug a USB
+ * interface and plug it back and it gets a different one, and after a reboot
+ * the numbering can differ again.  Anything stored in a config file therefore
+ * has to be the UID, which CoreAudio guarantees is stable for the device and
+ * unique between devices -- including between two units of the same model,
+ * which share a display name and defeat name matching (see issue #189 and
+ * ui_devices_disambiguate).
+ *
+ * Returns 0 on success and fills buf with a NUL-terminated UTF-8 UID. */
+static int coreaudio_dev_uid(AudioDeviceID dev, char *buf, size_t cap)
+{
+	CFStringRef cfs = NULL;
+	ffuint size = sizeof(cfs);
+	if (0 != AudioObjectGetPropertyData(dev, &prop_dev_uid, 0, NULL, &size, &cfs)
+		|| cfs == NULL)
+		return -1;
+	Boolean ok = CFStringGetCString(cfs, buf, (CFIndex)cap, kCFStringEncodingUTF8);
+	CFRelease(cfs);
+	return ok ? 0 : -1;
+}
+
 const char* ffcoreaudio_dev_info(ffaudio_dev *d, ffuint i)
 {
 	switch (i) {
@@ -194,6 +220,10 @@ const char* ffcoreaudio_dev_info(ffaudio_dev *d, ffuint i)
 		if (d->idev == 0)
 			return NULL;
 
+		/* Report the UID, not the index: this string is what the UI stores
+		 * and hands back on the next run, possibly after a reboot. */
+		if (0 == coreaudio_dev_uid(d->devs[d->idev - 1], d->id_str, sizeof(d->id_str)))
+			return d->id_str;
 		snprintf(d->id_str, sizeof(d->id_str), "%u", (unsigned)d->devs[d->idev - 1]);
 		return d->id_str;
 
@@ -317,6 +347,41 @@ static int coreaudio_dev_default(ffuint capture)
 	return dev;
 }
 
+/* Find the device currently carrying this UID.  Returns -1 if no device does,
+ * which is the honest answer when the interface is unplugged -- better than
+ * opening whatever now holds some remembered index. */
+static int coreaudio_dev_by_uid(const char *uid)
+{
+	AudioDeviceID *devs = NULL;
+	ffuint size = 0;
+	int found = -1;
+
+	if (uid == NULL || uid[0] == '\0')
+		return -1;
+	if (0 != AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &prop_dev_list,
+						0, NULL, &size) || size == 0)
+		return -1;
+	if (NULL == (devs = (AudioDeviceID *)ffmem_alloc(size)))
+		return -1;
+	if (0 != AudioObjectGetPropertyData(kAudioObjectSystemObject, &prop_dev_list,
+					    0, NULL, &size, devs)) {
+		ffmem_free(devs);
+		return -1;
+	}
+
+	ffuint n = size / sizeof(AudioDeviceID);
+	char buf[256];
+	for (ffuint i = 0; i != n; i++) {
+		if (0 == coreaudio_dev_uid(devs[i], buf, sizeof(buf))
+			&& 0 == strcmp(buf, uid)) {
+			found = (int)devs[i];
+			break;
+		}
+	}
+	ffmem_free(devs);
+	return found;
+}
+
 int ffcoreaudio_open(ffaudio_buf *b, ffaudio_conf *conf, ffuint flags)
 {
 	int rc = FFAUDIO_ERROR;
@@ -330,10 +395,19 @@ int ffcoreaudio_open(ffaudio_buf *b, ffaudio_conf *conf, ffuint flags)
 		 * default. A config written by an older build holds exactly such an
 		 * unparsable id (it stored the raw AudioDeviceID bytes), so this is the
 		 * upgrade path, not a hypothetical. */
-		char *end = NULL;
-		unsigned long v = strtoul(conf->device_id, &end, 10);
-		if (end != conf->device_id && *end == '\0' && v <= 0x7fffffffUL)
-			dev = (int)v;
+		/* A UID first: that is what enumeration now reports and what a
+		 * config written by this build holds.  Resolving it every open is the
+		 * point -- the index behind it changes when the device is replugged
+		 * or the machine reboots, which is why a stored index eventually
+		 * addresses nothing (issue #254). */
+		dev = coreaudio_dev_by_uid(conf->device_id);
+
+		if (dev < 0) {
+			char *end = NULL;
+			unsigned long v = strtoul(conf->device_id, &end, 10);
+			if (end != conf->device_id && *end == '\0' && v <= 0x7fffffffUL)
+				dev = (int)v;   /* config from an older build */
+		}
 	}
 	if (dev < 0) {
 		dev = coreaudio_dev_default(capture);

--- a/mercury.ini.example
+++ b/mercury.ini.example
@@ -24,11 +24,16 @@ ui_protocol = ws
 waterfall_enabled = true
 
 ; Audio capture (input) device id (e.g. "plughw:0,0")
-; Run mercury -z to list available devices.
+; Run mercury -z to list available devices, and store the id it prints.
+;
+; On macOS that id is the CoreAudio device UID, a string that stays with the
+; device across replug and reboot and is distinct between two units of the
+; same model.  Do NOT store the enumeration index shown by other tools: it is
+; not an identity, and once the device is replugged it addresses nothing.
 input_device =
 
 ; Audio playback (output) device id (e.g. "plughw:0,0")
-; Run mercury -z to list available devices.
+; Run mercury -z to list available devices, and store the id it prints.
 output_device =
 
 ; Capture input channel: left, right, or stereo (default: left)


### PR DESCRIPTION
Supersedes #264 (closed). Fixes the reopen/restart half of #254.

## The bug

`AudioDeviceID` is an enumeration index, not an identity. Unplug a USB interface and plug it back and it gets a different one; after a reboot the numbering can differ again. Mercury stored that index in the config (`input_device = "124"`) and re-read it on every start, so once it moved the id addressed nothing and the open failed inside `AudioObjectGetPropertyData` — #254's reopen loop.

**Verified on macOS 15.7.9:** an id absent from the device list fails exactly that call, reported by the new diagnostics as `'!obj'` (`kAudioHardwareBadObjectError`).

## The fix

`kAudioDevicePropertyDeviceUID` is stable for the device across replug and reboot, and distinct between two units of the same model — which share a display name and so defeat name matching (#189, and the reason `ui_devices_disambiguate` exists).

- enumeration reports the UID as the device id
- open resolves that UID to whatever index currently carries it, on every open

**No config schema change.** `input_device` is already free-form. The UI stores whatever the device list gives it, so new selections are stable automatically.

## UID only, no legacy fallback

Pre-2.0 carries no backward-compat constraint and clean removal beats a legacy path. An index is not an identity, so accepting one only defers the failure to the next replug. A stale config now fails clearly:

```
[WRN] device '50' is an old CoreAudio enumeration index and is no longer
accepted -- re-select the device, or use the id from -z (a stable UID)
[ERR] error in audio->open(): device UID not found (run -z to list devices)
```

This also fixes something worse that was already there: an unresolvable explicit device fell through to `coreaudio_dev_default()`, so a stale id would quietly bind the **built-in microphone** and the modem would sit hearing nothing. A refusal is much easier to diagnose than a link that is up and deaf.

## Why not name-only

It trades one bug for another: two of the same USB codec are both `"PCM2901 Audio Codec Analog Stereo"` (#189). The index appeared to solve that but does not — indices shuffle on replug, so "id 124" can become the *other* radio: silent misbinding rather than clean failure. The UID is the only identifier both stable and unique.

## Caveat

Some USB UIDs encode the port path (`AppleUSBAudioEngine:QEMU:QEMU USB Audio:1-0000:00:01.0-3:1`), so moving an interface to another socket can change it. Far more stable than an index, but not absolute.

## Verification status

Verified on macOS 15.7.9 (x86_64 VM) on the **previous** revision, which still had the numeric fallback: `-z` lists `BlackHole2ch_UID`; open by UID works with the name resolved and a clean shutdown; duplicate-name labels are fine (UID fits the 256-byte field, and the existing tail-preserving truncation is already right for UIDs, which differ at the tail).

**Not yet re-verified on macOS after removing the fallback** — the VM is mid-upgrade to Tahoe. Two behaviours to confirm when it returns: a UID still opens, and a bare index is refused rather than silently substituted. Linux build and unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTdTF7sefPbDiFx1g5nt8k
