### PR TITLE
arq: break the tie when both stations request the turn at once

### DIFF
--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -246,6 +246,26 @@ static uint64_t retry_deadline_from_s(const arq_session_t *sess, float seconds)
     return arq_protocol_retry_deadline_ms(seconds, rank);
 }
 
+/* Does this station yield when both request the turn at the same time?
+ *
+ * Reuses the retry rank -- the same strcmp() of the exchanged callsign pair
+ * that staggers retries for #217 -- so both peers compute the same answer from
+ * the same data and exactly one of them yields.  No negotiation round trip, no
+ * randomness, and reproducible in a test.
+ *
+ * Rank 1 yields.  A degenerate pair (rank < 0: identical or missing callsigns,
+ * i.e. a misconfigured link) also yields: with no way to break the tie, both
+ * sides deferring is a stall that the retry timer recovers from, while neither
+ * deferring is two stations transmitting on top of each other.
+ */
+static bool turn_conflict_should_yield(const arq_session_t *sess)
+{
+    char my_call[CALLSIGN_MAX_SIZE];
+    arq_conn_get_calls(my_call, NULL, NULL, sizeof(my_call));
+    const char *local = sess->local_call[0] ? sess->local_call : my_call;
+    return arq_protocol_retry_rank(local, sess->remote_call) != 0;
+}
+
 /** Update local_snr_x10 EMA from the SNR carried in a received frame event.
  *  Called in all RX_DATA handlers to avoid cross-thread race with the modem
  *  thread's arq_update_link_metrics() call. */
@@ -2329,6 +2349,44 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
                                   ? (ev->rx_flags & ARQ_FLAG_HAS_DATA) != 0
                                   : true;
             irs_arm_ack_deadline(sess, ev);
+        }
+        else if (ev->id == ARQ_EV_RX_TURN_REQ)
+        {
+            /* Both sides asked for the turn at the same time.
+             *
+             * Without this case the event fell through and neither peer
+             * yielded: both retried until the budget ran out, both dropped to
+             * IDLE_IRS, and the link sat with NO sender until one of them
+             * requested again -- immediately and unstaggered, so the two
+             * requests collided and the cycle repeated.  That is the pair of
+             * symptoms reported from the field on bidirectional B1F
+             * forwarding: long silent gaps, then both stations transmitting on
+             * top of each other.  Both are this one loop.
+             *
+             * The retry stagger from #217 cannot fix it.  It staggers retry
+             * DEADLINES, whereas the deadlock is that nobody yields at all and
+             * the collision is on a first send that no deadline governs.
+             *
+             * So break the tie with the same rank the stagger uses: exactly one
+             * peer yields, grants the turn, and becomes the receiver; the other
+             * keeps its request outstanding and gets the floor.  Deterministic,
+             * so both ends agree without another exchange.
+             *
+             * The winner deliberately does nothing here: its own TURN_REQ is
+             * still outstanding and the peer is about to answer it.  Sending
+             * anything now would key on top of that TURN_ACK. */
+            if (turn_conflict_should_yield(sess))
+            {
+                HLOGD(LOG_COMP, "Turn requested by both; yielding (rank)");
+                if (g_timing) arq_timing_record_turn(g_timing, false, "turn_conflict");
+                dflow_enter(sess, ARQ_DFLOW_TURN_ACK_TX,
+                            time_now_ms() + ARQ_CHANNEL_GUARD_MS,
+                            ARQ_EV_TIMER_ACK);
+            }
+            else
+            {
+                HLOGD(LOG_COMP, "Turn requested by both; holding (rank)");
+            }
         }
         else if (ev->id == ARQ_EV_TIMER_RETRY)
         {

--- a/tests/datalink_arq/test_arq_fsm.c
+++ b/tests/datalink_arq/test_arq_fsm.c
@@ -677,6 +677,98 @@ void test_keepalive_wait_accepts_data(void)
     TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
 }
 
+/* Both stations ask for the turn at the same instant.
+ *
+ * TURN_REQ_WAIT used to have no RX_TURN_REQ case at all, so the event fell
+ * through and NEITHER peer yielded.  Both retried to exhaustion, both dropped
+ * to IDLE_IRS, and the link sat with no sender until one requested again --
+ * immediately and unstaggered, so the requests collided and it repeated.  Both
+ * halves of the field report on bidirectional B1F forwarding (long silent
+ * gaps, then both stations transmitting over each other) are that one loop.
+ *
+ * This is the same omission already fixed for WAIT_ACK in
+ * test_wait_ack_yields_on_turn_req; TURN_REQ_WAIT was the state it was missed
+ * in.  A one-way transfer harness cannot reach either, because its IRS never
+ * initiates data.
+ *
+ * The tie is broken on the retry rank -- the strcmp() of the exchanged
+ * callsign pair that #217's stagger already uses -- so both ends compute the
+ * same answer and exactly one yields, with no extra exchange.  These two cases
+ * assert both sides of that decision from the same state, which is what proves
+ * it is a tiebreak and not just "always yield" (which would deadlock the other
+ * way) or "never yield" (the original bug).
+ */
+static void goto_turn_req_wait(void)
+{
+    /* Connect as the CALLEE, which starts as the receiver -- the caller sends
+     * first.  (goto_connected() dials out and would make us the sender.) */
+    arq_event_t ev = make_event(ARQ_EV_APP_LISTEN);
+    arq_fsm_dispatch(&sess, &ev);
+    ev = make_event(ARQ_EV_RX_CALL);
+    ev.session_id = 0x42;
+    strncpy(ev.remote_call, "DST1", CALLSIGN_MAX_SIZE);
+    arq_fsm_dispatch(&sess, &ev);
+    ev = make_event(ARQ_EV_TIMER_ACK);
+    arq_fsm_dispatch(&sess, &ev);          /* send the ACCEPT */
+    ev = make_event(ARQ_EV_TX_COMPLETE);
+    arq_fsm_dispatch(&sess, &ev);
+    ev = make_event(ARQ_EV_RX_DATA);       /* caller's first burst confirms us */
+    ev.session_id = sess.session_id;
+    ev.seq = sess.rx_expected;
+    ev.data_bytes = 8;
+    ev.payload_len = 8;
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
+    ev = make_event(ARQ_EV_TIMER_ACK);
+    arq_fsm_dispatch(&sess, &ev);          /* our ACK */
+    ev = make_event(ARQ_EV_TX_COMPLETE);
+    arq_fsm_dispatch(&sess, &ev);          /* -> IDLE_IRS */
+    TEST_ASSERT_EQUAL_INT(ARQ_DFLOW_IDLE_IRS, sess.dflow_state);
+
+    fake_tx_backlog_fake.return_val = 256; /* we now have traffic of our own */
+    ev = make_event(ARQ_EV_APP_DATA_READY);
+    arq_fsm_dispatch(&sess, &ev);
+    ev = make_event(ARQ_EV_TX_COMPLETE);
+    arq_fsm_dispatch(&sess, &ev);          /* TURN_REQ_TX -> TURN_REQ_WAIT */
+    TEST_ASSERT_EQUAL_INT(ARQ_DFLOW_TURN_REQ_WAIT, sess.dflow_state);
+}
+
+void test_simultaneous_turn_req_one_side_yields(void)
+{
+    /* Local "SRC1" vs remote "DST1": strcmp > 0 is rank 1, which yields. */
+    goto_turn_req_wait();
+    strncpy(sess.local_call, "SRC1", CALLSIGN_MAX_SIZE);
+    strncpy(sess.remote_call, "DST1", CALLSIGN_MAX_SIZE);
+    TEST_ASSERT_TRUE(strcmp(sess.local_call, sess.remote_call) > 0);
+
+    arq_event_t ev = make_event(ARQ_EV_RX_TURN_REQ);
+    ev.session_id = sess.session_id;
+    arq_fsm_dispatch(&sess, &ev);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(ARQ_DFLOW_TURN_ACK_TX, sess.dflow_state,
+        "the higher-ranked station must grant the turn, not ignore the request");
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
+}
+
+void test_simultaneous_turn_req_other_side_holds(void)
+{
+    /* Local "AAA1" vs remote "DST1": strcmp < 0 is rank 0, which holds. */
+    goto_turn_req_wait();
+    strncpy(sess.local_call, "AAA1", CALLSIGN_MAX_SIZE);
+    strncpy(sess.remote_call, "DST1", CALLSIGN_MAX_SIZE);
+    TEST_ASSERT_TRUE(strcmp(sess.local_call, sess.remote_call) < 0);
+
+    arq_event_t ev = make_event(ARQ_EV_RX_TURN_REQ);
+    ev.session_id = sess.session_id;
+    arq_fsm_dispatch(&sess, &ev);
+
+    /* Holds its request and stays silent: the peer is about to answer it, and
+     * transmitting now would key on top of that TURN_ACK. */
+    TEST_ASSERT_EQUAL_INT_MESSAGE(ARQ_DFLOW_TURN_REQ_WAIT, sess.dflow_state,
+        "the lower-ranked station must keep its request, not also yield");
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
+}
+
 /* Retry exhaustion within the no-progress budget persists (stays CONNECTED);
  * once the budget elapses, the next exhaustion tears the link down. */
 void test_retry_exhaustion_persists_then_disconnects(void)
@@ -1142,6 +1234,8 @@ int main(void)
     RUN_TEST(test_wait_ack_stale_ack_keeps_window);
     RUN_TEST(test_wait_ack_yields_on_turn_req);
     RUN_TEST(test_keepalive_wait_accepts_data);
+    RUN_TEST(test_simultaneous_turn_req_one_side_yields);
+    RUN_TEST(test_simultaneous_turn_req_other_side_holds);
     RUN_TEST(test_disconnect_drain_timeout_forces_teardown);
     RUN_TEST(test_retry_exhaustion_persists_then_disconnects);
     RUN_TEST(test_retry_exhaustion_disconnects_from_zero_uptime_baseline);


### PR DESCRIPTION
Diagnoses the field report from VE4KLM on JNOS↔BPQ B1F forwarding over ~2000 km:

> long gaps in the sessions at times, perhaps due to fade out, then the timing seems to go off, and stations on both ends wind up transmitting on top of each other

Those are not two problems. They are one loop.

### The defect

`TURN_REQ_WAIT` handles `RX_TURN_ACK`, `RX_DATA` and `TIMER_RETRY` — but **has no `RX_TURN_REQ` case**. So when both peers ask for the floor simultaneously:

1. Both send `TURN_REQ`, both enter `TURN_REQ_WAIT`
2. Each receives the other's request and **ignores it** — no handler, so it falls through
3. Both retry to exhaustion, both drop to `enter_idle_irs()`
4. **Both are now the receiver. Nobody transmits.** ← the long gaps
5. Both still hold data, so both re-request from `IDLE_IRS` — the path that sends *immediately and unstaggered* ← both transmitting at once
6. Back to step 2

Bidirectional forwarding is the precondition: it is what gives both ends queued traffic at the same time. A fade supplies the initial desynchronisation. Retrying later works because any asymmetry collapses the loop, which is exactly what he describes doing.

**#217's retry stagger cannot reach this.** It staggers retry *deadlines*; here nobody yields at all, and the collision is on a first send that no deadline governs.

### The fix

Break the tie with the same rank the stagger already uses — `strcmp()` of the exchanged callsign pair. Both ends compute the same answer from the same data, so exactly one yields, grants the turn and becomes the receiver. No extra exchange, no randomness, reproducible in a test.

The winner deliberately transmits nothing: its own request is still outstanding and the peer is about to answer it, so keying now would land on top of that `TURN_ACK`. A degenerate pair (identical or missing callsigns) yields, since a stall the retry timer recovers from beats two stations transmitting simultaneously.

### Not a new class of bug

This is the same omission **already fixed for `WAIT_ACK`** in `test_wait_ack_yields_on_turn_req`, whose comment records a 21-minute uucp hang from that instance. `TURN_REQ_WAIT` is the state it was missed in. Neither is reachable by the one-way transfer harness, because its IRS never initiates data — only unit tests can guard them.

### Tests

Two, asserting both sides of the decision from the same state. That is what distinguishes a tiebreak from "always yield" (which deadlocks the other way) and from "never yield" (the bug).

Verified against a build with the fix removed: the yield case fails there, expecting `TURN_ACK_TX` and finding `TURN_REQ_WAIT`. The holds case passes either way — ignoring a request and holding one are indistinguishable from that state — so it guards the over-broad fix rather than the original bug, which is why both are needed.

28/28 unit tests; `TestMercuryARQBidirectional` green.

### What this does not claim

It is a unit-level fix for a mechanism found by reading the FSM against a field report. I have not reproduced Maiko's session on air, and the integration harness cannot reach this state at all. Worth asking him to retest once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)