### PR TITLE
tcp: make broadcast listener shutdown bounded

### DIFF
--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -120,17 +120,27 @@ static ssize_t send_all(int socket_fd, const uint8_t *buffer, size_t len)
 {
     size_t total_sent = 0;
 
-    while (total_sent < len)
+    while (total_sent < len && !shutdown_ && !bcast_client_done)
     {
         ssize_t sent = send(socket_fd, (const char *)buffer + total_sent, len - total_sent, HERMES_SEND_FLAGS);
-        if (sent <= 0)
+        if (sent < 0)
         {
+            int err = sock_errno();
+            if (err == SOCK_EINTR)
+                continue;
+            if (err == SOCK_EAGAIN || err == SOCK_EWOULDBLOCK)
+            {
+                hermes_usleep(20000);
+                continue;
+            }
             return -1;
         }
+        if (sent == 0)
+            return -1;
         total_sent += (size_t)sent;
     }
 
-    return (ssize_t)total_sent;
+    return total_sent == len ? (ssize_t)total_sent : -1;
 }
 
 typedef struct
@@ -1239,10 +1249,9 @@ void *send_thread(void *client_socket_ptr)
 
     while (!shutdown_ && !bcast_client_done)
     {
-        /* Poll size_buffer() instead of blocking in read_buffer()'s
-         * condvar wait.  Re-check bcast_client_done after size_buffer()
-         * returns to close the race where clear_buffer() drains the
-         * ring between our size check and the read_buffer() call. */
+        /* Only this worker consumes the RX ring, and the server clears it
+         * after joining us. A full frame therefore cannot disappear between
+         * this size check and read_buffer(). Poll while no frame is ready. */
         if (size_buffer(data_rx_buffer_broadcast) < frame_size)
         {
             msleep(100);
@@ -1279,8 +1288,9 @@ void *send_thread(void *client_socket_ptr)
               reply_cmd, payload_len, kiss_len);
         if (send_all(client_socket, kiss_buffer, (size_t)kiss_len) < 0)
         {
-            HLOGW("tcp-bcast", "Error sending KISS broadcast frame: %s",
-                  strerror(errno));
+            if (!shutdown_ && !bcast_client_done)
+                HLOGW("tcp-bcast", "Error sending KISS broadcast frame (err=%d)",
+                      sock_errno());
             break;
         }
     }
@@ -1314,7 +1324,7 @@ void *recv_thread(void *client_socket_ptr)
 
     HLOGI("tcp-bcast", "Receive thread started (expected frame_size=%zu)", frame_size);
 
-    while (!shutdown_)
+    while (!shutdown_ && !bcast_client_done)
     {
         ssize_t received = recv(client_socket, (char *)buffer, DATA_TX_BUFFER_SIZE, 0);
         if (received > 0)
@@ -1341,7 +1351,15 @@ void *recv_thread(void *client_socket_ptr)
         }
         else if (received < 0)
         {
-            HLOGW("tcp-bcast", "Error receiving TCP data (err=%d)", sock_errno());
+            int err = sock_errno();
+            if (err == SOCK_EINTR)
+                continue;
+            if (err == SOCK_EAGAIN || err == SOCK_EWOULDBLOCK)
+            {
+                hermes_usleep(20000);
+                continue;
+            }
+            HLOGW("tcp-bcast", "Error receiving TCP data (err=%d)", err);
             break;
         }
     }
@@ -1388,7 +1406,9 @@ void *tcp_server_thread(void *port_ptr)
         return NULL;
     }
 
-    if (listen(tcp_socket, 1) < 0)
+    /* The server owns all descriptors; bounded waits avoid cross-thread close
+     * races and work with both POSIX and Winsock nonblocking sockets. */
+    if (set_nonblocking(tcp_socket) < 0 || listen(tcp_socket, 1) < 0)
     {
         HLOGE("tcp-bcast", "Failed to listen on TCP socket: %s", strerror(errno));
         SOCK_CLOSE(tcp_socket);
@@ -1399,15 +1419,35 @@ void *tcp_server_thread(void *port_ptr)
 
     while (!shutdown_)
     {
+        struct pollfd listener = { .fd = tcp_socket, .events = POLLIN };
+        int ready = poll(&listener, 1, 100);
+        if (shutdown_)
+            break;
+        if (ready == 0 || (ready < 0 && sock_errno() == SOCK_EINTR))
+            continue;
+        if (ready < 0 || (listener.revents & (POLLERR | POLLHUP | POLLNVAL)))
+            break;
+        client_addr_len = sizeof(client_addr);
         client_socket = accept(tcp_socket, (struct sockaddr *)&client_addr, &client_addr_len);
         if (client_socket < 0)
         {
+            int err = sock_errno();
+            if (err == SOCK_EINTR || err == SOCK_EAGAIN || err == SOCK_EWOULDBLOCK)
+                continue;
             HLOGE("tcp-bcast", "Failed to accept client connection: %s", strerror(errno));
             if (shutdown_)
                 break; // Exit if shutdown flag is set
             continue; // Retry accepting a connection
         }
 
+        if (shutdown_ || set_nonblocking(client_socket) < 0)
+        {
+            SOCK_CLOSE(client_socket);
+            continue;
+        }
+#if defined(SO_NOSIGPIPE)
+        setsockopt(client_socket, SOL_SOCKET, SO_NOSIGPIPE, (const char *)&opt, sizeof(opt));
+#endif
         HLOGI("tcp-bcast", "Client connected.");
 
         bcast_client_done = false;
@@ -1420,16 +1460,23 @@ void *tcp_server_thread(void *port_ptr)
 
         pthread_t recv_tid, send_tid;
 
-        pthread_create(&recv_tid, NULL, recv_thread, (void *)&client_socket);
-        pthread_create(&send_tid, NULL, send_thread, (void *)&client_socket);
+        if (pthread_create(&recv_tid, NULL, recv_thread, &client_socket) != 0)
+        {
+            SOCK_CLOSE(client_socket);
+            continue;
+        }
+        bool send_started = pthread_create(&send_tid, NULL, send_thread, &client_socket) == 0;
+        if (!send_started)
+            bcast_client_done = true;
 
-        /* recv_thread exits when the client disconnects (recv returns 0).
-         * Signal send_thread to stop and drain the RX buffer so it does
-         * not stay blocked inside a condvar wait holding the mutex. */
+        /* Stop and join the sole RX-buffer reader before draining its ring.
+         * Clearing before join can empty the ring after the sender's size/
+         * done checks but before read_buffer(), stranding it in a wait. */
         pthread_join(recv_tid, NULL);
         bcast_client_done = true;
+        if (send_started)
+            pthread_join(send_tid, NULL);
         clear_buffer(data_rx_buffer_broadcast);
-        pthread_join(send_tid, NULL);
 
         SOCK_CLOSE(client_socket);
         HLOGI("tcp-bcast", "Waiting for a new client to connect...");

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -131,10 +131,11 @@ test_arq_fsm: datalink_arq/test_arq_fsm.c $(UNITY_SRC) $(ARQ_STUBS) \
 # re-runs the previous binary -- which is exactly how a mutation check passes
 # when it should fail.  It stays off the link line ($(filter %.c %.a %.o,$^) would compile it twice).
 test_tcp_interfaces: data_interfaces/test_tcp_interfaces.c $(UNITY_SRC) ../modem/framer.c \
-                     ../datalink_arq/arq_tnc.c ../data_interfaces/tcp_interfaces.c
+                     ../datalink_arq/arq_tnc.c ../data_interfaces/tcp_interfaces.c \
+                     ../common/ring_buffer_posix.c ../common/shm_posix.c ../common/os_interop.c
 	$(CC) $(CFLAGS) -I../modem/freedv -o $@ \
 	    data_interfaces/test_tcp_interfaces.c $(UNITY_SRC) ../modem/framer.c \
-	    ../datalink_arq/arq_tnc.c $(LDFLAGS)
+	    ../datalink_arq/arq_tnc.c ../common/shm_posix.c ../common/os_interop.c $(LDFLAGS)
 
 # Two-FSM ARQ simulation harness
 SIM_SRC = sim/sim_clock.c sim/sim_channel.c sim/sim_endpoint.c \

--- a/tests/data_interfaces/test_tcp_interfaces.c
+++ b/tests/data_interfaces/test_tcp_interfaces.c
@@ -34,8 +34,12 @@
 #include "hermes_log.h"
 #include "radio_io.h"
 
+/* Interpose joins only to schedule the disconnect/read race deterministically. */
+static int test_server_join(pthread_t thread, void **result);
+#define pthread_join test_server_join
 /* include source to get access to static functions */
 #include "../../data_interfaces/tcp_interfaces.c"
+#undef pthread_join
 
 #include "unity.h"
 
@@ -171,11 +175,42 @@ void  modem_tune_stop(void)        { mock_tune_stop_calls++; }
 bool  modem_tune_active(void)      { return false; }
 float modem_tune_level_dbfs(void)  { return mock_tune_level_dbfs; }
 
+/* Use the actual ring implementation for the shutdown race; retain command
+ * test stubs under their usual names. No audio/modem hardware is linked. */
+#define size_buffer real_size_buffer
+#define read_buffer real_read_buffer
+#define clear_buffer real_clear_buffer
+#define write_buffer real_write_buffer
+#include "../../common/ring_buffer_posix.c"
+#undef size_buffer
+#undef read_buffer
+#undef clear_buffer
+#undef write_buffer
+
+static atomic_bool race_enabled, race_read_entered, race_release_read;
+static atomic_int race_reads;
+static int race_joins;
+
+static int test_server_join(pthread_t thread, void **result)
+{
+    if (race_enabled && ++race_joins == 2)
+        race_release_read = true; /* server is about to join its sender */
+    return pthread_join(thread, result);
+}
+
 /* ---- ring_buffer stubs ---- */
 
-size_t size_buffer(cbuf_handle_t cbuf) { (void)cbuf; return 0; }
-int read_buffer(cbuf_handle_t cbuf, uint8_t *data, size_t len) { (void)cbuf; (void)data; (void)len; return 0; }
-void clear_buffer(cbuf_handle_t cbuf) { (void)cbuf; }
+size_t size_buffer(cbuf_handle_t cbuf) { return race_enabled ? real_size_buffer(cbuf) : 0; }
+int read_buffer(cbuf_handle_t cbuf, uint8_t *data, size_t len)
+{
+    if (!race_enabled) return 0;
+    race_read_entered = true; /* sender has passed both size and done checks */
+    while (!race_release_read) usleep(1000);
+    int rc = real_read_buffer(cbuf, data, len);
+    race_reads++;
+    return rc;
+}
+void clear_buffer(cbuf_handle_t cbuf) { if (race_enabled) real_clear_buffer(cbuf); }
 
 static uint8_t last_write_buffer_data[MAX_PAYLOAD];
 static size_t  last_write_buffer_len  = 0;
@@ -1430,9 +1465,122 @@ void test_bitrate_query_is_always_answered(void)
         "host asked for BITRATE and got nothing: is the reply rate-limited?");
 }
 
+/* Real loopback sockets, no modem/audio/radio. The process watchdog makes
+ * a regression fail instead of leaving the test runner stuck in join. */
+static void broadcast_shutdown_case(int client_mode)
+{
+    int probe = socket(AF_INET, SOCK_STREAM, 0);
+    struct sockaddr_in addr = { .sin_family = AF_INET,
+                               .sin_addr.s_addr = htonl(INADDR_LOOPBACK) };
+    socklen_t len = sizeof(addr);
+    TEST_ASSERT_EQUAL_INT(0, bind(probe, (struct sockaddr *)&addr, sizeof(addr)));
+    TEST_ASSERT_EQUAL_INT(0, getsockname(probe, (struct sockaddr *)&addr, &len));
+    int port = ntohs(addr.sin_port);
+    close(probe);
+    shutdown_ = false;
+    uint8_t backing[128] = {0};
+    if (client_mode == 3)
+    {
+        race_read_entered = race_release_read = false;
+        race_reads = 0;
+        race_joins = 0;
+        data_rx_buffer_broadcast = circular_buf_init(backing, sizeof(backing));
+        uint8_t frame[64] = {0};
+        TEST_ASSERT_EQUAL_INT(0, real_write_buffer(data_rx_buffer_broadcast, frame, sizeof(frame)));
+        race_enabled = true;
+    }
+    broadcast_frame_size_cfg = 64;
+    pthread_t server;
+    alarm(5);
+    TEST_ASSERT_EQUAL_INT(0, pthread_create(&server, NULL, tcp_server_thread, &port));
+    int client = -1;
+    if (client_mode)
+    {
+        for (int i = 0; i < 100; ++i)
+        {
+            client = socket(AF_INET, SOCK_STREAM, 0);
+            if (connect(client, (struct sockaddr *)&addr, sizeof(addr)) == 0)
+                break;
+            close(client);
+            client = -1;
+            usleep(10000);
+        }
+        TEST_ASSERT_TRUE(client >= 0);
+    }
+    usleep(150000);
+    if (client_mode == 2)
+    {
+        close(client);
+        client = -1;
+        usleep(150000);
+    }
+    if (client_mode == 3)
+    {
+        while (!race_read_entered) usleep(1000);
+        /* EOF lets the server enter its disconnect teardown while read is paused. */
+        close(client);
+        client = -1;
+    }
+    uint64_t start = monotonic_ms();
+    shutdown_ = true;
+    pthread_join(server, NULL);
+    alarm(0);
+    if (client >= 0)
+        close(client);
+    TEST_ASSERT_TRUE(monotonic_ms() - start < 1000);
+    if (client_mode == 3)
+    {
+        TEST_ASSERT_EQUAL_INT(1, race_reads);
+        TEST_ASSERT_EQUAL_size_t(0, real_size_buffer(data_rx_buffer_broadcast));
+        circular_buf_free(data_rx_buffer_broadcast);
+        data_rx_buffer_broadcast = NULL;
+        race_enabled = false;
+    }
+    shutdown_ = false;
+}
+
+void test_bcast_disconnect_during_buffer_read(void) { broadcast_shutdown_case(3); }
+
+void test_bcast_shutdown_no_client(void) { broadcast_shutdown_case(0); }
+void test_bcast_shutdown_idle_client(void) { broadcast_shutdown_case(1); }
+void test_bcast_shutdown_disconnected_client(void) { broadcast_shutdown_case(2); }
+
+static void *blocked_broadcast_send(void *arg)
+{
+    uint8_t data[65536] = {0};
+    while (send_all(*(int *)arg, data, sizeof(data)) >= 0) {}
+    return NULL;
+}
+
+void test_bcast_shutdown_backpressured_send(void)
+{
+    int pair[2];
+    TEST_ASSERT_EQUAL_INT(0, socketpair(AF_UNIX, SOCK_STREAM, 0, pair));
+    TEST_ASSERT_EQUAL_INT(0, set_nonblocking(pair[0]));
+    shutdown_ = false;
+    bcast_client_done = false;
+    pthread_t sender;
+    alarm(5);
+    TEST_ASSERT_EQUAL_INT(0, pthread_create(&sender, NULL, blocked_broadcast_send, &pair[0]));
+    usleep(200000);
+    uint64_t start = monotonic_ms();
+    shutdown_ = true;
+    pthread_join(sender, NULL);
+    alarm(0);
+    close(pair[0]);
+    close(pair[1]);
+    TEST_ASSERT_TRUE(monotonic_ms() - start < 1000);
+    shutdown_ = false;
+}
+
 int main(void)
 {
     UNITY_BEGIN();
+    RUN_TEST(test_bcast_disconnect_during_buffer_read);
+    RUN_TEST(test_bcast_shutdown_no_client);
+    RUN_TEST(test_bcast_shutdown_idle_client);
+    RUN_TEST(test_bcast_shutdown_disconnected_client);
+    RUN_TEST(test_bcast_shutdown_backpressured_send);
     /* Command parser tests */
     RUN_TEST(test_cmd_mycall);
     RUN_TEST(test_cmd_mycall_registered_follows_ok);


### PR DESCRIPTION
The broadcast server could keep shutdown blocked in two independent waits: `accept()` with no client, and a sender stranded in `read_buffer()` when disconnect teardown cleared its ring before joining it.

This makes the listener and client sockets nonblocking with bounded polling, makes send and receive loops observe shutdown, and joins the sole ring reader before clearing its buffer. It also handles worker creation failures without joining an uninitialized thread. The existing message-store behavior and current broadcast framing changes are preserved.

Hardware-free regressions use real loopback sockets and the real ring implementation to cover:

- no connected client
- an idle connected client
- a client that has disconnected
- a backpressured send
- disconnect during the sender's size/read race

Validation:

- Current `mercuryv2` base `8cbdb9c`, macOS: 73/73 focused tests
- Current base, macOS ASan/UBSan: 73/73 focused tests
- Earlier identical shutdown correction, Windows 11: 20/20 no-client and 3/3 idle-client production shutdowns, 140–407 ms
- Earlier identical shutdown correction, Ubuntu 24.04 VMware: 20/20 no-client and 3/3 idle-client production shutdowns, 115–119 ms, plus focused native and sanitizer passes
- FT-710 receive-only validation on unmodified trunk reproduced the separate listener hang after both audio threads exited; no CAT/PTT or RF transmission was used