### PR TITLE
audioio: mark the system-default CoreAudio device, and clear the Tahoe deprecation warnings

### DIFF
--- a/audioio/audioio.c
+++ b/audioio/audioio.c
@@ -2240,10 +2240,16 @@ void list_soundcards(int audio_system)
                     break;
                 }
 
-            printf("device: name: '%s'  id: '%s'  default: %s\n"
+            /* IS_DEFAULT is a backend capability, not a property of the
+             * device: a backend that does not report it returns NULL for
+             * every device, and printing that as "(null)" reads like the
+             * device has no default status rather than like Mercury does not
+             * know.  Say "yes" or nothing. */
+            const char *is_def = audio->dev_info(d, FFAUDIO_DEV_IS_DEFAULT);
+            printf("device: name: '%s'  id: '%s'%s\n"
                    , audio->dev_info(d, FFAUDIO_DEV_NAME)
                    , audio->dev_info(d, FFAUDIO_DEV_ID)
-                   , audio->dev_info(d, FFAUDIO_DEV_IS_DEFAULT)
+                   , (is_def != NULL) ? "  (system default)" : ""
                 );
         }
 

--- a/audioio/ffaudio/ffaudio/coreaudio.c
+++ b/audioio/ffaudio/ffaudio/coreaudio.c
@@ -213,6 +213,9 @@ static int coreaudio_dev_uid(AudioDeviceID dev, char *buf, size_t cap)
 	return ok ? 0 : -1;
 }
 
+/* Defined below, next to the open path that is its main user. */
+static int coreaudio_dev_default(ffuint capture);
+
 const char* ffcoreaudio_dev_info(ffaudio_dev *d, ffuint i)
 {
 	switch (i) {
@@ -229,6 +232,19 @@ const char* ffcoreaudio_dev_info(ffaudio_dev *d, ffuint i)
 
 	case FFAUDIO_DEV_NAME:
 		return d->name;
+
+	case FFAUDIO_DEV_IS_DEFAULT: {
+		/* Which device the system would pick if the operator picked nothing.
+		 * The UI needs this to preselect sensibly on a first run, and an
+		 * operator reading -z needs to know which line is the one Mercury
+		 * would open by default -- on this VM the two VoodooHDA devices are
+		 * both called "Unknown Codec ... (N/A)", so the name does not say. */
+		if (d->idev == 0)
+			return NULL;
+		int def = coreaudio_dev_default(d->mode == FFAUDIO_DEV_CAPTURE);
+		return (def >= 0 && (AudioObjectID)def == d->devs[d->idev - 1])
+			? "1" : NULL;
+	}
 	}
 	return NULL;
 }

--- a/audioio/ffaudio/ffaudio/coreaudio.c
+++ b/audioio/ffaudio/ffaudio/coreaudio.c
@@ -2,10 +2,30 @@
 2020, Simon Zolin
 */
 
+/* macOS 12 renamed kAudioObjectPropertyElementMaster to ...Main and deprecated
+ * the old spelling; the value is the same.  Tahoe warns on every one of the ten
+ * uses in this file, which buries anything else the build has to say -- and
+ * this is the file people are asked to build when a sound-card bug is being
+ * chased.  Use the modern name, and fall back to the old one on SDKs that
+ * predate it.
+ *
+ * This has to come FIRST, before ffaudio/ffbase.  Including those first leaves
+ * MAC_OS_VERSION_12_0 undefined -- verified by compiling the same test with and
+ * without them -- so the guard silently took the fallback branch and the file
+ * went on using the deprecated name while looking as though it did not.  An
+ * undefined macro is 0 in #if, which makes that failure quiet in exactly the
+ * wrong direction. */
+#include <AvailabilityMacros.h>
+#if !defined(MAC_OS_VERSION_12_0) \
+	|| (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_VERSION_12_0)
+	#define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
+#endif
+
 #include <ffaudio/audio.h>
 #include <ffaudio/util.h>
 #include <ffbase/ring.h>
 #include <CoreAudio/CoreAudio.h>
+
 #include <CoreFoundation/CFString.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -53,22 +73,22 @@ void ffcoreaudio_dev_free(ffaudio_dev *d)
 }
 
 static const AudioObjectPropertyAddress prop_dev_list = {
-	kAudioHardwarePropertyDevices, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMaster
+	kAudioHardwarePropertyDevices, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain
 };
 static const AudioObjectPropertyAddress prop_dev_uid = {
-	kAudioDevicePropertyDeviceUID, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMaster
+	kAudioDevicePropertyDeviceUID, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain
 };
 static const AudioObjectPropertyAddress prop_dev_outname = {
-	kAudioObjectPropertyName, kAudioDevicePropertyScopeOutput, kAudioObjectPropertyElementMaster
+	kAudioObjectPropertyName, kAudioDevicePropertyScopeOutput, kAudioObjectPropertyElementMain
 };
 static const AudioObjectPropertyAddress prop_dev_inname = {
-	kAudioObjectPropertyName, kAudioDevicePropertyScopeInput, kAudioObjectPropertyElementMaster
+	kAudioObjectPropertyName, kAudioDevicePropertyScopeInput, kAudioObjectPropertyElementMain
 };
 static const AudioObjectPropertyAddress prop_dev_outconf = {
-	kAudioDevicePropertyStreamConfiguration, kAudioDevicePropertyScopeOutput, kAudioObjectPropertyElementMaster
+	kAudioDevicePropertyStreamConfiguration, kAudioDevicePropertyScopeOutput, kAudioObjectPropertyElementMain
 };
 static const AudioObjectPropertyAddress prop_dev_inconf = {
-	kAudioDevicePropertyStreamConfiguration, kAudioDevicePropertyScopeInput, kAudioObjectPropertyElementMaster
+	kAudioDevicePropertyStreamConfiguration, kAudioDevicePropertyScopeInput, kAudioObjectPropertyElementMain
 };
 
 /** Get device list */
@@ -340,17 +360,17 @@ static OSStatus coreaudio_ioproc_capture(AudioDeviceID device, const AudioTimeSt
 	AudioBufferList *outdata, const AudioTimeStamp *outtime,
 	void *udata);
 static const AudioObjectPropertyAddress prop_odev_fmt = {
-	kAudioDevicePropertyStreamFormat, kAudioDevicePropertyScopeOutput, kAudioObjectPropertyElementMaster
+	kAudioDevicePropertyStreamFormat, kAudioDevicePropertyScopeOutput, kAudioObjectPropertyElementMain
 };
 static const AudioObjectPropertyAddress prop_idev_fmt = {
-	kAudioDevicePropertyStreamFormat, kAudioDevicePropertyScopeInput, kAudioObjectPropertyElementMaster
+	kAudioDevicePropertyStreamFormat, kAudioDevicePropertyScopeInput, kAudioObjectPropertyElementMain
 };
 
 static const AudioObjectPropertyAddress prop_idev_default = {
-	kAudioHardwarePropertyDefaultInputDevice, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMaster
+	kAudioHardwarePropertyDefaultInputDevice, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain
 };
 static const AudioObjectPropertyAddress prop_odev_default = {
-	kAudioHardwarePropertyDefaultOutputDevice, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMaster
+	kAudioHardwarePropertyDefaultOutputDevice, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain
 };
 static int coreaudio_dev_default(ffuint capture)
 {


### PR DESCRIPTION
Two macOS fixes found while validating the UID work (#265) on Tahoe 26.6.2 (25G83) against a **real sound card**, not just BlackHole.

### `mercury -z` never said which device is the default

Only the WASAPI backend implements `FFAUDIO_DEV_IS_DEFAULT`, so every other platform printed `default: (null)` for every device. That reads as "this device is not the default" when it means "this build has no idea", and it leaves the UI nothing to preselect on a first run.

CoreAudio can answer it — `coreaudio_dev_default()` already existed for the open path — so `dev_info` now compares each enumerated device against it.

This matters more than it sounds on hardware where names do not disambiguate. On the test machine the two VoodooHDA devices enumerate as:

```
device: name: 'Unknown Codec: Line-out (Green N/A)'  id: 'VoodooHDAEngine:pci8086,293e:0'
device: name: 'Unknown Codec: Line-in (Red N/A)'     id: 'VoodooHDAEngine:pci8086,293e:1'  (system default)
```

An operator reading that list previously could not tell which one Mercury would open by default. The listing also stops printing `(null)`: a backend that cannot report this returns NULL for *every* device, so it is a property of the backend rather than of the device.

### Ten deprecation warnings on every macOS build

`kAudioObjectPropertyElementMaster` was renamed to `...Main` in macOS 12 and deprecated. Ten warnings bury whatever else a build has to say, and this is the file people are asked to build when a sound-card bug is being chased. Same value, so a rename, with the old spelling kept behind an availability guard for older SDKs.

The guard has to come **before** the ffaudio/ffbase includes: including those first leaves `MAC_OS_VERSION_12_0` undefined (verified by compiling the same test with and without them), and an undefined macro is 0 in `#if`, so the guard silently took the fallback branch and the file kept using the deprecated name while looking as though it did not. The first version of this commit had exactly that bug and did not remove a single warning.

### Verified on Tahoe 26.6.2 (25G83), real sound card

| check | result |
|---|---|
| real card (VoodooHDA line-in) by UID | opens, float32 / 48000 Hz / 2ch |
| BlackHole by UID | opens |
| unknown UID | refused — not substituted |
| legacy enumeration index | refused, with a message pointing at `-z` |
| 90 s sustained capture | 0 errors, 0 warnings, 0 reopens, 0 `AudioDeviceStart` failures |
| `coreaudio.c` build warnings | 10 → 0 |

Default-device marking cross-checked against `system_profiler SPAudioDataType`: it agrees on both the default input and the default output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTdTF7sefPbDiFx1g5nt8k