### PR TITLE
tests/integration: make the channel bridge behave like a radio

### DIFF
--- a/tests/integration/channel_bridge_test.go
+++ b/tests/integration/channel_bridge_test.go
@@ -397,9 +397,8 @@ func runChannelDirOnce(ctx context.Context, chBin, txPath, rxPath string, params
 				// handed over AFTER its PTT drops -- past the flush that was
 				// meant to discard it.  The peer then decodes a burst that
 				// left the air seconds earlier and answers into a window that
-				// has already closed.  Measured at SNR3k -9.8 dB: an answerer
-				// raised RX_CALL 5.86 s after the CALL had ended, and its
-				// ACCEPT landed inside the caller's next transmission.
+				// has already closed.  This is a fidelity principle, not a
+				// measured regression: a radio has no such buffer.
 				//
 				// So write what the kernel takes and discard the rest, which
 				// is what the radio does.
@@ -419,7 +418,7 @@ func runChannelDirOnce(ctx context.Context, chBin, txPath, rxPath string, params
 						return
 					}
 				}
-				atomic.AddInt64(&outBytes, int64(whole*2))
+				atomic.AddInt64(&outBytes, int64(written))
 			}
 			if err != nil {
 				pumpDone <- err

--- a/tests/integration/channel_bridge_test.go
+++ b/tests/integration/channel_bridge_test.go
@@ -242,7 +242,7 @@ func runChannelDirOnce(ctx context.Context, chBin, txPath, rxPath string, params
 	// time), converts s32le→s16le and streams it into ch; the RX pump
 	// streams ch output back as s32le into the peer's capture FIFO.
 
-	var inBytes, outBytes int64
+	var inBytes, outBytes, droppedBytes int64
 	pumpDone := make(chan error, 2)
 
 	// Diagnosis: is the bridge itself falling behind real time?  inBytes is
@@ -261,9 +261,10 @@ func runChannelDirOnce(ctx context.Context, chBin, txPath, rxPath string, params
 				case <-tk.C:
 					in := atomic.LoadInt64(&inBytes)
 					out := atomic.LoadInt64(&outBytes)
-					fmt.Printf("CHDIAG %-14s %7.3f keyed=%.2fs delivered=%.2fs\n",
+					fmt.Printf("CHDIAG %-14s %7.3f keyed=%.2fs delivered=%.2fs dropped=%.2fs\n",
 						filepath.Base(txPath), time.Since(t0).Seconds(),
-						float64(in)/4/8000, float64(out)/4/8000)
+						float64(in)/4/8000, float64(out)/4/8000,
+						float64(atomic.LoadInt64(&droppedBytes))/4/8000)
 				}
 			}
 		}()
@@ -387,18 +388,33 @@ func runChannelDirOnce(ctx context.Context, chBin, txPath, rxPath string, params
 				time.Sleep(deadline.Sub(now))
 				deadline = deadline.Add(20 * time.Millisecond)
 
+				// Deliver, or DROP -- never queue.  A receiver that is not
+				// listening (half-duplex: it is transmitting) loses the audio
+				// on a real link; there is no buffer in the air holding it
+				// back for later.  Retrying here until the peer drains turns
+				// the FIFO into exactly such a buffer: the peer stops reading
+				// while it transmits, this pump stalls, and the backlog is
+				// handed over AFTER its PTT drops -- past the flush that was
+				// meant to discard it.  The peer then decodes a burst that
+				// left the air seconds earlier and answers into a window that
+				// has already closed.  Measured at SNR3k -9.8 dB: an answerer
+				// raised RX_CALL 5.86 s after the CALL had ended, and its
+				// ACCEPT landed inside the caller's next transmission.
+				//
+				// So write what the kernel takes and discard the rest, which
+				// is what the radio does.
 				written := 0
 				for written < whole*2 {
 					wn, werr := syscall.Write(rxFD, s32[written:whole*2])
 					if wn > 0 {
 						written += wn
+						continue
+					}
+					if werr == syscall.EAGAIN {
+						atomic.AddInt64(&droppedBytes, int64(whole*2-written))
+						break
 					}
 					if werr != nil {
-						if werr == syscall.EAGAIN {
-							// Peer capture FIFO momentarily full.
-							time.Sleep(2 * time.Millisecond)
-							continue
-						}
 						pumpDone <- werr
 						return
 					}


### PR DESCRIPTION
Split out of #257, which it had nothing to do with beyond having been written the same week. Two commits, one file.

**The bridge queued audio nobody was listening to.** A real radio does not: what arrives while the peer is transmitting, or not reading, is simply gone. The harness instead buffered it and delivered it later, which is not a channel — it is a store-and-forward link. That hid a whole class of turnaround bug, because a burst that should have been lost to a deaf peer arrived anyway, just late.

It now drops on EAGAIN rather than queueing.

**And CHDIAG was counting bytes that never left.** `outBytes` included the tail discarded on EAGAIN, so "delivered" overstated what reached the peer — in a diagnostic whose entire job is to say what the channel carried. It now counts the write's return value. (That fix is Pedro's, from his review of #257.)

Harness only — no Mercury source is touched. Build clean, 28/28 unit tests.

Worth having on its own: the same harness is what the ACCEPT-collision measurement in #257 was taken on, and a bridge that invents delivery would have masked exactly the failure that measurement found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTdTF7sefPbDiFx1g5nt8k