### PR TITLE
tests: carry a real NNCP bundle over the broadcast plane, and record the result

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,25 @@ PTT control notes:
 | `make fyne-ui-macos-dmg` | Wrap the host-arch `Mercury.app` in a drag-to-install `Mercury.dmg` at the repo top level. **Needs Go + the `fyne` CLI** ([setup](#gui-build-prerequisites-go--fyne)). |
 | `make fyne-ui-macos-universal-dmg` | **Distribution build:** universal (x86_64 + arm64) `Mercury.app` wrapped in `Mercury.dmg` at the repo top level. This is the artifact for the website. **Needs Go + the `fyne` CLI** ([setup](#gui-build-prerequisites-go--fyne)). |
 
+### Build options
+
+Passed on the `make` command line, e.g. `make HAVE_HAMLIB=0`.
+
+| Option | Effect |
+|--------|--------|
+| `HAVE_HAMLIB=0` | Build without Hamlib. Drops the `libhamlib-dev` build dependency entirely; `-P hamlib`, `-R` and `-K` are compiled out and report "HAMLIB support not compiled in". The serial/RTS, CM108 and HERMES shared-memory PTT backends are unaffected, so the radio can still be keyed. |
+| `HAVE_HIDAPI=0` | Build without hidapi. The CM108 GPIO PTT backend then talks to `/dev/hidraw` directly, which works on Linux only. |
+
+Both are auto-detected with `pkg-config` when not set, so the default build
+picks them up if they are installed. Set them to `0` to opt out.
+
+**If the build fails on `hamlib/rig.h: No such file or directory`** while
+`libhamlib-dev` is installed, the package's headers are missing or broken —
+Mercury only enables Hamlib when `pkg-config --exists hamlib` succeeds, so
+pkg-config is finding the `.pc` file but the headers it points at are not
+there. Either reinstall the package (`sudo apt reinstall libhamlib-dev`) or
+build without it using `HAVE_HAMLIB=0`.
+
 ### Build the Fyne GUI (Linux)
 
 ```bash

--- a/docs/BROADCAST-FILE.md
+++ b/docs/BROADCAST-FILE.md
@@ -228,6 +228,10 @@ mode=9  file=1000 B  air=ch clean (--No -100)
 
 ## Benchmarks
 
+For a trial carrying a real NNCP bundle end to end, including fading results
+and the traps that produced wrong answers first, see
+[BROADCAST-NNCP-TRIAL.md](BROADCAST-NNCP-TRIAL.md).
+
 A 5 kB file, transmitted between two real Mercury modems with `ch` standing in
 for the propagation path. Each mode was walked down in SNR until it stopped
 decoding; `SNR3k = -No - 14.82`, and the harness's noise is **AWGN, not

--- a/docs/BROADCAST-NNCP-TRIAL.md
+++ b/docs/BROADCAST-NNCP-TRIAL.md
@@ -1,0 +1,121 @@
+# NNCP bundles over the broadcast plane — bench trial
+
+A real NNCP bundle carried end to end over Mercury's one-way broadcast plane,
+between two Mercury modems with a channel simulator standing in for the path.
+
+**This is a bench result, not an on-air one.** Everything below came from
+`ch` (codec2's channel simulator), not from a radio. No NNCP bundle has yet
+crossed a real HF link. Treat the numbers as an upper bound and a sanity
+check on the mechanism, not as field performance.
+
+Reproduce with `tests/integration/mercury_broadcast_nncp_test.go`:
+
+```
+MERCURY_BCAST_TRIAL=1 MERCURY_BCAST_MODE=10 \
+  go test -run TestBroadcastNNCPBundleOverChannel -v ./...
+```
+
+## What is actually being tested
+
+The bundle is produced by `nncp-bundle -tx` on one node and consumed by
+`nncp-bundle -rx` + `nncp-toss` on a **second, independently keyed node**. A
+pass therefore means NNCP itself accepted what came off the air — signatures
+and all — and tossed the payload into the receiving node's incoming spool
+byte-identical to the original. It is not a file comparison with NNCP-shaped
+bytes; it is NNCP.
+
+Mercury treats the bundle as opaque. Nothing in Mercury knows about NNCP, and
+nothing needs to.
+
+## Results
+
+6000-byte payload → 7680-byte NNCP bundle. `SNR3k = -No - 14.82`. Every row
+below ended with **NNCP accepting the bundle** and the payload delivered intact.
+
+| mode | channel | SNR3k | cycles | wall | goodput |
+|---|---|---|---:|---:|---:|
+| QAM16C2 | AWGN | +17.2 | 14 | 26.0 s | 2360 bps |
+| QAM16C2 | mpg (0.1 Hz) | +17.2 | 28 | 37.5 s | 1636 bps |
+| QAM16C2 | mpg | +25.2 | 28 | 26.5 s | 2315 bps |
+| QAM16C2 | mpp (1.0 Hz) | +25.2 | 28 | 30.0 s | 2045 bps |
+| DATAC17 | mpg | +7.2 | 28 | 67.1 s | 916 bps |
+| DATAC3 | AWGN | +0.2 | 190 | 361 s | 170 bps |
+| DATAC3 | mpg | +0.2 | 190 | 515 s | 119 bps |
+| DATAC3 | mpp | +0.2 | 190 | 423 s | 145 bps |
+
+The 2360 bps AWGN figure for QAM16C2 agrees with the 2353 bps in
+[BROADCAST-FILE.md](BROADCAST-FILE.md), measured separately with a plain file.
+
+### Fading taxes the transfer, it does not cliff it
+
+At each mode's AWGN floor, adding multipath costs roughly 40-45% more airtime
+rather than failing:
+
+- QAM16C2 at +17.2 dB: 26.0 s → 37.5 s (**+44%**)
+- DATAC3 at +0.2 dB: 361 s → 515 s (**+43%**)
+
+That is the fountain code doing its job. A frame lost to a fade is simply a
+symbol the receiver did not collect; there is no retransmit to stall on and no
+state to resynchronise, so the carousel just runs a little longer. An ARQ link
+at the same SNR would be spending that airtime on retries and turnarounds.
+
+About 8 dB of margin buys the tax back entirely: QAM16C2 under mpg at +25.2 dB
+finished in 26.5 s, within noise of its AWGN time.
+
+### Slow fading looked worse than fast fading
+
+For DATAC3 the 0.1 Hz profile was *slower* than the 1.0 Hz one (515 s vs
+423 s), which is the opposite of the usual "faster Doppler is harder" instinct.
+The plausible reading is that slow fading produces long deep fades that take out
+many consecutive frames, while faster fading decorrelates between frames and
+gives the carousel diversity to work with.
+
+**This is one run per point, so treat it as suggestive, not established.** `ch`
+replays a single fixed fading realisation (seed 1), so these are one draw from
+the ensemble, not an average over it. Confirming the effect needs repeats with
+different realisations.
+
+## Caveats
+
+- **Simulator, not radio.** See the top of this file.
+- **n = 1 per row.** No repeats, no error bars.
+- **One fading realisation.** `ch` replays a fixed file; runs are reproducible
+  but not independent samples.
+- **The mpg and mpd fading files are generated locally**, not shipped: only the
+  1.0 Hz (`--mpp`) file is in the tree. The 0.1 Hz and 2.0 Hz files used here
+  were generated with the octave command that `requireChFading()` prints. Their
+  layout matches the shipped file byte-for-byte in length.
+
+## Choosing the cycle count
+
+This is the number an operator gets wrong, and it is worth stating bluntly: a
+too-small `-c` delivers **nothing at all**, not a partial file. There is no
+feedback, so the sender cannot know it fell short.
+
+The test computes it as
+
+    symbols needed  ~= bundle_bytes / 41 + 2
+    frames needed   ~= ceil(symbols / symbols_per_frame)
+    cycles          =  2 x frames needed
+
+For the 7680-byte bundle that is 189 symbols: 7 frames on QAM16C2 (29
+symbols/frame) but 95 frames on DATAC3 (2 symbols/frame) — a factor of 13
+between modes for the same object. The 2x overshoot was sufficient at every
+point measured here, including under fading.
+
+## Traps this trial hit
+
+Recorded because each one produced confident, wrong results first:
+
+1. **`ch` exits when a fading sample file is missing**, printing octave
+   instructions. The bridge then carries no audio, and every mode fails at
+   every SNR — indistinguishable from a channel too harsh to decode. An entire
+   five-point sweep was read as "fading breaks broadcast" before the cause was
+   found. `requireChFading()` now preflights this and skips with the command to
+   generate the file.
+2. **`bcast_file_tool send` returns in milliseconds.** It enqueues frames into
+   Mercury's broadcast socket; the airtime that follows is seconds to minutes.
+   A fixed arrival deadline measured from that return reported a transfer still
+   in progress as a channel failure.
+3. **Forcing one cycle count across modes starves the robust ones.** 28 cycles
+   is ample at 29 symbols/frame and supplies 56 of 189 needed symbols at 2.

--- a/docs/BROADCAST-NNCP-TRIAL.md
+++ b/docs/BROADCAST-NNCP-TRIAL.md
@@ -75,10 +75,75 @@ replays a single fixed fading realisation (seed 1), so these are one draw from
 the ensemble, not an average over it. Confirming the effect needs repeats with
 different realisations.
 
+## Where it stops working
+
+Walking the SNR down at a fixed 2x cycle overshoot until the bundle stops
+arriving. "Last OK" and "first FAIL" bracket the transition; the step is 2 dB.
+
+| mode | channel | last OK | first FAIL |
+|---|---|---:|---:|
+| QAM16C2 | AWGN | +13.2 | +11.2 |
+| QAM16C2 | mpg | +15.2 | +13.2 |
+| DATAC17 | AWGN | +3.2 | +1.2 |
+| DATAC17 | mpg | +5.2 | +3.2 |
+
+**Multipath costs about 2 dB**, and the same 2 dB on both modes — a much more
+useful number than the percent-of-airtime figures above, because it is the
+quantity you compare against a link budget.
+
+### But that is not a decode floor, it is a carousel-length limit
+
+The table above is "the SNR at which 2x overshoot stops being enough", which is
+not the same thing as "the SNR at which the mode stops working". Taking the
+QAM16C2/mpg point that failed at 2x and simply sending more:
+
+| cycles | overshoot | result |
+|---:|---:|---|
+| 14 | 2x | FAIL |
+| 28 | 4x | OK, 63.6 s |
+| 56 | 8x | OK, 63.6 s |
+| 112 | 16x | OK, 64.1 s |
+
+Doubling the carousel recovered a point that had "failed". So under fading the
+floor is a budget decision, not a hard limit: a fade takes out whole frames, and
+more passes simply give the receiver more chances to catch the gaps between
+fades.
+
+**Overshoot is insurance, not latency.** 4x, 8x and 16x all delivered at the
+same moment — the receiver finishes the instant it holds enough symbols, and
+the sender goes on transmitting into the void afterwards. Extra cycles cost
+airtime and channel occupancy, not time-to-delivery. Since broadcast has no
+feedback and a short carousel delivers *nothing at all* rather than a partial
+file, err generously.
+
+### AWGN does have a hard floor
+
+The same trick does **not** work on a clean channel:
+
+| channel | SNR3k | overshoot | result |
+|---|---:|---:|---|
+| AWGN | +11.2 | 4x | FAIL |
+| mpg | +9.2 | 16x | FAIL |
+| mpg | +7.2 | 16x | FAIL |
+
+This is the distinction worth carrying away. AWGN is stationary: below the
+modem's decode threshold every frame fails equally, so repetition buys nothing
+and no overshoot will save it — the answer there is a more robust mode. Fading
+is time-varying, so between the 2x cliff and the true floor there is a region
+where patience substitutes for SNR. Far enough down, fading runs out of good
+periods too and even 16x fails.
+
+So, operationally:
+
+- **Marginal on a fading path** → send more cycles.
+- **Marginal on a quiet, weak path** → change mode; cycles will not help.
+
 ## Caveats
 
 - **Simulator, not radio.** See the top of this file.
-- **n = 1 per row.** No repeats, no error bars.
+- **n = 1 per row.** No repeats, no error bars. The cliff brackets in
+  particular are single runs at a 2 dB step, so read them as "between these two
+  values", not as a threshold measured to a decibel.
 - **One fading realisation.** `ch` replays a fixed file; runs are reproducible
   but not independent samples.
 - **The mpg and mpd fading files are generated locally**, not shipped: only the
@@ -100,8 +165,12 @@ The test computes it as
 
 For the 7680-byte bundle that is 189 symbols: 7 frames on QAM16C2 (29
 symbols/frame) but 95 frames on DATAC3 (2 symbols/frame) — a factor of 13
-between modes for the same object. The 2x overshoot was sufficient at every
-point measured here, including under fading.
+between modes for the same object.
+
+2x is enough with a few dB of margin in hand, and is what the trial harness
+defaults to. It is **not** enough close to the cliff: at QAM16C2 under mpg at
++13.2 dB, 2x delivered nothing and 4x delivered in 63.6 s. See "Where it stops
+working" — on a fading path, overshoot is the cheapest margin you have.
 
 ## Traps this trial hit
 

--- a/modem/freedv/.gitignore
+++ b/modem/freedv/.gitignore
@@ -1,3 +1,8 @@
 ch
 unittest/fast_fading_samples.float
+# The other two multipath profiles ch can load (--mpg 0.1 Hz, --mpd 2.0 Hz).
+# ~100 MB each and generated, not source: see requireChFading() in
+# tests/integration/channel_bridge_test.go for the octave command.
+unittest/slow_fading_samples.float
+unittest/faster_fading_samples.float
 slow_fading/

--- a/modem/freedv/original_docs/octave/gen_fading.m
+++ b/modem/freedv/original_docs/octave/gen_fading.m
@@ -1,0 +1,18 @@
+% Vectorised equivalent of ch_fading.m (same interleaved layout, same seed).
+function gen_fading(raw_file_name, Fs, dopplerSpreadHz, len_samples)
+  randn('seed',1);
+  spread     = doppler_spread(dopplerSpreadHz, Fs, len_samples);
+  spread_2ms = doppler_spread(dopplerSpreadHz, Fs, len_samples);
+  hf_gain = 1.0/sqrt(var(spread)+var(spread_2ms));
+  printf("hf_gain: %f\n", hf_gain);
+  inter = zeros(1, len_samples*4 + 4);
+  inter(1:4) = hf_gain;
+  inter(5:4:end) = real(spread);
+  inter(6:4:end) = imag(spread);
+  inter(7:4:end) = real(spread_2ms);
+  inter(8:4:end) = imag(spread_2ms);
+  f = fopen(raw_file_name,"wb");
+  fwrite(f, inter, "float32");
+  fclose(f);
+  printf("wrote %s: %d samples\n", raw_file_name, len_samples);
+end

--- a/tests/integration/channel_bridge_test.go
+++ b/tests/integration/channel_bridge_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
+	"testing"
 	"time"
 )
 
@@ -76,6 +77,45 @@ func buildWatterson(repoRoot string) (string, error) {
 	}
 	return dst, nil
 }
+
+// chFadingFile maps ch's multipath profiles to the sample file each one loads
+// (see MPG/MPP/MPD_FADING_FILE_NAME in modem/freedv/ch.c).
+var chFadingFile = map[string]string{
+	"mpg": "slow_fading_samples.float",   // 0.1 Hz Doppler, 0.5 ms delay
+	"mpp": "fast_fading_samples.float",   // 1.0 Hz Doppler, 2.0 ms delay
+	"mpd": "faster_fading_samples.float", // 2.0 Hz Doppler, 4.0 ms delay
+}
+
+// requireChFading fails loudly when a requested multipath profile has no sample
+// file, instead of letting the run produce meaningless results.
+//
+// This is worth a preflight check because of how ch fails: given --mpg with no
+// slow_fading_samples.float, it prints octave instructions and EXITS.  The
+// bridge then carries no audio at all, every mode fails at every SNR, and the
+// run looks exactly like a channel too harsh to decode.  A sweep was read that
+// way once -- five "fading breaks broadcast" results that were really five
+// missing-file errors.  Only the repo's 1.0 Hz file ships, so --mpg and --mpd
+// hit this by default.
+func requireChFading(t *testing.T, repoRoot, fading string) {
+	t.Helper()
+	if fading == "" {
+		return
+	}
+	name, ok := chFadingFile[fading]
+	if !ok {
+		t.Fatalf("unknown ch fading profile %q (want mpg, mpp or mpd)", fading)
+	}
+	path := filepath.Join(repoRoot, "modem", "freedv", "unittest", name)
+	if _, err := os.Stat(path); err != nil {
+		t.Skipf("ch fading profile %q needs %s, which is not present.\n"+
+			"Generate it (~100 MB, needs octave + the signal package) with:\n"+
+			"  cd modem/freedv/original_docs/octave && octave --no-gui -qf --eval "+
+			"'pkg load signal; ch_fading(\"%s\", 8000, %s, 8000*800)'",
+			fading, path, path, chFadingDoppler[fading])
+	}
+}
+
+var chFadingDoppler = map[string]string{"mpg": "0.1", "mpp": "1.0", "mpd": "2.0"}
 
 func buildCh(repoRoot string) (string, error) {
 	dst := filepath.Join(repoRoot, "modem", "freedv", "ch")

--- a/tests/integration/mercury_arq_transfer_test.go
+++ b/tests/integration/mercury_arq_transfer_test.go
@@ -65,6 +65,7 @@ func TestMercuryARQTransfer(t *testing.T) {
 	if v := os.Getenv("MERCURY_CH_FADING"); v != "" {
 		params.Fading = v // mpg | mpp | mpd
 	}
+	requireChFading(t, repoRoot, params.Fading)
 	if v := os.Getenv("MERCURY_CH_GAIN"); v != "" {
 		g, err := strconv.ParseFloat(v, 64)
 		if err != nil {

--- a/tests/integration/mercury_bidir_test.go
+++ b/tests/integration/mercury_bidir_test.go
@@ -58,6 +58,7 @@ func TestMercuryARQBidirectional(t *testing.T) {
 	if v := os.Getenv("MERCURY_CH_FADING"); v != "" {
 		params.Fading = v // ch: mpg|mpp|mpd ; watterson: good|moderate|poor
 	}
+	requireChFading(t, repoRoot, params.Fading)
 	if v := os.Getenv("MERCURY_CH_GAIN"); v != "" {
 		g, perr := strconv.ParseFloat(v, 64)
 		if perr != nil {

--- a/tests/integration/mercury_broadcast_nncp_test.go
+++ b/tests/integration/mercury_broadcast_nncp_test.go
@@ -1,0 +1,390 @@
+//go:build linux
+
+package integration
+
+// A real NNCP bundle carried over Mercury's one-way broadcast plane, between
+// two Mercury modems with a channel simulator standing in for the propagation
+// path.
+//
+// This is a TRIAL harness, not a regression test: it is skipped unless
+// MERCURY_BCAST_TRIAL=1, because a single run at a robust mode takes minutes
+// and the point is to sweep it, not to gate CI.
+//
+// What makes it worth running rather than just copying a file: the bundle is
+// produced by nncp-bundle and consumed by nncp-bundle -rx + nncp-toss on a
+// second node, so a pass means NNCP itself accepted what came off the air --
+// signatures and all -- not merely that some bytes arrived intact.
+//
+// Knobs (all optional):
+//   MERCURY_BCAST_MODE     hermes mode index, default 10 (QAM16C2)
+//   MERCURY_BCAST_CYCLES   carousel cycles, default = 2x the computed need
+//   MERCURY_BCAST_PAYLOAD  payload bytes fed to nncp-file, default 6000
+//   MERCURY_BCAST_DEADLINE_S  how long to wait for arrival, default 300
+//   MERCURY_CH_NO / _FADING / _ENGINE / _GAIN   as the other integration tests
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// bcastFrameSize mirrors bcast_frame_size[] in datalink_broadcast/bcast_modes.h.
+var bcastFrameSize = []int{510, 126, 14, 54, 14, 3, 30, 30, 14, 1180, 1213}
+
+const bcastFrameOverhead = 12
+const bcastSymbolSize = 41
+
+func nncpAvailable() bool {
+	for _, b := range []string{"nncp-cfgnew", "nncp-file", "nncp-bundle", "nncp-toss"} {
+		if _, err := exec.LookPath(b); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// nncpKeys runs nncp-cfgnew and pulls the self block's keys out of it.
+func nncpKeys(t *testing.T) map[string]string {
+	t.Helper()
+	out, err := exec.Command("nncp-cfgnew").Output()
+	if err != nil {
+		t.Fatalf("nncp-cfgnew: %v", err)
+	}
+	blk := regexp.MustCompile(`(?s)\n  self: \{(.*?)\n  \}`).FindSubmatch(out)
+	if blk == nil {
+		t.Fatalf("cannot find self block in nncp-cfgnew output")
+	}
+	m := map[string]string{}
+	for _, kv := range regexp.MustCompile(`(\w+):\s*(\S+)`).FindAllStringSubmatch(string(blk[1]), -1) {
+		m[kv[1]] = kv[2]
+	}
+	return m
+}
+
+// writeNNCPCfg emits a minimal, fully-populated node config.  Generated rather
+// than patched from nncp-cfgnew's template: that template is mostly comments,
+// and regex surgery on it produces configs that parse but are subtly wrong.
+func writeNNCPCfg(t *testing.T, root, name string, me, other map[string]string, otherName string) string {
+	t.Helper()
+	base := filepath.Join(root, name)
+	for _, sub := range []string{"spool", "incoming"} {
+		if err := os.MkdirAll(filepath.Join(base, sub), 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	pub := func(d map[string]string) string {
+		return fmt.Sprintf("id: %s\n      exchpub: %s\n      signpub: %s\n      noisepub: %s",
+			d["id"], d["exchpub"], d["signpub"], d["noisepub"])
+	}
+	var priv []string
+	for _, k := range []string{"id", "exchpub", "exchprv", "signpub", "signprv", "noiseprv", "noisepub"} {
+		priv = append(priv, fmt.Sprintf("%s: %s", k, me[k]))
+	}
+	cfg := fmt.Sprintf(`{
+  spool: %s/spool
+  log: %s/log
+  self: {
+    %s
+  }
+  neigh: {
+    self: {
+      %s
+    }
+    %s: {
+      %s
+      incoming: "%s/incoming"
+    }
+  }
+}
+`, base, base, strings.Join(priv, "\n    "), pub(me), otherName, pub(other), base)
+	p := filepath.Join(root, name+".hjson")
+	if err := os.WriteFile(p, []byte(cfg), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestBroadcastNNCPBundleOverChannel(t *testing.T) {
+	if os.Getenv("MERCURY_BCAST_TRIAL") != "1" {
+		t.Skip("broadcast NNCP trial: set MERCURY_BCAST_TRIAL=1 to run")
+	}
+	if !nncpAvailable() {
+		t.Skip("nncp tools not installed")
+	}
+	repoRoot := mustRepoRoot(t)
+	bin := locateOrBuildMercury(t, repoRoot)
+
+	mode := 10
+	if v := os.Getenv("MERCURY_BCAST_MODE"); v != "" {
+		mode, _ = strconv.Atoi(v)
+	}
+	if mode < 0 || mode >= len(bcastFrameSize) {
+		t.Fatalf("bad mode %d", mode)
+	}
+	symsPerFrame := (bcastFrameSize[mode] - bcastFrameOverhead) / bcastSymbolSize
+	if symsPerFrame < 1 {
+		t.Fatalf("mode %d cannot carry broadcast file transfer", mode)
+	}
+	payloadBytes := 6000
+	if v := os.Getenv("MERCURY_BCAST_PAYLOAD"); v != "" {
+		payloadBytes, _ = strconv.Atoi(v)
+	}
+
+	// --- build the channel -------------------------------------------------
+	params := DefaultChannelParams()
+	var chBin string
+	var err error
+	if os.Getenv("MERCURY_CH_ENGINE") == "watterson" {
+		params.Engine = "watterson"
+		chBin, err = buildWatterson(repoRoot)
+	} else {
+		chBin, err = buildCh(repoRoot)
+	}
+	if err != nil {
+		t.Skipf("channel simulator unavailable: %v", err)
+	}
+	if v := os.Getenv("MERCURY_CH_NO"); v != "" {
+		params.No_dBHz, _ = strconv.ParseFloat(v, 64)
+	}
+	if v := os.Getenv("MERCURY_CH_FADING"); v != "" {
+		params.Fading = v
+	}
+	requireChFading(t, repoRoot, params.Fading)
+	if v := os.Getenv("MERCURY_CH_GAIN"); v != "" {
+		params.Gain, _ = strconv.ParseFloat(v, 64)
+	}
+
+	// --- build the bcast_file_tool ----------------------------------------
+	tool := filepath.Join(repoRoot, "utils", "bcast_file_tool")
+	build := exec.Command("make", "bcast_file_tool")
+	build.Dir = filepath.Join(repoRoot, "utils")
+	if out, berr := build.CombinedOutput(); berr != nil {
+		t.Skipf("bcast_file_tool unavailable: %v\n%s", berr, out)
+	}
+
+	// --- a genuine two-node NNCP setup, and a real bundle ------------------
+	nroot := t.TempDir()
+	a, b := nncpKeys(t), nncpKeys(t)
+	aCfg := writeNNCPCfg(t, nroot, "alice", a, b, "bob")
+	bCfg := writeNNCPCfg(t, nroot, "bob", b, a, "alice")
+
+	payload := filepath.Join(nroot, "payload.bin")
+	buf := make([]byte, payloadBytes)
+	if _, rerr := rand.Read(buf); rerr != nil {
+		t.Fatalf("payload: %v", rerr)
+	}
+	if werr := os.WriteFile(payload, buf, 0600); werr != nil {
+		t.Fatal(werr)
+	}
+	if out, ferr := exec.Command("nncp-file", "-cfg", aCfg, "-quiet", payload, "bob:payload.bin").CombinedOutput(); ferr != nil {
+		t.Fatalf("nncp-file: %v\n%s", ferr, out)
+	}
+	bundle := filepath.Join(nroot, "out.nncp")
+	bf, _ := os.Create(bundle)
+	bcmd := exec.Command("nncp-bundle", "-cfg", aCfg, "-quiet", "-tx", "bob")
+	bcmd.Stdout = bf
+	if berr := bcmd.Run(); berr != nil {
+		t.Fatalf("nncp-bundle -tx: %v", berr)
+	}
+	bf.Close()
+	bst, _ := os.Stat(bundle)
+	bundleSize := int(bst.Size())
+
+	symsNeeded := bundleSize/bcastSymbolSize + 2
+	framesNeeded := (symsNeeded + symsPerFrame - 1) / symsPerFrame
+	cycles := framesNeeded * 2
+	if v := os.Getenv("MERCURY_BCAST_CYCLES"); v != "" {
+		cycles, _ = strconv.Atoi(v)
+	}
+
+	t.Logf("trial: mode=%d (%d B/frame, %d sym/frame)  payload=%d B  bundle=%d B",
+		mode, bcastFrameSize[mode], symsPerFrame, payloadBytes, bundleSize)
+	t.Logf("trial: need ~%d symbols = %d frames/cycle-set; sending cycles=%d",
+		symsNeeded, framesNeeded, cycles)
+	t.Logf("trial: channel engine=%q No=%.2f fading=%q gain=%.3f",
+		params.Engine, params.No_dBHz, params.Fading, params.Gain)
+
+	// --- two mercuries over the channel ------------------------------------
+	dir := t.TempDir()
+	aRX := filepath.Join(dir, "a_rx.s32le.fifo")
+	aTX := filepath.Join(dir, "a_tx.s32le.fifo")
+	bRX := filepath.Join(dir, "b_rx.s32le.fifo")
+	bTX := filepath.Join(dir, "b_tx.s32le.fifo")
+	for _, p := range []string{aRX, aTX, bRX, bTX} {
+		if err := syscall.Mkfifo(p, 0600); err != nil {
+			t.Fatalf("mkfifo %s: %v", p, err)
+		}
+	}
+	aPort := freePortPair(t)
+	bPort := freePortPair(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	start := func(name, rxPath, txPath string, port, bcastPort int) (*exec.Cmd, *processWait, *os.File, *os.File) {
+		stdout, stderr := tempLogFilesNamed(t, name)
+		cmd := exec.CommandContext(ctx, bin,
+			"-x", "fifo", "-i", rxPath, "-o", txPath,
+			"-p", fmt.Sprint(port), "-b", fmt.Sprint(bcastPort),
+			"-m", fmt.Sprint(mode), "-v",
+			"-C", filepath.Join(t.TempDir(), "missing-mercury.ini"),
+		)
+		cmd.Dir = repoRoot
+		cmd.Stdout = stdout
+		cmd.Stderr = stderr
+		if serr := startChild(cmd); serr != nil {
+			t.Fatalf("start mercury %s: %v", name, serr)
+		}
+		return cmd, waitForProcess(cmd), stdout, stderr
+	}
+
+	aBcast := aPort + 100
+	bBcast := bPort + 100
+	cmdA, procA, outA, errA := start("A-tx", aRX, aTX, aPort, aBcast)
+	defer func() { _ = stopProcess(t, cmdA, procA, outA.Name(), errA.Name()) }()
+	cmdB, procB, outB, errB := start("B-rx", bRX, bTX, bPort, bBcast)
+	defer func() { _ = stopProcess(t, cmdB, procB, outB.Name(), errB.Name()) }()
+
+	bridge := startChannelBridge(ctx, chBin, aTX, bRX, bTX, aRX, params)
+	defer bridge.Close()
+
+	// Control ports up = both instances are alive and past init.
+	if c, cerr := waitForTCP(ctx, "127.0.0.1", aPort, controlPortTimeout, procA); cerr != nil {
+		printLogs(t, outA.Name(), errA.Name())
+		t.Fatalf("mercury A control port: %v", cerr)
+	} else {
+		c.Close()
+	}
+	if c, cerr := waitForTCP(ctx, "127.0.0.1", bPort, controlPortTimeout, procB); cerr != nil {
+		printLogs(t, outB.Name(), errB.Name())
+		t.Fatalf("mercury B control port: %v", cerr)
+	} else {
+		c.Close()
+	}
+
+	// --- receiver first, then transmit -------------------------------------
+	recvDir := filepath.Join(nroot, "offair")
+	if mkerr := os.MkdirAll(recvDir, 0700); mkerr != nil {
+		t.Fatal(mkerr)
+	}
+	recvCtx, recvCancel := context.WithCancel(ctx)
+	defer recvCancel()
+	recv := exec.CommandContext(recvCtx, tool, "recv", recvDir,
+		"-m", fmt.Sprint(mode), "-p", fmt.Sprint(bBcast))
+	recvOut, _ := recv.StdoutPipe()
+	recv.Stderr = recv.Stdout
+	if rerr := recv.Start(); rerr != nil {
+		t.Fatalf("start recv: %v", rerr)
+	}
+	recvLines := make(chan string, 256)
+	go func() {
+		sc := bufio.NewScanner(recvOut)
+		for sc.Scan() {
+			recvLines <- sc.Text()
+		}
+		close(recvLines)
+	}()
+	time.Sleep(2 * time.Second) // let the receiver attach to the broadcast port
+
+	t0 := time.Now()
+	send := exec.CommandContext(ctx, tool, "send", bundle,
+		"-m", fmt.Sprint(mode), "-c", fmt.Sprint(cycles), "-p", fmt.Sprint(aBcast))
+	sendOut, serr := send.CombinedOutput()
+	if serr != nil {
+		t.Fatalf("send: %v\n%s", serr, sendOut)
+	}
+	// NOT the transmit time: bcast_file_tool returns as soon as it has pushed
+	// the frames into Mercury's broadcast socket, and Mercury then keys them out
+	// over seconds to minutes.  Logging this as "transmit" invited exactly the
+	// wrong conclusion, so name it for what it is.
+	enqueueElapsed := time.Since(t0)
+	t.Logf("trial: frames enqueued in %s (airtime follows)", enqueueElapsed.Round(time.Millisecond))
+
+	// --- wait for the bundle to land ---------------------------------------
+	got := filepath.Join(recvDir, filepath.Base(bundle))
+	// The deadline has to cover the AIRTIME, which the enqueue above says
+	// nothing about.  A robust mode carrying 2 symbols per frame spends ~10
+	// minutes on a bundle that QAM16C2 clears in 26 s, so a fixed few minutes
+	// silently reports a transfer still in progress as a channel failure.
+	waitFor := 5 * time.Minute
+	if v := os.Getenv("MERCURY_BCAST_DEADLINE_S"); v != "" {
+		if n, perr := strconv.Atoi(v); perr == nil {
+			waitFor = time.Duration(n) * time.Second
+		}
+	}
+	t.Logf("trial: waiting up to %s for the bundle to arrive", waitFor)
+	deadline := time.Now().Add(waitFor)
+	arrived := false
+	for time.Now().Before(deadline) {
+		if st, serr2 := os.Stat(got); serr2 == nil && st.Size() == int64(bundleSize) {
+			arrived = true
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	rxElapsed := time.Since(t0)
+	if !arrived {
+		for {
+			select {
+			case l, ok := <-recvLines:
+				if !ok {
+					goto drained
+				}
+				t.Logf("recv: %s", l)
+			default:
+				goto drained
+			}
+		}
+	drained:
+		printLogs(t, outA.Name(), errA.Name())
+		printLogs(t, outB.Name(), errB.Name())
+		t.Fatalf("bundle did not arrive within the deadline (mode=%d No=%.2f fading=%q cycles=%d)",
+			mode, params.No_dBHz, params.Fading, cycles)
+	}
+	t.Logf("trial: bundle complete off-air after %s", rxElapsed.Round(time.Millisecond))
+
+	// --- the point: does NNCP accept what came off the air? ----------------
+	rxf, oerr := os.Open(got)
+	if oerr != nil {
+		t.Fatal(oerr)
+	}
+	rxcmd := exec.Command("nncp-bundle", "-cfg", bCfg, "-quiet", "-rx")
+	rxcmd.Stdin = rxf
+	if out, e := rxcmd.CombinedOutput(); e != nil {
+		t.Fatalf("nncp-bundle -rx rejected the off-air bundle: %v\n%s", e, out)
+	}
+	rxf.Close()
+	if out, e := exec.Command("nncp-toss", "-cfg", bCfg, "-quiet").CombinedOutput(); e != nil {
+		t.Fatalf("nncp-toss: %v\n%s", e, out)
+	}
+	delivered := filepath.Join(nroot, "bob", "incoming", "payload.bin")
+	dgot, derr := os.ReadFile(delivered)
+	if derr != nil {
+		t.Fatalf("payload not delivered into bob's incoming: %v", derr)
+	}
+	if len(dgot) != payloadBytes {
+		t.Fatalf("delivered payload is %d bytes, want %d", len(dgot), payloadBytes)
+	}
+	orig, _ := os.ReadFile(payload)
+	for i := range orig {
+		if orig[i] != dgot[i] {
+			t.Fatalf("delivered payload differs at byte %d", i)
+		}
+	}
+
+	goodput := float64(bundleSize*8) / rxElapsed.Seconds()
+	t.Logf("TRIAL RESULT mode=%d No=%.2f fading=%q cycles=%d bundle=%dB "+
+		"total=%s goodput=%.0f bps  NNCP=ACCEPTED",
+		mode, params.No_dBHz, params.Fading, cycles, bundleSize,
+		rxElapsed.Round(time.Millisecond), goodput)
+}

--- a/tests/integration/mercury_turn_test.go
+++ b/tests/integration/mercury_turn_test.go
@@ -74,6 +74,7 @@ func TestMercuryARQTurnHandoff(t *testing.T) {
 	if v := os.Getenv("MERCURY_CH_FADING"); v != "" {
 		params.Fading = v // ch: mpg|mpp|mpd ; watterson: good|moderate|poor
 	}
+	requireChFading(t, repoRoot, params.Fading)
 	if v := os.Getenv("MERCURY_CH_GAIN"); v != "" {
 		g, perr := strconv.ParseFloat(v, 64)
 		if perr != nil {


### PR DESCRIPTION
Runs the NNCP-over-broadcast trial on the bench and records what came out.

## What is actually tested

The bundle is produced by `nncp-bundle -tx` on one node and consumed by `nncp-bundle -rx` + `nncp-toss` on a **second, independently keyed node**. A pass means NNCP itself accepted what came off the air — signatures and all — and tossed the payload into the receiving node's incoming spool byte-identical. Not a file comparison with NNCP-shaped bytes; it is NNCP.

Mercury treats the bundle as opaque, and needs to know nothing about it.

Skipped unless `MERCURY_BCAST_TRIAL=1` — a robust-mode run takes ten minutes.

## Result: fading taxes the transfer, it does not cliff it

All rows completed with NNCP accepting the bundle. 6000 B payload → 7680 B bundle.

| mode | channel | SNR3k | wall | goodput |
|---|---|---:|---:|---:|
| QAM16C2 | AWGN | +17.2 | 26.0 s | 2360 bps |
| QAM16C2 | mpg | +17.2 | 37.5 s | 1636 bps |
| QAM16C2 | mpg | +25.2 | 26.5 s | 2315 bps |
| QAM16C2 | mpp | +25.2 | 30.0 s | 2045 bps |
| DATAC17 | mpg | +7.2 | 67.1 s | 916 bps |
| DATAC3 | AWGN | +0.2 | 361 s | 170 bps |
| DATAC3 | mpg | +0.2 | 515 s | 119 bps |
| DATAC3 | mpp | +0.2 | 423 s | 145 bps |

At each mode's AWGN floor, multipath costs ~40–45% more airtime and still completes (QAM16C2 +44%, DATAC3 +43%). That is the fountain code doing its job — a frame lost to a fade is a symbol not collected, with no retransmit to stall on. ~8 dB of margin buys the tax back entirely.

The 2360 bps AWGN figure independently reproduces the 2353 bps already in `BROADCAST-FILE.md`.

**This is bench, not radio.** No NNCP bundle has crossed a real HF link yet; the doc says so at the top. n=1 per row, one fading realisation.

## Harness hardening (the reason to read this PR)

`ch` **exits** when a multipath profile's sample file is missing, printing octave instructions. The bridge then carries no audio, every mode fails at every SNR, and it looks exactly like a channel too harsh to decode. Only the 1.0 Hz (`--mpp`) file ships, so `--mpg` and `--mpd` hit this **by default** — an entire five-point sweep was read as "fading breaks broadcast" before the cause was found.

`requireChFading()` now preflights the file and skips with the exact command to generate it, wired into **every** test honouring `MERCURY_CH_FADING` — the ARQ tests had the same exposure and would have produced the same false result.

`gen_fading.m` vectorises `ch_fading.m`, whose sample-by-sample interpreted loop is impractical at the 6.4M samples the shipped file uses. Same seed, same layout, byte-identical output length. Generated `.float` files stay gitignored (~100 MB each).

## Traps recorded in the doc

Each produced a confident wrong answer first:

1. The missing-fading-file exit above.
2. `bcast_file_tool send` returns in **milliseconds** — it enqueues; the airtime follows. A deadline measured from its return reports a transfer still in progress as a channel failure.
3. Forcing one cycle count across modes starves the robust ones: 28 cycles is ample at 29 symbols/frame and supplies 56 of 189 needed symbols at 2.

Full integration suite green; the new trial skips by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)