### PR TITLE
modem: MODE command to change the listen mode while the link is idle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ MERCURY_LINK_INPUTS = \
 	datalink_arq/arq_fsm.o datalink_arq/arq_protocol.o datalink_arq/arq_timing.o datalink_arq/arq_modem.o \
 	datalink_broadcast/broadcast.o datalink_broadcast/kiss.o modem/modem.o modem/framer.o modem/channel_busy.o modem/freedv/libfreedvdata.a \
 	audioio/audioio.a common/os_interop.o common/ring_buffer_posix.o common/shm_posix.o common/crc6.o common/hermes_log.o common/virtual_clock.o \
-	common/chan.o common/queue.o common/mercury_engine.o common/mercury_cli.o common/message_store.o data_interfaces/tcp_interfaces.o data_interfaces/net.o \
+	common/chan.o common/queue.o common/mercury_engine.o common/mercury_cli.o common/mercury_modes.o common/message_store.o data_interfaces/tcp_interfaces.o data_interfaces/net.o \
 	gui_interface/ui_communication.o gui_interface/ui_status.o gui_interface/ui_devices.o gui_interface/ui_history.o \
 	gui_interface/websocket/mongoose.o gui_interface/websocket/mercury_websocket.o \
 	gui_interface/websocket/web_packed.o \
@@ -297,7 +297,7 @@ MERCURY_CORE_OBJS = \
 	datalink_broadcast/broadcast.o datalink_broadcast/kiss.o \
 	modem/modem.o modem/framer.o modem/channel_busy.o \
 	common/os_interop.o common/ring_buffer_posix.o common/shm_posix.o common/crc6.o common/hermes_log.o common/virtual_clock.o \
-	common/chan.o common/queue.o common/mercury_engine.o common/mercury_cli.o common/message_store.o \
+	common/chan.o common/queue.o common/mercury_engine.o common/mercury_cli.o common/mercury_modes.o common/message_store.o \
 	data_interfaces/tcp_interfaces.o data_interfaces/net.o \
 	gui_interface/ui_communication.o gui_interface/ui_status.o gui_interface/ui_devices.o gui_interface/ui_history.o \
 	gui_interface/websocket/mongoose.o gui_interface/websocket/mercury_websocket.o \

--- a/common/Makefile
+++ b/common/Makefile
@@ -16,7 +16,7 @@ ENGINE_CFLAGS = $(CFG_CFLAGS) -I.. -I../modem -I../modem/freedv -I../datalink_br
 
 all: os_interop.o ring_buffer_posix.o shm_posix.o crc6.o hermes_log.o chan.o queue.o \
      virtual_clock.o cfg_utils.o iniparser/iniparser.o iniparser/dictionary.o watterson.o mercury_engine.o \
-     mercury_cli.o message_store.o
+     mercury_cli.o mercury_modes.o message_store.o
 
 os_interop.o: os_interop.c
 	$(CC) $(CFLAGS) -c os_interop.c
@@ -59,6 +59,9 @@ mercury_engine.o: mercury_engine.c mercury_engine.h
 
 mercury_cli.o: mercury_cli.c mercury_cli.h
 	$(CC) $(ENGINE_CFLAGS) $(CLI_SHM_CFLAGS) -c mercury_cli.c
+
+mercury_modes.o: mercury_modes.c mercury_cli.h
+	$(CC) $(ENGINE_CFLAGS) -c mercury_modes.c
 
 message_store.o: message_store.c message_store.h
 	$(CC) $(CFLAGS) -c message_store.c

--- a/common/mercury_cli.c
+++ b/common/mercury_cli.c
@@ -19,36 +19,7 @@
 #include "radio_io.h"
 #include "hermes_log.h"
 
-/* Startup-mode table (index -> FreeDV mode).  Non-static: shared with the
- * modem, and referenced by main()'s -l listing. */
-int freedv_modes[] = { FREEDV_MODE_DATAC1,
-                       FREEDV_MODE_DATAC3,
-                       FREEDV_MODE_DATAC0,
-                       FREEDV_MODE_DATAC4,
-                       FREEDV_MODE_DATAC13,
-                       FREEDV_MODE_DATAC14,
-                       FREEDV_MODE_FSK_LDPC,
-                       FREEDV_MODE_DATAC15,
-                       FREEDV_MODE_DATAC16,
-                       FREEDV_MODE_DATAC17,
-                       FREEDV_MODE_QAM16C2 };
-
-char *freedv_mode_names[] = { "DATAC1",
-                              "DATAC3",
-                              "DATAC0",
-                              "DATAC4",
-                              "DATAC13",
-                              "DATAC14",
-                              "FSK_LDPC",
-                              "DATAC15",
-                              "DATAC16",
-                              "DATAC17",
-                              "QAM16C2" };
-
-int mercury_cli_mode_count(void)
-{
-    return (int)(sizeof(freedv_modes) / sizeof(freedv_modes[0]));
-}
+/* The mode table itself lives in mercury_modes.c. */
 
 static int parse_rx_channel_layout(const char *value)
 {

--- a/common/mercury_engine.c
+++ b/common/mercury_engine.c
@@ -70,11 +70,6 @@ static int apply_audio_defaults(int audio_system, char *input_dev, size_t in_siz
     return 0;
 }
 
-int mercury_engine_modem_mode(void)
-{
-    return g_modem.mode;
-}
-
 /* Payload bit rate of the running modem, in bits/s: the bytes a frame carries
  * over the time that frame occupies the air.  Derived from the modem itself so
  * it reflects the mode actually in use. */

--- a/common/mercury_engine.h
+++ b/common/mercury_engine.h
@@ -52,10 +52,11 @@ int mercury_engine_init(const mercury_config *cfg,
 /* ------------------------------------------------------------------ */
 void mercury_engine_shutdown(void);
 
-/* The FreeDV mode the modem is running.  Fixed at startup by -m; there is no
- * runtime switch.  The UI needs it to tell the operator which broadcast mode
- * the far station must also be set to. */
-int mercury_engine_modem_mode(void);
+/* Bit rate and bandwidth of the running modem.  Derived from the modem itself
+ * rather than a table, so they describe what is actually on the air.  For the
+ * broadcast mode an operator has to match, see mercury_bcast_engine_mode():
+ * that reports the listen mode, which is what broadcast uses, rather than
+ * whatever rung the ARQ ladder currently sits on. */
 int mercury_engine_modem_bitrate(void);
 int mercury_engine_modem_bandwidth_hz(void);
 

--- a/common/mercury_modes.c
+++ b/common/mercury_modes.c
@@ -1,0 +1,44 @@
+/* Startup/listen mode table (index -> FreeDV mode).
+ *
+ * Its own translation unit so that anything needing the index<->mode mapping
+ * can link it without dragging in mercury_cli.c's audioio/radio_io/ldpc
+ * dependencies.  That matters for the control-port tests, which assert on the
+ * index space the MODE command accepts: duplicating the table in the test
+ * would let the two drift apart and silently invalidate those assertions.
+ *
+ * The index space is the user-facing one: `-m <index>`, `-l` to list, and the
+ * MODE control-port command all speak it, so entries must only ever be
+ * appended -- reordering would silently repoint every operator's config.
+ */
+
+#include "freedv_api.h"
+#include "mercury_cli.h"
+
+int freedv_modes[] = { FREEDV_MODE_DATAC1,
+                       FREEDV_MODE_DATAC3,
+                       FREEDV_MODE_DATAC0,
+                       FREEDV_MODE_DATAC4,
+                       FREEDV_MODE_DATAC13,
+                       FREEDV_MODE_DATAC14,
+                       FREEDV_MODE_FSK_LDPC,
+                       FREEDV_MODE_DATAC15,
+                       FREEDV_MODE_DATAC16,
+                       FREEDV_MODE_DATAC17,
+                       FREEDV_MODE_QAM16C2 };
+
+char *freedv_mode_names[] = { "DATAC1",
+                              "DATAC3",
+                              "DATAC0",
+                              "DATAC4",
+                              "DATAC13",
+                              "DATAC14",
+                              "FSK_LDPC",
+                              "DATAC15",
+                              "DATAC16",
+                              "DATAC17",
+                              "QAM16C2" };
+
+int mercury_cli_mode_count(void)
+{
+    return (int)(sizeof(freedv_modes) / sizeof(freedv_modes[0]));
+}

--- a/data_interfaces/tcp_interfaces.c
+++ b/data_interfaces/tcp_interfaces.c
@@ -47,6 +47,8 @@
 #include "chan.h"
 #include "defines_modem.h"
 #include "kiss.h"
+#include "modem.h"
+#include "mercury_cli.h"
 #include "framer.h"
 #include "hermes_log.h"
 #include "radio_io.h"
@@ -57,7 +59,9 @@ static pthread_t tid[7];
 static bool tid_started[7];
 static int arq_tcp_base_port_cfg = 0;
 static int broadcast_tcp_port_cfg = 0;
-static size_t broadcast_frame_size_cfg = 0;
+/* Broadcast wire frame size.  Written by the control-port thread on a
+ * listen-mode change and read by the broadcast client threads, so _Atomic. */
+static _Atomic size_t broadcast_frame_size_cfg = 0;
 /* SNR and bitrate are written by the ARQ FSM thread and read by the UI
  * publisher thread; use atomics to avoid a data race.  The float SNR is
  * stored as its raw IEEE-754 bit pattern in a uint32 atomic and
@@ -460,6 +464,49 @@ static void execute_control_command(char *buffer)
             tcp_write(CTL_TCP_PORT, (uint8_t *)"OK\r", 3);
         else
             tcp_write(CTL_TCP_PORT, (uint8_t *)"WRONG\r", 6);
+        return;
+    }
+
+    /* MODE <index>  -- set the idle ("listen") payload mode, same index space
+     * as -m (use -l to list).  MODE alone reports the current one.
+     *
+     * Only accepted while the ARQ link is idle: during a session the ARQ mode
+     * ladder owns the payload mode and would overwrite this within one RX-loop
+     * iteration.  Note this does NOT give a later ARQ connection a head start
+     * -- every session starts at DATAC15 and climbs via OLLA regardless. */
+    if (!strncmp(buffer, "MODE", strlen("MODE")))
+    {
+        int idx = -1;
+        if (sscanf(buffer, "MODE %d", &idx) == 1)
+        {
+            int count = mercury_cli_mode_count();
+            int rc = (idx >= 0 && idx < count)
+                         ? modem_set_listen_mode(freedv_modes[idx])
+                         : MODEM_LISTEN_MODE_BAD;
+            if (rc == 0)
+                tcp_write(CTL_TCP_PORT, (uint8_t *)"OK\r", 3);
+            else if (rc == MODEM_LISTEN_MODE_BUSY)
+                tcp_write(CTL_TCP_PORT, (uint8_t *)"BUSY\r", 5);
+            else
+                tcp_write(CTL_TCP_PORT, (uint8_t *)"WRONG\r", 6);
+        }
+        else
+        {
+            /* Report the live mode by index so the answer round-trips as the
+             * argument to a later MODE command. */
+            int mode = modem_get_listen_mode();
+            int count = mercury_cli_mode_count();
+            char reply[64];
+            int n = snprintf(reply, sizeof(reply), "MODE -1 UNKNOWN\r");
+            for (int i = 0; i < count; i++)
+                if (freedv_modes[i] == mode)
+                {
+                    n = snprintf(reply, sizeof(reply), "MODE %d %s\r",
+                                 i, freedv_mode_names[i]);
+                    break;
+                }
+            tcp_write(CTL_TCP_PORT, (uint8_t *)reply, (size_t)n);
+        }
         return;
     }
 
@@ -1226,7 +1273,7 @@ static void bcast_store_peer(const uint8_t *payload, int len, char *peer, size_t
 void *send_thread(void *client_socket_ptr)
 {
     int client_socket = *((int *)client_socket_ptr);
-    size_t frame_size = broadcast_frame_size_cfg;
+    size_t frame_size = atomic_load(&broadcast_frame_size_cfg);
     uint8_t *frame_buffer = NULL;
     uint8_t *kiss_buffer = NULL;
 
@@ -1236,8 +1283,11 @@ void *send_thread(void *client_socket_ptr)
         return NULL;
     }
 
-    frame_buffer = (uint8_t *)malloc(frame_size);
-    kiss_buffer = (uint8_t *)malloc((frame_size * 2) + 3);
+    /* Size for the widest selectable frame, not the current one: a listen-mode
+     * change can grow the frame size under a connected client, and the loop
+     * below re-reads it.  MAX_PAYLOAD is 1213 bytes, so this costs nothing. */
+    frame_buffer = (uint8_t *)malloc(MAX_PAYLOAD);
+    kiss_buffer = (uint8_t *)malloc((MAX_PAYLOAD * 2) + 3);
 
     if (!frame_buffer || !kiss_buffer)
     {
@@ -1249,6 +1299,15 @@ void *send_thread(void *client_socket_ptr)
 
     while (!shutdown_ && !bcast_client_done)
     {
+        /* Re-read: a MODE command can change the broadcast framing while this
+         * client stays connected. */
+        frame_size = atomic_load(&broadcast_frame_size_cfg);
+        if (frame_size == 0 || frame_size > MAX_PAYLOAD)
+        {
+            msleep(100);
+            continue;
+        }
+
         /* Only this worker consumes the RX ring, and the server clears it
          * after joining us. A full frame therefore cannot disappear between
          * this size check and read_buffer(). Poll while no frame is ready. */
@@ -1303,7 +1362,7 @@ void *send_thread(void *client_socket_ptr)
 void *recv_thread(void *client_socket_ptr)
 {
     int client_socket = *((int *)client_socket_ptr);
-    size_t frame_size = broadcast_frame_size_cfg;
+    size_t frame_size = atomic_load(&broadcast_frame_size_cfg);
     uint8_t *buffer = (uint8_t *)malloc(DATA_TX_BUFFER_SIZE);
     uint8_t decoded_frame[MAX_PAYLOAD];
 
@@ -1336,6 +1395,8 @@ void *recv_thread(void *client_socket_ptr)
                 if (frame_len <= 0)
                     continue;
 
+                /* Re-read: see send_thread. */
+                frame_size = atomic_load(&broadcast_frame_size_cfg);
                 uint8_t kiss_cmd = kiss_last_command();
                 HLOGI("tcp-bcast", "KISS frame decoded: cmd=0x%02X len=%d (expected %zu)",
                       kiss_cmd, frame_len, frame_size);
@@ -1644,12 +1705,22 @@ uint32_t tnc_get_last_bitrate_bps(void)
     return atomic_load_explicit(&last_bitrate_bps, memory_order_relaxed);
 }
 
+void interfaces_set_broadcast_frame_size(size_t broadcast_frame_size)
+{
+    atomic_store(&broadcast_frame_size_cfg, broadcast_frame_size);
+}
+
+size_t interfaces_get_broadcast_frame_size(void)
+{
+    return atomic_load(&broadcast_frame_size_cfg);
+}
+
 int interfaces_init(int arq_tcp_base_port, int broadcast_tcp_port, size_t broadcast_frame_size)
 {
     arq_set_tnc_callbacks(&g_arq_tnc_cbs);
     arq_tcp_base_port_cfg = arq_tcp_base_port;
     broadcast_tcp_port_cfg = broadcast_tcp_port;
-    broadcast_frame_size_cfg = broadcast_frame_size;
+    atomic_store(&broadcast_frame_size_cfg, broadcast_frame_size);
     memset(tid_started, 0, sizeof(tid_started));
 
     /*************** ARQ TCP ports *******************/

--- a/data_interfaces/tcp_interfaces.h
+++ b/data_interfaces/tcp_interfaces.h
@@ -31,6 +31,13 @@
 #define TCP_BLOCK_SIZE 128
 
 int interfaces_init(int arq_tcp_base_port, int broadcast_tcp_port, size_t broadcast_frame_size);
+
+/* Re-frame the broadcast TCP plane after a listen-mode change.  The connected
+ * client (the server serves one at a time) picks the new size up on its next
+ * frame; its buffers are sized for the largest selectable frame, so no
+ * reallocation is needed. */
+void interfaces_set_broadcast_frame_size(size_t broadcast_frame_size);
+size_t interfaces_get_broadcast_frame_size(void);
 void interfaces_shutdown();
 
 // ARQ TCP/IP server threads

--- a/datalink_arq/arq.c
+++ b/datalink_arq/arq.c
@@ -1073,6 +1073,40 @@ int arq_get_control_mode(void)      { SESS_READ(g_sess.control_mode); }
 int arq_get_preferred_rx_mode(void) { SESS_READ(arq_modem_preferred_rx_mode(&g_sess)); }
 int arq_get_preferred_tx_mode(void) { SESS_READ(arq_modem_preferred_tx_mode(&g_sess)); }
 
+/* Operator-selected idle ("listen") payload mode.  initial_payload_mode is
+ * what sess_enter() restores peer_tx_mode to whenever the session falls back
+ * to DISCONNECTED/LISTENING, so it is the single field that decides which
+ * payload mode the RX decoder sits on while no ARQ session is up (and hence
+ * which broadcast frames we can hear).
+ *
+ * Refused unless the link is actually idle: while a session is up the ARQ
+ * ladder owns peer_tx_mode and would overwrite an operator setting within one
+ * RX-loop iteration, so accepting the command there would silently do nothing.
+ * The state test is inside the lock deliberately -- checking it in the caller
+ * would race the event loop, which is the same unsynchronized-g_sess class of
+ * bug as the on-air handshake freeze.
+ *
+ * A session that starts later is unaffected: every session-start path
+ * (APP_CONNECT, RX_ACCEPT, and the ACCEPTING data/ack paths) hard-resets
+ * payload_mode and peer_tx_mode to DATAC15, so the listen mode cannot leak
+ * into a connection's mode ladder. */
+int arq_set_listen_mode(int mode)
+{
+    int rc = -1;
+    pthread_mutex_lock(&g_sess_lock);
+    if (g_sess.conn_state == ARQ_CONN_DISCONNECTED ||
+        g_sess.conn_state == ARQ_CONN_LISTENING)
+    {
+        g_sess.initial_payload_mode = mode;
+        /* Apply now rather than waiting for the next sess_enter(): we are
+         * already in an idle state, so no further transition is guaranteed. */
+        g_sess.peer_tx_mode = mode;
+        rc = 0;
+    }
+    pthread_mutex_unlock(&g_sess_lock);
+    return rc;
+}
+
 void arq_set_active_modem_mode(int mode, size_t frame_size)
 {
     /* Only record payload_mode for data modes.  Control-mode TX switches

--- a/datalink_arq/arq.h
+++ b/datalink_arq/arq.h
@@ -217,6 +217,14 @@ bool arq_get_peer_snr_x10(int *snr_x10);
  */
 int arq_get_payload_mode(void);
 
+/* Idle ("listen") payload mode: what the payload decoder sits on while no ARQ
+ * session is up, and therefore which broadcast frames this station can hear.
+ * arq_set_listen_mode() returns 0 on success, -1 if a session is up (the ARQ
+ * mode ladder owns the mode then).  Does not affect any later session: every
+ * session-start path resets the mode state to DATAC15.  Read it back through
+ * modem_get_listen_mode(), which owns the operator-facing value. */
+int arq_set_listen_mode(int mode);
+
 /**
  * @brief Get active ARQ control mode.
  * @return FreeDV control mode value.

--- a/docs/BROADCAST-FILE.md
+++ b/docs/BROADCAST-FILE.md
@@ -88,8 +88,9 @@ mode — 1 kB takes about half a minute.
 ## Choosing the mode
 
 **Both stations must be set to the same mode.** There is no negotiation on the
-broadcast plane, and no runtime mode switch: the mode is fixed when Mercury
-starts.
+broadcast plane: nothing tells one station what the other is using, so you set
+it on both.  It is set with `-m` at startup, and can be changed at runtime with
+the [`MODE`](TNC.md#mode) control-port command while the ARQ link is idle.
 
 ```
 mercury -m <index>          # see `mercury -l` for the list; default is 1 (DATAC3)
@@ -163,11 +164,11 @@ Defaults: `-m 1` (DATAC3), `-c 0` (repeat until interrupted), `-p 8100`,
 
 #### Worked example: sending an NNCP bundle
 
-There is no negotiation in broadcast.  **The mode is fixed at Mercury's start
-by `-m` and cannot be changed at runtime**, so the same mode has to be set in
-four places: both Mercury instances, and both invocations of the tool.  Get one
-of them wrong and the receiver simply never decodes -- there is no error,
-because a mismatched frame is indistinguishable from noise.
+There is no negotiation in broadcast.  **The same mode has to be set in four
+places**: both Mercury instances (with `-m`, or at runtime with the
+[`MODE`](TNC.md#mode) command) and both invocations of the tool.  Get one of
+them wrong and the receiver simply never decodes -- there is no error, because
+a mismatched frame is indistinguishable from noise.
 
 Produce the bundle with NNCP as usual, then hand the file to Mercury:
 

--- a/docs/BROADCAST-WIRE-FORMAT.md
+++ b/docs/BROADCAST-WIRE-FORMAT.md
@@ -242,9 +242,12 @@ pass the length check as well.
 
 ## 9. Mode agreement
 
-There is **no negotiation** on the broadcast plane and no runtime mode switch.
-Both stations must be started with the same mode (`mercury -m <index>`), and a
-receiver silently ignores any frame whose length is not its mode's frame size.
+There is **no negotiation** on the broadcast plane: nothing on the wire tells
+one station which mode another is using, so both must be set to the same one --
+with `mercury -m <index>` at startup, or at runtime with the
+[`MODE`](TNC.md#mode) control-port command while the ARQ link is idle.  A
+receiver silently ignores any frame whose length is not its mode's frame size,
+which is also what confines a receive to a single mode.
 
 ## 10. Interoperability
 

--- a/docs/TNC.md
+++ b/docs/TNC.md
@@ -327,6 +327,45 @@ CALLINT 0\r
 
 ---
 
+### MODE
+
+Set the **listen mode** — the payload mode the station sits on while no ARQ
+session is up.  This decides which broadcast frames the station can hear and
+send, and takes the same index space as the `-m` startup option (use `-l` to
+list them).
+
+```
+MODE 10\r          set the listen mode to QAM16C2
+MODE\r             report the current listen mode
+```
+
+The query form answers `MODE <index> <name>\r`, e.g. `MODE 10 QAM16C2\r`, so
+the reported index round-trips as the argument to a later `MODE` command.
+
+**Response:** `OK\r` on success, `BUSY\r` if an ARQ session is up, `WRONG\r`
+for an index that is out of range or not switchable at runtime.
+
+Two limits are worth knowing:
+
+* **Only accepted while the ARQ link is idle** (disconnected or listening).
+  During a session the ARQ mode ladder owns the payload mode and would
+  overwrite an operator setting within one RX-loop iteration, so the command
+  answers `BUSY\r` rather than silently accepting a setting that is about to
+  be discarded.
+* **Only the pooled payload modes are runtime-switchable:** indexes 0
+  (DATAC1), 1 (DATAC3), 3 (DATAC4), 7 (DATAC15), 9 (DATAC17) and 10
+  (QAM16C2).  DATAC16 is the ARQ control mode, and DATAC0 / DATAC13 / DATAC14
+  / FSK_LDPC have no runtime pool slot — `-m` can still *start* on some of
+  those, but they cannot be selected later, and `MODE` answers `WRONG\r`.
+
+This does **not** change how ARQ connections behave.  Every session — inbound
+or outbound — resets its mode ladder to DATAC15 and climbs from there via
+OLLA, so a fast listen mode gives a later connection no head start, and a
+robust one costs it nothing.  Setting the listen mode is about *broadcast*
+reception and transmission while idle.
+
+---
+
 ### TUNE
 
 Key the transmitter and hold a steady **1000 Hz tone**, so an antenna tuner
@@ -503,6 +542,13 @@ port only carries payload when a session is CONNECTED.
 The **broadcast port** (default 8100) is independent of ARQ and uses
 **KISS framing**.  One-way broadcast frames are sent/received as
 fixed-size KISS-encoded packets matching the modem's payload size.
+
+That frame size follows the **listen mode**, set at startup with `-m` and
+changeable at runtime with the [`MODE`](#mode) control-port command.  A
+connected broadcast client picks up a new frame size on its next frame — the
+socket does not need to be reopened — so a `MODE` change re-frames the plane
+underneath a live client.  Size your client's frames from the mode you
+selected, not from a cached value.
 
 Three client framings are accepted, distinguished by the KISS command byte:
 

--- a/gui_interface/fyne-ui/broadcast_file.go
+++ b/gui_interface/fyne-ui/broadcast_file.go
@@ -183,7 +183,7 @@ func broadcastModeUsable(mode int) bool {
 	return C.mercury_bcast_mode_usable(C.int(mode)) != 0
 }
 
-// broadcastEngineModeRaw is the running mode's index whether or not broadcast
+// broadcastEngineModeRaw is the broadcast mode's index whether or not broadcast
 // can use it.  broadcastEngineMode() reports -1 for an unusable mode so the
 // guards fire; this still knows which mode that was, so the operator can be
 // told what to change rather than only that something is wrong.
@@ -191,9 +191,11 @@ func broadcastEngineModeRaw() int {
 	return int(C.mercury_bcast_engine_mode_raw())
 }
 
-// broadcastEngineMode is the hermes mode index the engine is running, or -1 if
-// it cannot carry broadcast.  Fixed at startup by -m; there is no runtime
-// switch, and the far station must be set to the same one.
+// broadcastEngineMode is the hermes mode index broadcast is using, or -1 if it
+// cannot carry broadcast.  This is the listen mode, not whatever mode an ARQ
+// session happens to be on: set by -m at startup and changeable at runtime
+// with the MODE control-port command.  The far station must be set to the
+// same one.
 func broadcastEngineMode() int {
 	return int(C.mercury_bcast_engine_mode())
 }

--- a/gui_interface/fyne-ui/broadcast_file_ui.go
+++ b/gui_interface/fyne-ui/broadcast_file_ui.go
@@ -441,7 +441,8 @@ func (p *broadcastFilePanel) installFilter() {
 //
 // The index alone is meaningless to anyone who has not read the source, so lead
 // with the name, then the speed/robustness trade, then the -m index they would
-// actually type.  The mode is fixed at engine start and cannot be changed here.
+// actually type.  The mode cannot be changed from this window; it comes from -m
+// or the MODE control-port command.
 func broadcastModeDescription() string {
 	m := broadcastEngineMode()
 	if m < 0 {
@@ -454,7 +455,7 @@ func broadcastModeDescription() string {
 					"or faster (see 'mercury -l').", broadcastModeName(raw))
 		}
 		return "Mode: this modem's mode cannot carry broadcast.\n" +
-			"Restart mercury with -m (see 'mercury -l')."
+			"Set a broadcast-capable mode with -m or the MODE command (see 'mercury -l')."
 	}
 	line := fmt.Sprintf("Mode: %s - %s", broadcastModeName(m), broadcastModeCharacter(m))
 

--- a/gui_interface/fyne-ui/engine/mercury_bridge.c
+++ b/gui_interface/fyne-ui/engine/mercury_bridge.c
@@ -288,45 +288,48 @@ int  mercury_bcast_mode_usable(int mode)     { return bcast_file_mode_usable(mod
 const char *mercury_bcast_mode_name(int mode) { return bcast_file_mode_name(mode); }
 long mercury_bcast_max_file_bytes(void)      { return (long)BCAST_FILE_MAX_BYTES; }
 
-/* hermes mode index -> FreeDV enum, in the order `mercury -l` reports them.
- * Shared by both accessors below so the two cannot drift apart. */
-static const int hermes_to_freedv[] = {
-    FREEDV_MODE_DATAC1, FREEDV_MODE_DATAC3, FREEDV_MODE_DATAC0,
-    FREEDV_MODE_DATAC4, FREEDV_MODE_DATAC13, FREEDV_MODE_DATAC14,
-    FREEDV_MODE_FSK_LDPC, FREEDV_MODE_DATAC15, FREEDV_MODE_DATAC16,
-    FREEDV_MODE_DATAC17, FREEDV_MODE_QAM16C2
-};
-#define HERMES_MODE_COUNT ((int)(sizeof(hermes_to_freedv)/sizeof(hermes_to_freedv[0])))
+/* Both accessors below report the LISTEN mode, not the live modem mode.
+ * g_modem.mode follows whatever rung the ARQ ladder is currently on, so
+ * reading it made the broadcast UI report -- and size its frames from -- a
+ * mode unrelated to broadcast as soon as an ARQ session came up.  The listen
+ * mode is the one broadcast actually uses: what the payload decoder sits on
+ * while idle and what pure-broadcast TX is pinned to.  It also means these
+ * follow a MODE control-port command instead of reporting the startup mode
+ * forever.
+ *
+ * The hermes index they return is the same index space as -m, `mercury -l` and
+ * MODE, and comes from the shared table in common/mercury_modes.c rather than
+ * a copy here: it is a user-facing API, so two copies could drift apart. */
+static int listen_mode_index(void)
+{
+    int m = modem_get_listen_mode();
+    int count = mercury_cli_mode_count();
+    for (int i = 0; i < count; i++)
+        if (freedv_modes[i] == m)
+            return i;
+    return -1;
+}
 
 int mercury_bcast_engine_mode(void)
 {
-    /* g_modem.mode is a FreeDV enum; map it back to the hermes index the
-     * broadcast protocol and hermes-broadcast both speak. */
-    int m = mercury_engine_modem_mode();
-    for (int i = 0; i < HERMES_MODE_COUNT; i++)
-        if (hermes_to_freedv[i] == m)
-        {
-            /* Runnable by the engine is not the same as usable for broadcast.
-             * A broadcast frame has to carry the framing plus one whole
-             * RaptorQ symbol, and FSK_LDPC and DATAC15 (30-byte frames) do
-             * not -- see BCAST_SYMBOL_SIZE_MIN.  Report -1 for those, so the
-             * callers' existing "this modem's mode cannot carry broadcast"
-             * paths fire BEFORE a transfer is attempted, instead of the
-             * operator getting an opaque failure out of tx_open. */
-            return bcast_file_mode_usable(i) ? i : -1;
-        }
-    return -1;
+    int i = listen_mode_index();
+    if (i < 0)
+        return -1;
+    /* Runnable by the engine is not the same as usable for broadcast.  A
+     * broadcast frame has to carry the framing plus one whole RaptorQ symbol,
+     * and FSK_LDPC and DATAC15 (30-byte frames) do not -- see
+     * BCAST_SYMBOL_SIZE_MIN.  Report -1 for those, so the callers' existing
+     * "this modem's mode cannot carry broadcast" paths fire BEFORE a transfer
+     * is attempted, instead of the operator getting an opaque failure out of
+     * tx_open. */
+    return bcast_file_mode_usable(i) ? i : -1;
 }
 
 /* The mapped index whether or not broadcast can use it, so the UI can NAME the
  * mode it is refusing rather than saying only that something is wrong. */
 int mercury_bcast_engine_mode_raw(void)
 {
-    int m = mercury_engine_modem_mode();
-    for (int i = 0; i < HERMES_MODE_COUNT; i++)
-        if (hermes_to_freedv[i] == m)
-            return i;
-    return -1;
+    return listen_mode_index();
 }
 
 int mercury_bcast_engine_bitrate(void)      { return mercury_engine_modem_bitrate(); }

--- a/modem/modem.c
+++ b/modem/modem.c
@@ -113,7 +113,14 @@ static pthread_mutex_t *modem_inst_lock_for(struct freedv *f);
 static uint64_t modem_freedv_epoch = 1;
 static uint64_t modem_last_switch_ms = 0;
 static bool modem_owns_radio_buffers = false;
-static size_t broadcast_frame_size = 0;  /* expected broadcast payload size (set at init) */
+/* Expected broadcast payload size, and the operator-selected idle ("listen")
+ * mode it belongs to.  Both are written by the control-port thread via
+ * modem_set_listen_mode() and read by the modem RX thread (the broadcast frame
+ * size filter) and the TX thread (the pure-broadcast mode pin), so they are
+ * _Atomic: a plain size_t would be a data race, the same class as the
+ * unsynchronized g_sess access behind the on-air handshake freeze. */
+static _Atomic size_t broadcast_frame_size = 0;
+static _Atomic int    modem_listen_mode    = -1;
 
 /* --- Spectrum data for UI waterfall display --- */
 #include "freedv/modem_stats.h"
@@ -745,6 +752,59 @@ static int select_payload_rx_mode(const arq_runtime_snapshot_t *snapshot, bool r
     return mode;
 }
 
+/* Set the idle ("listen") payload mode: which payload mode this station sits
+ * on when no ARQ session is up, and hence which broadcast frames it can hear
+ * and send.  Pure state -- it deliberately does NOT switch the modem itself.
+ * The TX thread's pure-broadcast branch and the RX payload worker (via ARQ's
+ * peer_tx_mode -> select_payload_rx_mode) already converge on this every
+ * iteration, exactly as they do for the ARQ ladder, so a forced switch here
+ * would only race them.
+ *
+ * Returns 0 on success, MODEM_LISTEN_MODE_BAD for a mode that cannot be a
+ * runtime payload mode or whose pool slot is not up yet, and
+ * MODEM_LISTEN_MODE_BUSY if an ARQ session is up (the ladder owns the mode
+ * then).  Nothing is changed unless the whole change is accepted. */
+int modem_set_listen_mode(int mode)
+{
+    /* Runtime switching is limited to the pooled payload modes: DATAC16 is the
+     * control mode, and DATAC0/DATAC13/DATAC14/FSK_LDPC have no pool slot to
+     * switch to even though -m can start on some of them. */
+    if (!is_payload_split_mode(mode))
+        return MODEM_LISTEN_MODE_BAD;
+
+    size_t frame_size = 0;
+    pthread_mutex_lock(&modem_pool_lock);
+    struct freedv *fdv = pooled_freedv_for_mode_locked(mode, &frame_size);
+    pthread_mutex_unlock(&modem_pool_lock);
+    if (!fdv || frame_size == 0)
+        return MODEM_LISTEN_MODE_BAD;   /* pool not initialised yet */
+
+    /* Ask ARQ first: it is the one party that can refuse, and it owns the
+     * idle-state test.  Doing this before touching the frame size keeps the
+     * refusal clean -- a rejected command leaves every field untouched. */
+    if (arq_set_listen_mode(mode) != 0)
+        return MODEM_LISTEN_MODE_BUSY;
+
+    atomic_store(&broadcast_frame_size, frame_size);
+    atomic_store(&modem_listen_mode, mode);
+    /* Broadcast TCP clients frame to this size; they re-read it per frame. */
+    interfaces_set_broadcast_frame_size(frame_size);
+
+    HLOGI("modem", "Listen mode set to %d (%s), broadcast frame size %zu",
+          mode, mode_name_from_enum(mode), frame_size);
+    return 0;
+}
+
+int modem_get_listen_mode(void)
+{
+    return atomic_load(&modem_listen_mode);
+}
+
+size_t modem_get_broadcast_frame_size(void)
+{
+    return atomic_load(&broadcast_frame_size);
+}
+
 static int maybe_switch_modem_mode(generic_modem_t *g_modem,
                                    int target_mode,
                                    int arq_trx,
@@ -871,7 +931,13 @@ try_shm_connect2:
 
     g_modem->mode = mode;
     g_modem->payload_bytes_per_modem_frame = payload_bytes_per_modem_frame;
-    broadcast_frame_size = payload_bytes_per_modem_frame;
+    atomic_store(&broadcast_frame_size, payload_bytes_per_modem_frame);
+    /* Seed the listen mode from -m, whatever it is.  Runtime changes are
+     * restricted to pooled payload modes (see modem_set_listen_mode), but the
+     * startup mode may legitimately be one that is not runtime-switchable
+     * (DATAC0/DATAC14/FSK_LDPC), so do not filter it here -- that would change
+     * startup behaviour for those modes. */
+    atomic_store(&modem_listen_mode, mode);
     
     int modem_sample_rate = freedv_get_modem_sample_rate(g_modem->freedv);
     HLOGI("modem", "Initialized persistent FreeDV mode pool (DATAC16/DATAC15/DATAC13/DATAC4/DATAC3/DATAC1/DATAC17/QAM16C2), frames per burst: %d", frames_per_burst);
@@ -1634,14 +1700,17 @@ static void process_received_frame(const uint8_t *data,
         break;
     case PACKET_TYPE_BROADCAST_CONTROL:
     case PACKET_TYPE_BROADCAST_DATA:
-        if (broadcast_frame_size > 0 && payload_nbytes != broadcast_frame_size)
+    {
+        size_t expect_bcast = atomic_load(&broadcast_frame_size);
+        if (expect_bcast > 0 && payload_nbytes != expect_bcast)
         {
             HLOGD("modem-rx", "Discarding broadcast frame: size %zu != expected %zu",
-                  payload_nbytes, broadcast_frame_size);
+                  payload_nbytes, expect_bcast);
             break;
         }
         write_buffer(data_rx_buffer_broadcast, (uint8_t *)data, payload_nbytes);
         break;
+    }
     default:
         HLOGW("modem-rx", "Unknown frame type received");
         break;
@@ -1998,7 +2067,6 @@ void *tx_thread(void *g_modem)
     generic_modem_t *modem = (generic_modem_t *)g_modem;
     uint8_t *data = NULL;
     size_t data_size = 0;
-    int startup_mode = -1;
 
     while (!shutdown_)
     {
@@ -2006,13 +2074,6 @@ void *tx_thread(void *g_modem)
         memset(&arq_snapshot, 0, sizeof(arq_snapshot));
         bool have_arq_snapshot = arq_get_runtime_snapshot(&arq_snapshot);
         bool arq_policy_ready = arq_mode_policy_ready_snapshot(have_arq_snapshot, &arq_snapshot);
-
-        if (startup_mode < 0)
-        {
-            pthread_mutex_lock(&modem_pool_lock);
-            startup_mode = modem->mode;
-            pthread_mutex_unlock(&modem_pool_lock);
-        }
 
         size_t pending_arq_data = size_buffer(data_tx_buffer_arq);
         size_t pending_arq_control = size_buffer(data_tx_buffer_arq_control);
@@ -2033,11 +2094,16 @@ void *tx_thread(void *g_modem)
         }
         else if (arq_snapshot.trx != TX &&
                  !arq_tx_queued &&
-                 pending_broadcast > 0 &&
-                 startup_mode >= 0)
+                 pending_broadcast > 0)
         {
-            // Keep pure broadcast TX on the startup payload mode/frame size.
-            maybe_switch_modem_mode(modem, startup_mode, arq_snapshot.trx, false);
+            /* Keep pure broadcast TX on the listen mode's payload mode/frame
+             * size.  Read live rather than latched once at thread start, so a
+             * MODE command actually moves broadcast TX; otherwise the frame
+             * size would follow the new mode while TX stayed on the old one
+             * and the size gate below would silently drop every frame. */
+            int listen = atomic_load(&modem_listen_mode);
+            if (listen >= 0)
+                maybe_switch_modem_mode(modem, listen, arq_snapshot.trx, false);
         }
 
         size_t payload_bytes_per_modem_frame = 0;
@@ -2142,9 +2208,10 @@ void *tx_thread(void *g_modem)
                 HLOGW("modem-tx", "Failed to send ARQ buffered frame");
         }
 
+        size_t expect_bcast = atomic_load(&broadcast_frame_size);
         if (size_buffer(data_tx_buffer_broadcast) >= required &&
-            broadcast_frame_size > 0 &&
-            payload_bytes_per_modem_frame == broadcast_frame_size)
+            expect_bcast > 0 &&
+            payload_bytes_per_modem_frame == expect_bcast)
         {
             for (int i = 0; i < tx_frames_per_burst; i++)
             {

--- a/modem/modem.h
+++ b/modem/modem.h
@@ -112,6 +112,19 @@ float modem_get_tx_peak_dbfs(void);
 //
 // Returns 0 on success, -1 if the level is out of range, -2 if a link is up or
 // a burst is in flight (the two never key together), -3 if the thread failed.
+/* Idle ("listen") payload mode -- the payload mode the station sits on while
+ * no ARQ session is up, which decides the broadcast frames it can hear and
+ * send.  Seeded from -m at startup; changeable at runtime only while the ARQ
+ * link is idle, and only to a pooled payload mode (DATAC1/3/4/15/17/QAM16C2).
+ *
+ * This does NOT affect a later ARQ connection: every session-start path resets
+ * the mode ladder to DATAC15, so an inbound CALL cannot inherit this mode. */
+#define MODEM_LISTEN_MODE_BAD   (-1)  /* not a runtime-switchable payload mode */
+#define MODEM_LISTEN_MODE_BUSY  (-2)  /* an ARQ session is up; ladder owns mode */
+int    modem_set_listen_mode(int mode);
+int    modem_get_listen_mode(void);
+size_t modem_get_broadcast_frame_size(void);
+
 int   modem_tune_start(float dbfs);
 // Stop the carrier and unkey. Safe to call when not tuning; blocks until the
 // tuning thread has unkeyed.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -130,12 +130,17 @@ test_arq_fsm: datalink_arq/test_arq_fsm.c $(UNITY_SRC) $(ARQ_STUBS) \
 # make does not relink when the implementation changes and the suite silently
 # re-runs the previous binary -- which is exactly how a mutation check passes
 # when it should fail.  It stays off the link line ($(filter %.c %.a %.o,$^) would compile it twice).
+# ../common/mercury_modes.c carries the -m/MODE index table; linking the real
+# one (rather than a copy in the test) is the point -- the MODE tests assert on
+# specific indexes, which is only meaningful against the shipping table.
 test_tcp_interfaces: data_interfaces/test_tcp_interfaces.c $(UNITY_SRC) ../modem/framer.c \
                      ../datalink_arq/arq_tnc.c ../data_interfaces/tcp_interfaces.c \
-                     ../common/ring_buffer_posix.c ../common/shm_posix.c ../common/os_interop.c
+                     ../common/ring_buffer_posix.c ../common/shm_posix.c ../common/os_interop.c \
+                     ../common/mercury_modes.c
 	$(CC) $(CFLAGS) -I../modem/freedv -o $@ \
 	    data_interfaces/test_tcp_interfaces.c $(UNITY_SRC) ../modem/framer.c \
-	    ../datalink_arq/arq_tnc.c ../common/shm_posix.c ../common/os_interop.c $(LDFLAGS)
+	    ../datalink_arq/arq_tnc.c ../common/shm_posix.c ../common/os_interop.c \
+	    ../common/mercury_modes.c $(LDFLAGS)
 
 # Two-FSM ARQ simulation harness
 SIM_SRC = sim/sim_clock.c sim/sim_channel.c sim/sim_endpoint.c \

--- a/tests/data_interfaces/test_tcp_interfaces.c
+++ b/tests/data_interfaces/test_tcp_interfaces.c
@@ -175,6 +175,23 @@ void  modem_tune_stop(void)        { mock_tune_stop_calls++; }
 bool  modem_tune_active(void)      { return false; }
 float modem_tune_level_dbfs(void)  { return mock_tune_level_dbfs; }
 
+/* ---- modem listen-mode stubs ---- */
+
+static int mock_listen_mode_set    = -1;   /* last mode passed to the setter */
+static int mock_listen_mode_calls  = 0;
+static int mock_listen_mode_rc     = 0;    /* what modem_set_listen_mode returns */
+static int mock_listen_mode_cur    = FREEDV_MODE_DATAC15;
+
+int modem_set_listen_mode(int mode)
+{
+    mock_listen_mode_calls++;
+    if (mock_listen_mode_rc == 0)
+        mock_listen_mode_set = mode;
+    return mock_listen_mode_rc;
+}
+int    modem_get_listen_mode(void)          { return mock_listen_mode_cur; }
+size_t modem_get_broadcast_frame_size(void) { return 14; }
+
 /* Use the actual ring implementation for the shutdown race; retain command
  * test stubs under their usual names. No audio/modem hardware is linked. */
 #define size_buffer real_size_buffer
@@ -349,6 +366,12 @@ void setUp(void)
     mock_tune_start_rc    = 0;
     mock_tune_stop_calls  = 0;
     mock_tune_level_dbfs  = -15.0f;
+
+    /* Listen mode */
+    mock_listen_mode_set   = -1;
+    mock_listen_mode_calls = 0;
+    mock_listen_mode_rc    = 0;
+    mock_listen_mode_cur   = FREEDV_MODE_DATAC15;
 }
 
 void tearDown(void) { }
@@ -534,6 +557,74 @@ void test_cmd_tune_garbage_argument(void)
 
     assert_wrong_response();
     TEST_ASSERT_EQUAL_INT(0, mock_tune_start_calls);
+}
+
+/* MODE takes the same index space as -m.  Index 7 is DATAC15. */
+void test_cmd_mode_sets_listen_mode(void)
+{
+    char cmd[] = "MODE 7";
+    execute_control_command(cmd);
+
+    assert_ok_response();
+    TEST_ASSERT_EQUAL_INT(1, mock_listen_mode_calls);
+    TEST_ASSERT_EQUAL_INT(FREEDV_MODE_DATAC15, mock_listen_mode_set);
+}
+
+void test_cmd_mode_index_out_of_range(void)
+{
+    /* Must be rejected by the parser without reaching the modem, or an
+     * out-of-range index would read past freedv_modes[]. */
+    char cmd[] = "MODE 99";
+    execute_control_command(cmd);
+
+    assert_wrong_response();
+    TEST_ASSERT_EQUAL_INT(0, mock_listen_mode_calls);
+}
+
+void test_cmd_mode_negative_index(void)
+{
+    char cmd[] = "MODE -3";
+    execute_control_command(cmd);
+
+    assert_wrong_response();
+    TEST_ASSERT_EQUAL_INT(0, mock_listen_mode_calls);
+}
+
+void test_cmd_mode_busy_is_not_ok(void)
+{
+    /* An ARQ session owns the payload mode: the host must see BUSY, never OK,
+     * or it would believe a setting that was silently discarded. */
+    mock_listen_mode_rc = MODEM_LISTEN_MODE_BUSY;
+    char cmd[] = "MODE 7";
+    execute_control_command(cmd);
+
+    TEST_ASSERT_EQUAL(1, tcp_write_call_count);
+    TEST_ASSERT_EQUAL_STRING_LEN("BUSY\r", (char *)last_tcp_write_buf, 5);
+    TEST_ASSERT_EQUAL_INT(1, mock_listen_mode_calls);
+}
+
+void test_cmd_mode_unsupported_mode_is_wrong(void)
+{
+    /* Index 6 is FSK_LDPC: a valid -m startup mode but not runtime-switchable,
+     * so the modem refuses it and the host must not see OK. */
+    mock_listen_mode_rc = MODEM_LISTEN_MODE_BAD;
+    char cmd[] = "MODE 6";
+    execute_control_command(cmd);
+
+    assert_wrong_response();
+    TEST_ASSERT_EQUAL_INT(1, mock_listen_mode_calls);
+}
+
+void test_cmd_mode_query_reports_index_and_name(void)
+{
+    /* The reply must round-trip: the reported index is a valid MODE argument. */
+    mock_listen_mode_cur = FREEDV_MODE_QAM16C2;
+    char cmd[] = "MODE";
+    execute_control_command(cmd);
+
+    TEST_ASSERT_EQUAL(1, tcp_write_call_count);
+    TEST_ASSERT_EQUAL_STRING_LEN("MODE 10 QAM16C2\r", (char *)last_tcp_write_buf, 16);
+    TEST_ASSERT_EQUAL_INT(0, mock_listen_mode_calls);
 }
 
 void test_cmd_chat_on(void)
@@ -1597,6 +1688,12 @@ int main(void)
     RUN_TEST(test_cmd_tune_refusal_is_not_ok);
     RUN_TEST(test_cmd_tune_missing_argument);
     RUN_TEST(test_cmd_tune_garbage_argument);
+    RUN_TEST(test_cmd_mode_sets_listen_mode);
+    RUN_TEST(test_cmd_mode_index_out_of_range);
+    RUN_TEST(test_cmd_mode_negative_index);
+    RUN_TEST(test_cmd_mode_busy_is_not_ok);
+    RUN_TEST(test_cmd_mode_unsupported_mode_is_wrong);
+    RUN_TEST(test_cmd_mode_query_reports_index_and_name);
     RUN_TEST(test_cmd_chat_on);
     RUN_TEST(test_cmd_bw500);
     RUN_TEST(test_cmd_bw2300);

--- a/tests/datalink_arq/test_arq_fsm.c
+++ b/tests/datalink_arq/test_arq_fsm.c
@@ -274,6 +274,68 @@ void test_accept_transitions_to_connected(void)
     TEST_ASSERT_GREATER_THAN(0, fake_notify_connected_fake.call_count);
 }
 
+/* The listen mode (initial_payload_mode) is an operator setting for the IDLE
+ * decoder -- which broadcast frames the station can hear while no session is
+ * up.  It must not leak into a session: an inbound CALL answered on a station
+ * listening in QAM16C2 must still start its mode ladder at the safest rung,
+ * or the first data burst of every inbound connection would be sent in a mode
+ * the link may not support at all.  This pins the guarantee that makes the
+ * MODE control-port command safe to accept while LISTENING. */
+void test_listen_mode_does_not_leak_into_inbound_session(void)
+{
+    sess.initial_payload_mode = FREEDV_MODE_QAM16C2;
+
+    arq_event_t ev = make_event(ARQ_EV_APP_LISTEN);
+    arq_fsm_dispatch(&sess, &ev);
+    /* Entering LISTENING puts the idle decoder on the listen mode. */
+    TEST_ASSERT_EQUAL_INT(FREEDV_MODE_QAM16C2, sess.peer_tx_mode);
+
+    ev = make_event(ARQ_EV_RX_CALL);
+    ev.session_id = 0x42;
+    strncpy(ev.remote_call, "REMOTE1", CALLSIGN_MAX_SIZE);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_ACCEPTING, sess.conn_state);
+
+    /* The caller's first data burst completes the inbound connect. */
+    ev = make_event(ARQ_EV_RX_DATA);
+    ev.session_id = 0x42;
+    ev.mode       = FREEDV_MODE_DATAC15;
+    arq_fsm_dispatch(&sess, &ev);
+
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
+    TEST_ASSERT_EQUAL_INT(FREEDV_MODE_DATAC15, sess.payload_mode);
+    /* The listen mode is remembered for the next idle period, not applied. */
+    TEST_ASSERT_EQUAL_INT(FREEDV_MODE_QAM16C2, sess.initial_payload_mode);
+}
+
+/* ...and the converse: once the session ends, the idle decoder goes back to
+ * the listen mode rather than being stranded on whatever rung the ladder
+ * happened to finish on -- otherwise broadcast RX would silently stop working
+ * after every ARQ call. */
+void test_listen_mode_restored_after_session_ends(void)
+{
+    sess.initial_payload_mode = FREEDV_MODE_QAM16C2;
+
+    arq_event_t ev = make_event(ARQ_EV_APP_LISTEN);
+    arq_fsm_dispatch(&sess, &ev);
+    ev = make_event(ARQ_EV_APP_CONNECT);
+    strncpy(ev.remote_call, "DST1", CALLSIGN_MAX_SIZE);
+    arq_fsm_dispatch(&sess, &ev);
+    ev = make_event(ARQ_EV_RX_ACCEPT);
+    ev.session_id = sess.session_id;
+    strncpy(ev.remote_call, "DST1", CALLSIGN_MAX_SIZE);
+    arq_fsm_dispatch(&sess, &ev);
+    TEST_ASSERT_EQUAL_INT(ARQ_CONN_CONNECTED, sess.conn_state);
+    /* The session climbed away from the listen mode. */
+    TEST_ASSERT_EQUAL_INT(FREEDV_MODE_DATAC15, sess.peer_tx_mode);
+
+    ev = make_event(ARQ_EV_RX_DISCONNECT);
+    ev.session_id = sess.session_id;
+    arq_fsm_dispatch(&sess, &ev);
+
+    TEST_ASSERT_EQUAL_INT(FREEDV_MODE_QAM16C2, sess.peer_tx_mode);
+}
+
 /* APP_DISCONNECT from CONNECTED */
 void test_disconnect_from_connected(void)
 {
@@ -1215,6 +1277,8 @@ int main(void)
     RUN_TEST(test_incoming_call_transitions_to_accepting);
     RUN_TEST(test_incoming_call_records_dialed_secondary);
     RUN_TEST(test_accept_transitions_to_connected);
+    RUN_TEST(test_listen_mode_does_not_leak_into_inbound_session);
+    RUN_TEST(test_listen_mode_restored_after_session_ends);
     RUN_TEST(test_disconnect_from_connected);
     RUN_TEST(test_listen_off_drops_pending_accept);
     RUN_TEST(test_listen_off_drops_outgoing_call);


### PR DESCRIPTION
Adds a `MODE` control-port command to set the **listen mode** — the payload mode the station sits on while no ARQ session is up, which decides the broadcast frames it can hear and send. Until now this was only settable with `-m` at startup.

```
MODE 10\r          set the listen mode to QAM16C2 (same index space as -m)
MODE\r             -> MODE 10 QAM16C2\r
```

`OK` / `BUSY` (a session is up) / `WRONG` (index out of range or not runtime-switchable).

## Why this was awkward: the mode was five settings, not one

Tracing how a broadcast on `-m 10` actually decodes turned up five places that all have to agree:

| # | Where | Role |
|---|---|---|
| 1 | `g_sess.initial_payload_mode` | restored into `peer_tx_mode` on every fall back to DISCONNECTED/LISTENING; via `select_payload_rx_mode()` this is what binds the payload RX decoder while idle |
| 2 | `modem.c` `broadcast_frame_size` | RX size filter — silently discards every broadcast frame that does not match |
| 3 | `tx_thread`'s `startup_mode` | latched once at thread start, pinning pure-broadcast TX |
| 4 | the broadcast TX size gate | `payload_bytes_per_modem_frame == broadcast_frame_size` |
| 5 | `tcp_interfaces.c` `broadcast_frame_size_cfg` | captured once per broadcast TCP client at connect, used to `malloc` its buffers |

Miss any one and the change *half*-applies. In particular, a frame size that follows the new mode while TX stays on the old one drops every broadcast frame, with nothing in the logs pointing back at the mode command. The setter now owns all five.

Notably neither RX decoder reads `-m` directly — the "listen mode" was an emergent property of an ARQ session field laundered through the runtime snapshot, which is exactly why it was hard to change from outside.

## Changes

- **`arq_set_listen_mode()`** — writes `initial_payload_mode` (+ `peer_tx_mode`, since we are already idle and no further transition is guaranteed). The idle-state test is **inside `g_sess_lock`**, not in the caller: checking it outside would race the event loop.
- **`modem_set_listen_mode()`** — the single owned setter. Asks ARQ first, so a refused command leaves every field untouched. Deliberately does **not** switch the modem: the TX broadcast branch and the RX payload worker already converge on this state every iteration, exactly as they do for the ARQ ladder, so forcing a switch here would only race them.
- **`tx_thread`** reads the listen mode live instead of latching it once.
- **Broadcast client threads** re-read the frame size per frame, with buffers sized for the widest selectable frame (1213 B). So a mode change re-frames the plane under a *connected* client instead of being refused or silently corrupting its framing.
- **`broadcast_frame_size` / `broadcast_frame_size_cfg` → `_Atomic`.** They are now written by the control-port thread and read by the modem RX/TX and broadcast client threads. As plain scalars that is the same data race as the unsynchronized `g_sess` access behind the on-air handshake freeze.
- **`common/mercury_modes.c`** — the `-m`/`MODE` index table moves to its own dependency-free TU so the control-port tests link the *shipping* table rather than a copy. The MODE tests assert on specific indexes, which only means anything against the real one.

## Second commit: a fyne UI bug this exposed

`mercury_bcast_engine_mode()` read `g_modem.mode` — the **live** modem mode, which follows whatever rung the ARQ ladder is on. So as soon as an ARQ session came up, the broadcast UI reported and sized its frames from a mode unrelated to broadcast: the file window's mode description, its usability check, and the chat window's character limit all tracked the ARQ ladder. The chat limit is the one that actually bites, since it silently caps or admits the wrong number of characters.

It now reads the listen mode, which is what broadcast genuinely uses — and as a side effect the UI follows a `MODE` command instead of showing the startup mode forever.

Also in that commit:

- The bridge's **private duplicate of the `-m` index table is gone**, replaced by the shared one. Two copies of a table whose indexes are a user-facing API is a drift hazard, for the same reason the control-port tests link the real table. The two were verified byte-identical before collapsing them.
- An uninitialised engine now reports −1 ("cannot carry broadcast") rather than mapping a zeroed `g_modem.mode` onto whichever FreeDV mode happens to be 0.
- `mercury_engine_modem_mode()` had no caller left, so it is removed rather than left as dead code. Its bitrate/bandwidth neighbours still describe the live modem, which is what they are for.
- Two operator-facing strings that said the mode was fixed at engine start and to restart mercury with `-m` are corrected.

## Limits, stated in `docs/TNC.md`

- **Idle only.** During a session the ARQ ladder owns the payload mode and would overwrite an operator setting within one RX-loop iteration — hence `BUSY` rather than accepting something about to be discarded.
- **Pooled payload modes only:** indexes 0/1/3/7/9/10 (DATAC1, DATAC3, DATAC4, DATAC15, DATAC17, QAM16C2). DATAC16 is the control mode; DATAC0/13/14/FSK_LDPC have no runtime pool slot. `-m` can still *start* on some of those.
- **No effect on ARQ connections.** Every session resets its ladder to DATAC15 and climbs via OLLA, so a fast listen mode gives a later connection no head start and a robust one costs it nothing. This is a natural wrong expectation, so it is called out explicitly in the docs.

## Testing

Two invariants are now pinned by tests rather than by reading — these are the load-bearing claims:

- `test_listen_mode_does_not_leak_into_inbound_session` — a station listening in QAM16C2 that answers an inbound CALL still starts its ladder at DATAC15.
- `test_listen_mode_restored_after_session_ends` — the idle decoder returns to the listen mode, or broadcast RX would silently stop working after every ARQ call.

Both were **verified to fail** against a deliberately broken DATAC15 reset and a deliberately dropped restore. The command's index-bound and BUSY-is-not-OK paths were likewise mutation-checked (a `BUSY` reported as `OK` is precisely the silent-discard the command exists to avoid).

35 unit suites green with every binary's exit code checked individually — `test_arq_fsm` 42→44, `test_tcp_interfaces` 73→79. Native build, `libmercury_core.a` and `make fyne-ui` all built locally. `arq_fsm.c` itself is **unmodified**; only its test file grew.

Not covered: there is no mode selector widget in the fyne UI — this PR makes the UI *report* the mode correctly and follow a `MODE` command, but adding an operator control for it is a UI feature rather than a gap in this change, so it is left out deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)