### PR TITLE
arq: accept incoming DATA while waiting for a keepalive reply

### DIFF
--- a/datalink_arq/arq_fsm.c
+++ b/datalink_arq/arq_fsm.c
@@ -2366,7 +2366,49 @@ static void fsm_dflow(arq_session_t *sess, const arq_event_t *ev)
         break;
 
     case ARQ_DFLOW_KEEPALIVE_WAIT:
-        if (ev->id == ARQ_EV_RX_KEEPALIVE_ACK)
+        if (ev->id == ARQ_EV_RX_DATA)
+        {
+            /* The peer is not merely alive, it is transmitting -- and it holds
+             * the floor, or it would not be sending DATA.  Abandon the
+             * keepalive and take the data.
+             *
+             * Without this case RX_DATA fell through and was DISCARDED, which
+             * is the worst possible outcome: the sender retransmits into a
+             * station that will not listen, makes no progress, and this side
+             * meanwhile counts keepalive misses and eventually tears the link
+             * down.  Reproduced in the two-station sim at seed 17 with only 10%
+             * frame erasure: zero bytes delivered in either direction, the
+             * sender cycling DATA_TX -> WAIT_ACK throughout, and
+             * "Keepalive miss limit -- disconnecting" at 37 s.
+             *
+             * A keepalive exists to find out whether the peer is still there.
+             * A DATA frame answers that question better than a KEEPALIVE_ACK
+             * would, so there is nothing left to wait for.
+             *
+             * Same shape as the RX_DATA case in TURN_REQ_WAIT, and the same
+             * class as the RX_TURN_REQ omissions in WAIT_ACK and
+             * TURN_REQ_WAIT: a state that ignores an event which can
+             * legitimately arrive in it. */
+            sess->keepalive_miss_count = 0;
+            update_local_snr(sess, ev);
+            update_peer_snr(sess, ev);
+            sess->peer_tx_mode = ev->mode;
+            bool new_frame = deliver_rx_checked(sess, ev);
+            if (new_frame && g_timing)
+                arq_timing_record_data_rx(g_timing, (int)ev->seq,
+                                          (int)ev->data_bytes,
+                                          sess->local_snr_x10);
+            sess->last_rx_ms = time_now_ms();
+            /* As in TURN_REQ_WAIT: a duplicate means the sender is still the
+             * active ISS and is retransmitting because it has not had our ACK,
+             * so do not take a piggyback turn that would put both sides into
+             * ISS at once. */
+            sess->peer_has_data = new_frame
+                                  ? (ev->rx_flags & ARQ_FLAG_HAS_DATA) != 0
+                                  : true;
+            irs_arm_ack_deadline(sess, ev);
+        }
+        else if (ev->id == ARQ_EV_RX_KEEPALIVE_ACK)
         {
             sess->keepalive_miss_count = 0;
             if (sess->keepalive_from_irs)

--- a/tests/datalink_arq/test_arq_fsm.c
+++ b/tests/datalink_arq/test_arq_fsm.c
@@ -619,6 +619,64 @@ void test_wait_ack_yields_on_turn_req(void)
     TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
 }
 
+/* A station waiting for a KEEPALIVE_ACK must accept incoming DATA.
+ *
+ * KEEPALIVE_WAIT handled RX_KEEPALIVE_ACK, RX_KEEPALIVE and TIMER_RETRY, and
+ * nothing else -- so RX_DATA fell through and was DISCARDED.  The sender then
+ * retransmitted into a station that would not listen, made no progress, and
+ * this side counted keepalive misses until it tore the link down.
+ *
+ * Reproduced in the two-station sim (tests/sim) at seed 17 with only 10% frame
+ * erasure: zero bytes delivered in EITHER direction, the sender cycling
+ * DATA_TX -> WAIT_ACK the whole time, and "Keepalive miss limit --
+ * disconnecting" at 37 s.  Fixing it took the sim's total-failure count from 2
+ * to 0 over 114 bidirectional trials.
+ *
+ * A keepalive asks whether the peer is still there.  A DATA frame answers that
+ * better than a KEEPALIVE_ACK would, so there is nothing left to wait for: take
+ * the data and ACK it.
+ *
+ * Third instance of one class -- a state ignoring an event that can
+ * legitimately arrive in it.  WAIT_ACK ignored RX_TURN_REQ (a 21-minute uucp
+ * hang), TURN_REQ_WAIT ignored RX_TURN_REQ, and this one ignored RX_DATA.
+ */
+void test_keepalive_wait_accepts_data(void)
+{
+    goto_connected();
+
+    /* ISS with nothing queued goes idle, then the keepalive timer fires. */
+    fake_tx_backlog_fake.return_val = 0;
+    arq_event_t ev = make_event(ARQ_EV_TIMER_KEEPALIVE);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_DFLOW_KEEPALIVE_TX, sess.dflow_state);
+    ev = make_event(ARQ_EV_TX_COMPLETE);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_DFLOW_KEEPALIVE_WAIT, sess.dflow_state);
+
+    /* The peer answers with DATA rather than a KEEPALIVE_ACK: it is alive and
+     * it holds the floor. */
+    const uint8_t payload[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    ev = make_event(ARQ_EV_RX_DATA);
+    ev.session_id  = sess.session_id;
+    ev.seq         = sess.rx_expected;
+    ev.data_bytes  = sizeof(payload);
+    ev.payload_len = sizeof(payload);
+    memcpy(ev.payload, payload, sizeof(payload));
+    unsigned before = fake_deliver_rx_data_fake.call_count;
+    arq_fsm_dispatch(&sess, &ev);
+
+    /* Delivered upward, not dropped. */
+    TEST_ASSERT_EQUAL_UINT_MESSAGE(before + 1,
+        fake_deliver_rx_data_fake.call_count,
+        "DATA arriving in KEEPALIVE_WAIT was discarded");
+    /* Keepalive abandoned in favour of ACKing what arrived. */
+    TEST_ASSERT_EQUAL_INT_MESSAGE(ARQ_DFLOW_DATA_RX, sess.dflow_state,
+        "must move to DATA_RX to ACK, not keep waiting for a KEEPALIVE_ACK");
+    /* A frame is proof of life, so the miss counter must not stand. */
+    TEST_ASSERT_EQUAL_INT(0, sess.keepalive_miss_count);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
+}
+
 /* Retry exhaustion within the no-progress budget persists (stays CONNECTED);
  * once the budget elapses, the next exhaustion tears the link down. */
 void test_retry_exhaustion_persists_then_disconnects(void)
@@ -1083,6 +1141,7 @@ int main(void)
     RUN_TEST(test_wait_ack_cumulative_ack_advances_window);
     RUN_TEST(test_wait_ack_stale_ack_keeps_window);
     RUN_TEST(test_wait_ack_yields_on_turn_req);
+    RUN_TEST(test_keepalive_wait_accepts_data);
     RUN_TEST(test_disconnect_drain_timeout_forces_teardown);
     RUN_TEST(test_retry_exhaustion_persists_then_disconnects);
     RUN_TEST(test_retry_exhaustion_disconnects_from_zero_uptime_baseline);


### PR DESCRIPTION
`KEEPALIVE_WAIT` handled `RX_KEEPALIVE_ACK`, `RX_KEEPALIVE` and `TIMER_RETRY` — and nothing else. So `RX_DATA` **fell through and was discarded.**

That is the worst available outcome. The sender retransmits into a station that will not listen and makes no progress; meanwhile this side counts keepalive misses and eventually tears the link down. Neither end is misbehaving and neither can recover.

### Reproduced deterministically

Found while trying to reproduce VE4KLM's report of stalled B1F forwarding, and it is **not** the bug I went looking for (see the honest correction below).

The two-station sim in `tests/sim` — both real `arq_session_t` FSMs through an erasing channel — fails at **seed 17 with only 10 % frame erasure**:

- **zero bytes delivered in either direction**
- the sender cycling `DATA_TX` → `WAIT_ACK` for the whole run
- `Keepalive miss limit -- disconnecting` at 37 s

It reproduces identically at 25 %. Not a marginal-channel effect.

### Measured, over 114 bidirectional trials at 10/25/40 % erasure

| | delivered both ways | delivered **neither** way |
|---|---|---|
| before | 106 | **2** |
| after | 108 | **0** |

Both total-failure cases are gone. The 6 remaining failures are all at 40 % erasure and end in a link legitimately giving up — correct behaviour, not a defect.

### The fix

A keepalive asks whether the peer is still there. A DATA frame answers that better than a `KEEPALIVE_ACK` would, and a peer sending DATA holds the floor — so there is nothing left to wait for. Clear the miss counter, take the data, ACK it.

Same shape as the `RX_DATA` case `TURN_REQ_WAIT` already has, including the duplicate-frame guard that stops a piggyback turn from putting both sides into ISS at once.

### A pattern, now three deep

| state | ignored event | |
|---|---|---|
| `WAIT_ACK` | `RX_TURN_REQ` | fixed earlier; recorded as a 21-minute uucp hang |
| `TURN_REQ_WAIT` | `RX_TURN_REQ` | #271 |
| `KEEPALIVE_WAIT` | `RX_DATA` | this PR |

Three instances of one class — a dflow state ignoring an event that can legitimately arrive in it. That seems enough to justify auditing every state against the events reachable in it, rather than waiting for the fourth to surface on air.

### Correction to #271

I need to walk back an implication I made there. #271 closes a real hole — its unit test fails without it — but measured on the same sim it moves bidirectional delivery by **1 trial in 114**. It is not the cause of the field-reported stalls. This is. #271 is still worth having on its own merits; it just does not explain what Maiko saw.

### What this does not claim

The integration harness cannot reach any of these states — it issues zero `TURN_REQ` frames in the whole bidirectional test, because turn handoff normally goes via the piggyback `HAS_DATA` flag. The evidence here is the discrete-event sim plus a unit test, not an on-air session. Worth asking Maiko to retest once this lands.

28/28 unit tests; ARQ transfer and bidirectional integration tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)